### PR TITLE
Consent Component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "jose": "^4.14.4",
         "list": "^2.0.19",
         "lodash": "^4.17.21",
+        "marked": "^7.0.3",
         "papaparse": "^5.3.2",
         "pinia": "^2.0.33",
         "pinia-plugin-persistedstate": "^3.1.0",
@@ -34,6 +35,7 @@
         "vega-lite": "^5.6.0",
         "vite-plugin-node-polyfills": "^0.9.0",
         "vue": "^3.2.25",
+        "vue-markdown-render": "^2.0.1",
         "vue-router": "^4.1.6"
       },
       "devDependencies": {
@@ -9209,6 +9211,17 @@
         "markdown-it": "bin/markdown-it.js"
       }
     },
+    "node_modules/inchjs/node_modules/marked": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.3.0.tgz",
+      "integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/inchjs/node_modules/minimatch": {
       "version": "2.0.10",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
@@ -10156,14 +10169,14 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
     },
     "node_modules/marked": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-4.3.0.tgz",
-      "integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==",
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-7.0.3.tgz",
+      "integrity": "sha512-ev2uM40p0zQ/GbvqotfKcSWEa59fJwluGZj5dcaUOwDRrB1F3dncdXy8NWUApk4fi8atU3kTBOwjyjZ0ud0dxw==",
       "bin": {
         "marked": "bin/marked.js"
       },
       "engines": {
-        "node": ">= 12"
+        "node": ">= 16"
       }
     },
     "node_modules/md5.js": {
@@ -19920,6 +19933,51 @@
         "@vue/runtime-dom": "3.3.4",
         "@vue/server-renderer": "3.3.4",
         "@vue/shared": "3.3.4"
+      }
+    },
+    "node_modules/vue-markdown-render": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/vue-markdown-render/-/vue-markdown-render-2.0.1.tgz",
+      "integrity": "sha512-/UBCu0OrZ9zzEDtiZVwlV/CQ+CgcwViServGis3TRXSVc6+6lJxcaOcD43vRoQzYfPa9r9WDt0Q7GyupOmpEWA==",
+      "dependencies": {
+        "markdown-it": "^12.3.2",
+        "vue": "^3.2.45"
+      }
+    },
+    "node_modules/vue-markdown-render/node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
+    },
+    "node_modules/vue-markdown-render/node_modules/entities": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-2.1.0.tgz",
+      "integrity": "sha512-hCx1oky9PFrJ611mf0ifBLBRW8lUUVRlFolb5gWRfIELabBlbp9xZvrqZLZAs+NxFnbfQoeGd8wDkygjg7U85w==",
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/vue-markdown-render/node_modules/linkify-it": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-3.0.3.tgz",
+      "integrity": "sha512-ynTsyrFSdE5oZ/O9GEf00kPngmOfVwazR5GKDq6EYfhlpFug3J2zybX56a2PRRpc9P+FuSoGNAwjlbDs9jJBPQ==",
+      "dependencies": {
+        "uc.micro": "^1.0.1"
+      }
+    },
+    "node_modules/vue-markdown-render/node_modules/markdown-it": {
+      "version": "12.3.2",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-12.3.2.tgz",
+      "integrity": "sha512-TchMembfxfNVpHkbtriWltGWc+m3xszaRD0CZup7GFFhzIgQqxIfn3eGj1yZpfuflzPvfkt611B2Q/Bsk1YnGg==",
+      "dependencies": {
+        "argparse": "^2.0.1",
+        "entities": "~2.1.0",
+        "linkify-it": "^3.0.1",
+        "mdurl": "^1.0.1",
+        "uc.micro": "^1.0.5"
+      },
+      "bin": {
+        "markdown-it": "bin/markdown-it.js"
       }
     },
     "node_modules/vue-router": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "roar-query",
       "version": "0.0.0",
       "dependencies": {
-        "@bdelab/roar-firekit": "^3.9.0",
+        "@bdelab/roar-firekit": "^3.10.0",
         "@bdelab/roar-pa": "^1.0.7",
         "@bdelab/roar-sre": "^1.0.8",
         "@bdelab/roar-swr": "^1.0.9",
@@ -35,7 +35,6 @@
         "vega-lite": "^5.6.0",
         "vite-plugin-node-polyfills": "^0.9.0",
         "vue": "^3.2.25",
-        "vue-markdown-render": "^2.0.1",
         "vue-router": "^4.1.6"
       },
       "devDependencies": {
@@ -2026,9 +2025,9 @@
       "integrity": "sha512-uq7O52wvo2Lggsx1x21tKZgqkJpvwCseBBPtX/nKQfpVlEsLOb11zZ1CRsWUKvJF0+lzuA9jwvA7Pr2Wt7i3xw=="
     },
     "node_modules/@bdelab/roar-firekit": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/@bdelab/roar-firekit/-/roar-firekit-3.9.0.tgz",
-      "integrity": "sha512-L1oeVUa3UXOK/2jBeCeFPN7HpJ+c0pAG+nVCeUZQlFJgyWw9iKWMVRJBekZSr+rMmz2s3LkxY3Kj+x7ciLpU5Q==",
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/@bdelab/roar-firekit/-/roar-firekit-3.10.0.tgz",
+      "integrity": "sha512-XUVlcCKKiB4T3RGlaQQ3/CqcVAiZLvKQisEsjjlzxFPxU6tyFLGtcSYHi9ltFiqt8jUyTn++xh1PTVz4LfAQag==",
       "dependencies": {
         "crc-32": "^1.2.2",
         "dot-object": "^2.1.4",
@@ -12198,7 +12197,6 @@
     },
     "node_modules/npm/node_modules/lodash._baseindexof": {
       "version": "3.1.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
@@ -12223,19 +12221,16 @@
     },
     "node_modules/npm/node_modules/lodash._bindcallback": {
       "version": "3.0.1",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/lodash._cacheindexof": {
       "version": "3.0.2",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/lodash._createcache": {
       "version": "3.1.2",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -12244,7 +12239,6 @@
     },
     "node_modules/npm/node_modules/lodash._getnative": {
       "version": "3.9.1",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
@@ -12255,7 +12249,6 @@
     },
     "node_modules/npm/node_modules/lodash.restparam": {
       "version": "3.6.1",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
@@ -19933,51 +19926,6 @@
         "@vue/runtime-dom": "3.3.4",
         "@vue/server-renderer": "3.3.4",
         "@vue/shared": "3.3.4"
-      }
-    },
-    "node_modules/vue-markdown-render": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/vue-markdown-render/-/vue-markdown-render-2.0.1.tgz",
-      "integrity": "sha512-/UBCu0OrZ9zzEDtiZVwlV/CQ+CgcwViServGis3TRXSVc6+6lJxcaOcD43vRoQzYfPa9r9WDt0Q7GyupOmpEWA==",
-      "dependencies": {
-        "markdown-it": "^12.3.2",
-        "vue": "^3.2.45"
-      }
-    },
-    "node_modules/vue-markdown-render/node_modules/argparse": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
-    },
-    "node_modules/vue-markdown-render/node_modules/entities": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-2.1.0.tgz",
-      "integrity": "sha512-hCx1oky9PFrJ611mf0ifBLBRW8lUUVRlFolb5gWRfIELabBlbp9xZvrqZLZAs+NxFnbfQoeGd8wDkygjg7U85w==",
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
-      }
-    },
-    "node_modules/vue-markdown-render/node_modules/linkify-it": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-3.0.3.tgz",
-      "integrity": "sha512-ynTsyrFSdE5oZ/O9GEf00kPngmOfVwazR5GKDq6EYfhlpFug3J2zybX56a2PRRpc9P+FuSoGNAwjlbDs9jJBPQ==",
-      "dependencies": {
-        "uc.micro": "^1.0.1"
-      }
-    },
-    "node_modules/vue-markdown-render/node_modules/markdown-it": {
-      "version": "12.3.2",
-      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-12.3.2.tgz",
-      "integrity": "sha512-TchMembfxfNVpHkbtriWltGWc+m3xszaRD0CZup7GFFhzIgQqxIfn3eGj1yZpfuflzPvfkt611B2Q/Bsk1YnGg==",
-      "dependencies": {
-        "argparse": "^2.0.1",
-        "entities": "~2.1.0",
-        "linkify-it": "^3.0.1",
-        "mdurl": "^1.0.1",
-        "uc.micro": "^1.0.5"
-      },
-      "bin": {
-        "markdown-it": "bin/markdown-it.js"
       }
     },
     "node_modules/vue-router": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@bdelab/roar-firekit": "^3.9.0",
+    "@bdelab/roar-firekit": "^3.10.0",
     "@bdelab/roar-pa": "^1.0.7",
     "@bdelab/roar-sre": "^1.0.8",
     "@bdelab/roar-swr": "^1.0.9",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "jose": "^4.14.4",
     "list": "^2.0.19",
     "lodash": "^4.17.21",
+    "marked": "^7.0.3",
     "papaparse": "^5.3.2",
     "pinia": "^2.0.33",
     "pinia-plugin-persistedstate": "^3.1.0",

--- a/src/components/ConsentModal.vue
+++ b/src/components/ConsentModal.vue
@@ -1,0 +1,60 @@
+<template>
+  <Toast />
+  <ConfirmDialog group="templating">
+    <template #message="slotProps">
+      <div class="scrolling-box">
+        <div v-html="markdownToHtml"></div>
+      </div>
+    </template>
+  </ConfirmDialog>
+</template>
+<script setup>
+import { computed, defineProps, onMounted } from 'vue';
+import { useConfirm } from "primevue/useconfirm";
+import { useToast } from "primevue/usetoast";
+import { marked } from 'marked';
+
+console.log('inside consentModal')
+const props = defineProps({
+  consentText: {require: true, default: 'Text Here'},
+  consentType: {require: true, default: 'Consent'},
+})
+
+const confirm = useConfirm();
+const toast = useToast();
+
+const markdownToHtml = computed(() => {
+  return marked(props.consentText)
+})
+
+onMounted(() => {
+  confirm.require({
+    group: 'templating',
+    header: `${props.consentType} Form`,
+    icon: 'pi pi-question-circle',
+    acceptLabel: 'Continue',
+    acceptIcon: 'pi pi-check',
+    accept: () => {
+      toast.add({ severity: 'info', summary: 'Confirmed', detail: `${props.consentType} status updated.`, life: 3000 });
+    },
+  });
+})
+</script>
+<style>
+.scrolling-box {
+  width: 50vw;
+  height: 50vh;
+  min-width: 33vw;
+  min-height: 25vh;
+  padding: 1rem;
+  overflow: scroll;
+  border: 2px solid var(--surface-d);
+  border-radius: 5px;
+}
+.p-confirm-dialog-reject {
+  display: none;
+}
+.p-dialog-header-close {
+  display: none !important;
+}
+</style>

--- a/src/components/ConsentModal.vue
+++ b/src/components/ConsentModal.vue
@@ -19,6 +19,11 @@ const props = defineProps({
   consentText: {require: true, default: 'Text Here'},
   consentType: {require: true, default: 'Consent'},
 })
+const consentHeader = {
+  tos: "Terms of Service",
+  consent: "Consent",
+  assent: "Assent"
+}
 const emit = defineEmits(['accepted']);
 
 const confirm = useConfirm();
@@ -31,13 +36,13 @@ const markdownToHtml = computed(() => {
 onMounted(() => {
   confirm.require({
     group: 'templating',
-    header: `${props.consentType} Form`,
+    header: `${consentHeader[props.consentType]} Form`,
     icon: 'pi pi-question-circle',
     acceptLabel: 'Continue',
     acceptIcon: 'pi pi-check',
     accept: () => {
       emit('accepted');
-      toast.add({ severity: 'info', summary: 'Confirmed', detail: `${props.consentType} status updated.`, life: 3000 });
+      toast.add({ severity: 'info', summary: 'Confirmed', detail: `${consentHeader[props.consentType]} status updated.`, life: 3000 });
     },
   });
 })

--- a/src/components/ConsentModal.vue
+++ b/src/components/ConsentModal.vue
@@ -59,7 +59,7 @@ onMounted(() => {
   border-radius: 5px;
 }
 .p-confirm-dialog-reject {
-  display: none;
+  display: none !important;
 }
 .p-dialog-header-close {
   display: none !important;

--- a/src/components/ConsentModal.vue
+++ b/src/components/ConsentModal.vue
@@ -9,7 +9,7 @@
   </ConfirmDialog>
 </template>
 <script setup>
-import { computed, defineProps, onMounted } from 'vue';
+import { computed, defineProps, defineEmits, onMounted } from 'vue';
 import { useConfirm } from "primevue/useconfirm";
 import { useToast } from "primevue/usetoast";
 import { marked } from 'marked';
@@ -19,6 +19,7 @@ const props = defineProps({
   consentText: {require: true, default: 'Text Here'},
   consentType: {require: true, default: 'Consent'},
 })
+const emit = defineEmits(['accepted']);
 
 const confirm = useConfirm();
 const toast = useToast();
@@ -35,6 +36,7 @@ onMounted(() => {
     acceptLabel: 'Continue',
     acceptIcon: 'pi pi-check',
     accept: () => {
+      emit('accepted');
       toast.add({ severity: 'info', summary: 'Confirmed', detail: `${props.consentType} status updated.`, life: 3000 });
     },
   });

--- a/src/main.js
+++ b/src/main.js
@@ -21,6 +21,7 @@ import Chart from 'primevue/chart'
 import Chip from "primevue/chip";
 import ConfirmPopup from "primevue/confirmpopup";
 import ConfirmationService from 'primevue/confirmationservice';
+import ConfirmDialog from "primevue/confirmdialog";
 import DataView from 'primevue/dataview';
 import Dialog from 'primevue/dialog';
 import Divider from "primevue/divider";
@@ -52,6 +53,9 @@ import ToggleButton from "primevue/togglebutton";
 import TreeSelect from "primevue/treeselect";
 import TreeTable from "primevue/treetable";
 import TriStateCheckbox from 'primevue/tristatecheckbox'
+
+// PrimeVue confirmation service import
+import ConfirmationService from 'primevue/confirmationservice';
 
 // PrimeVue data table imports
 import DataTable from 'primevue/datatable';
@@ -93,6 +97,7 @@ app.component("Checkbox", Checkbox);
 app.component("Chart", Chart);
 app.component("Chip", Chip);
 app.component("ConfirmPopup", ConfirmPopup);
+app.component("ConfirmDialog", ConfirmDialog);
 app.component("DataView", DataView);
 app.component("Dialog", Dialog);
 app.component("Divider", Divider);
@@ -121,6 +126,8 @@ app.component("Toolbar", Toolbar);
 app.component("TreeSelect", TreeSelect);
 app.component("TreeTable", TreeTable);
 app.component("TriStateCheckbox", TriStateCheckbox)
+
+app.use(ConfirmationService);
 
 app.component("DataTable", DataTable);
 app.component("Column", Column);

--- a/src/main.js
+++ b/src/main.js
@@ -20,7 +20,6 @@ import Checkbox from "primevue/checkbox";
 import Chart from 'primevue/chart'
 import Chip from "primevue/chip";
 import ConfirmPopup from "primevue/confirmpopup";
-import ConfirmationService from 'primevue/confirmationservice';
 import ConfirmDialog from "primevue/confirmdialog";
 import DataView from 'primevue/dataview';
 import Dialog from 'primevue/dialog';

--- a/src/pages/Home.vue
+++ b/src/pages/Home.vue
@@ -1,7 +1,7 @@
 <template>
   <Participant v-if="!isAdminRef"/>
   <Administrator v-else-if="isAdminRef" />
-  <ConsentModal v-if="showConsent" :consent-text="confirmText" consent-type="Assent" @accepted="updateConsent"/>
+  <ConsentModal v-if="showConsent" :consent-text="confirmText" :consent-type="consentType" @accepted="updateConsent"/>
 </template>
 
 <script setup>
@@ -17,7 +17,7 @@ const { isFirekitInit, roarfirekit, firekitUserData } = storeToRefs(authStore)
 const isAdmin = authStore.isUserAdmin();
 const isAdminRef = ref(isAdmin)
 
-const consentType = ref(isAdmin ? 'consent' : 'assent')
+const consentType = ref(isAdmin ? 'tos' : 'assent')
 const showConsent = ref(false);
 const confirmText = ref("");
 const consentVersion = ref("");

--- a/src/pages/Home.vue
+++ b/src/pages/Home.vue
@@ -1,14 +1,47 @@
 <template>
   <Participant v-if="!isAdminRef"/>
   <Administrator v-else-if="isAdminRef" />
+  <ConsentModal v-if="showConsent" :consent-text="confirmText" consent-type="Assent" @accepted="updateConsent"/>
 </template>
 
 <script setup>
-import { ref } from "vue";
+import { onMounted, ref, toRaw, watch } from "vue";
 import { useAuthStore } from '@/store/auth';
 import Participant from "./Participant.vue";
 import Administrator from "./Administrator.vue";
+import _get from "lodash/get"
+import { storeToRefs } from "pinia";
+import ConsentModal from "../components/ConsentModal.vue";
 const authStore = useAuthStore();
+const { isFirekitInit, roarfirekit, firekitUserData } = storeToRefs(authStore)
 const isAdmin = authStore.isUserAdmin();
 const isAdminRef = ref(isAdmin)
+
+const consentType = ref(isAdmin ? 'consent' : 'assent')
+const showConsent = ref(false);
+const confirmText = ref("");
+const consentVersion = ref("");
+
+async function updateConsent() {
+  authStore.updateConsentStatus(consentType.value, consentVersion.value)
+}
+
+async function checkConsent() {
+  // Check for consent
+  const consentStatus = _get(roarfirekit.value, `userData.legal.${consentType.value}`) || _get(firekitUserData.value, `legal.${consentType.value}`)
+  const consentDoc = await authStore.getLegalDoc(consentType.value);
+  consentVersion.value = consentDoc.version
+  if(!_get(toRaw(consentStatus), consentDoc.version)){
+    confirmText.value = consentDoc.text;
+    showConsent.value = true;
+  }
+}
+onMounted(async () => {
+  if(isFirekitInit.value){
+    await checkConsent();
+  }
+})
+watch(isFirekitInit, async (newValue, oldValue) => {
+  await checkConsent();
+})
 </script>

--- a/src/pages/MassUploader.vue
+++ b/src/pages/MassUploader.vue
@@ -138,7 +138,7 @@ import _omit from 'lodash/omit';
 import _find from 'lodash/find';
 import { useAuthStore } from '@/store/auth';
 import { useQueryStore } from '@/store/query';
-import RoarDataTable from '../components/RoarDataTable.vue';
+// import RoarDataTable from '../components/RoarDataTable.vue';
 import { storeToRefs } from 'pinia';
 import AppSpinner from '../components/AppSpinner.vue';
 import AdministratorSidebar from "@/components/AdministratorSidebar.vue";

--- a/src/pages/Participant.vue
+++ b/src/pages/Participant.vue
@@ -6,7 +6,7 @@
         <ParticipantSidebar :total-games="totalGames" :completed-games="completeGames" :student-info="studentInfo" />
         <GameTabs :games="assessments" />
       </div>
-      <ConsentModal v-if="showConsent" :consent-text="confirmText" consent-type="Assent"/>
+      <ConsentModal v-if="showConsent" :consent-text="confirmText" consent-type="Assent" @accepted="updateConsent"/>
       <Button @click="showConsent = true" label="Show Consent Form" />
     </div>
     <div v-else>
@@ -22,7 +22,7 @@
 </template>
 
 <script setup>
-import { onMounted, ref, watch } from "vue";
+import { onMounted, ref, watch, toRaw } from "vue";
 import GameTabs from "../components/GameTabs.vue";
 import ParticipantSidebar from "../components/ParticipantSidebar.vue";
 import _filter from 'lodash/filter'
@@ -35,6 +35,7 @@ import ConsentModal from "../components/ConsentModal.vue";
 
 const showConsent = ref(false);
 const confirmText = ref("");
+const consentVersion = ref("");
 
 const authStore = useAuthStore();
 const { isFirekitInit, firekitUserData, roarfirekit } = storeToRefs(authStore);
@@ -50,9 +51,20 @@ const studentInfo = ref({
   grade: _get(roarfirekit.value, 'userData.studentData.grade') || _get(firekitUserData.value, 'studentData.grade'),
 })
 
+async function updateConsent() {
+  console.log('consent status update', consentVersion.value)
+  authStore.updateConsentStatus(consentVersion.value)
+}
+
 async function setUpAssignments() {
   // Check for consent
-  confirmText.value = await authStore.getLegalDoc('assent');
+  const consentStatus = _get(roarfirekit.value, 'userData.consent') || _get(firekitUserData.value, 'consent')
+  const consentDoc = await authStore.getLegalDoc('assent');
+  consentVersion.value = consentDoc.version
+  if(!_get(toRaw(consentStatus), consentDoc.version)){
+    confirmText.value = consentDoc.text;
+    showConsent.value = true;
+  }
   // confirmText.value = _get(assentDoc, 'formText');
   const assignedAssignments = _get(roarfirekit.value, "currentAssignments.assigned");
   console.log("assignedAssignments from storeToRefs: ", assignedAssignments);

--- a/src/pages/Participant.vue
+++ b/src/pages/Participant.vue
@@ -6,8 +6,6 @@
         <ParticipantSidebar :total-games="totalGames" :completed-games="completeGames" :student-info="studentInfo" />
         <GameTabs :games="assessments" />
       </div>
-      <ConsentModal v-if="showConsent" :consent-text="confirmText" consent-type="Assent" @accepted="updateConsent"/>
-      <Button @click="showConsent = true" label="Show Consent Form" />
     </div>
     <div v-else>
       <div class="col-full text-center">
@@ -31,11 +29,6 @@ import _get from 'lodash/get'
 import { useAuthStore } from "@/store/auth";
 import { storeToRefs } from 'pinia';
 import AppSpinner from "../components/AppSpinner.vue";
-import ConsentModal from "../components/ConsentModal.vue";
-
-const showConsent = ref(false);
-const confirmText = ref("");
-const consentVersion = ref("");
 
 const authStore = useAuthStore();
 const { isFirekitInit, firekitUserData, roarfirekit } = storeToRefs(authStore);
@@ -51,21 +44,7 @@ const studentInfo = ref({
   grade: _get(roarfirekit.value, 'userData.studentData.grade') || _get(firekitUserData.value, 'studentData.grade'),
 })
 
-async function updateConsent() {
-  console.log('consent status update', consentVersion.value)
-  authStore.updateConsentStatus(consentVersion.value)
-}
-
 async function setUpAssignments() {
-  // Check for consent
-  const consentStatus = _get(roarfirekit.value, 'userData.consent') || _get(firekitUserData.value, 'consent')
-  const consentDoc = await authStore.getLegalDoc('assent');
-  consentVersion.value = consentDoc.version
-  if(!_get(toRaw(consentStatus), consentDoc.version)){
-    confirmText.value = consentDoc.text;
-    showConsent.value = true;
-  }
-  // confirmText.value = _get(assentDoc, 'formText');
   const assignedAssignments = _get(roarfirekit.value, "currentAssignments.assigned");
   console.log("assignedAssignments from storeToRefs: ", assignedAssignments);
   let assignmentInfo = [];

--- a/src/pages/Participant.vue
+++ b/src/pages/Participant.vue
@@ -6,6 +6,8 @@
         <ParticipantSidebar :total-games="totalGames" :completed-games="completeGames" :student-info="studentInfo" />
         <GameTabs :games="assessments" />
       </div>
+      <ConsentModal v-if="showConsent" :consent-text="confirmText" consent-type="Assent"/>
+      <Button @click="showConsent = true" label="Show Consent Form" />
     </div>
     <div v-else>
       <div class="col-full text-center">
@@ -29,6 +31,10 @@ import _get from 'lodash/get'
 import { useAuthStore } from "@/store/auth";
 import { storeToRefs } from 'pinia';
 import AppSpinner from "../components/AppSpinner.vue";
+import ConsentModal from "../components/ConsentModal.vue";
+
+const showConsent = ref(false);
+const confirmText = ref("");
 
 const authStore = useAuthStore();
 const { isFirekitInit, firekitUserData, roarfirekit } = storeToRefs(authStore);
@@ -45,6 +51,9 @@ const studentInfo = ref({
 })
 
 async function setUpAssignments() {
+  // Check for consent
+  confirmText.value = await authStore.getLegalDoc('assent');
+  // confirmText.value = _get(assentDoc, 'formText');
   const assignedAssignments = _get(roarfirekit.value, "currentAssignments.assigned");
   console.log("assignedAssignments from storeToRefs: ", assignedAssignments);
   let assignmentInfo = [];

--- a/src/store/auth.js
+++ b/src/store/auth.js
@@ -84,12 +84,11 @@ export const useAuthStore = () => {
         });
       },
       async getLegalDoc(docName) {
-        console.log('about to call firekit with', docName)
         return await this.roarfirekit.getLegalDoc(docName);
       },
-      async updateConsentStatus(consentVersion) {
-        _set(this.firekitUserData.consent, consentVersion, new Date(Date.now()))
-        this.roarfirekit.updateConsentStatus(consentVersion);
+      async updateConsentStatus(docName, consentVersion) {
+        _set(this.firekitUserData, `legal.${docName}.${consentVersion}`, new Date())
+        this.roarfirekit.updateConsentStatus(docName, consentVersion);
       },
       async registerWithEmailAndPassword({ email, password, userData }) {
         return this.roarfirekit.createStudentWithEmailPassword(email, password, userData);

--- a/src/store/auth.js
+++ b/src/store/auth.js
@@ -3,6 +3,7 @@ import { onAuthStateChanged } from "firebase/auth";
 import { initNewFirekit } from "../firebaseInit";
 
 import _get from "lodash/get";
+import _set from "lodash/set";
 
 export const useAuthStore = () => {
   return defineStore('authStore', {
@@ -85,6 +86,10 @@ export const useAuthStore = () => {
       async getLegalDoc(docName) {
         console.log('about to call firekit with', docName)
         return await this.roarfirekit.getLegalDoc(docName);
+      },
+      async updateConsentStatus(consentVersion) {
+        _set(this.firekitUserData.consent, consentVersion, new Date(Date.now()))
+        this.roarfirekit.updateConsentStatus(consentVersion);
       },
       async registerWithEmailAndPassword({ email, password, userData }) {
         return this.roarfirekit.createStudentWithEmailPassword(email, password, userData);

--- a/src/store/auth.js
+++ b/src/store/auth.js
@@ -82,6 +82,10 @@ export const useAuthStore = () => {
           return firekit
         });
       },
+      async getLegalDoc(docName) {
+        console.log('about to call firekit with', docName)
+        return await this.roarfirekit.getLegalDoc(docName);
+      },
       async registerWithEmailAndPassword({ email, password, userData }) {
         return this.roarfirekit.createStudentWithEmailPassword(email, password, userData);
       },


### PR DESCRIPTION
This PR adds consent functionality to the dashboard.
- On login, check if the user has already consented to this version of the consent (updates are based on gitHub commit hashes)
- If not, determine type of consent document based on admin or student account. 
- Show the user that consent doc, and do not allow them to proceed until they have accepted. 
- After accepting, update their userdoc to reflect accepted consent (with timestamp)

Requires RoarFirekit [PR #45](https://github.com/yeatmanlab/roar-firekit/pull/45)