### PR TITLE
Remove empty lines

### DIFF
--- a/src/helpers/index.js
+++ b/src/helpers/index.js
@@ -109,7 +109,7 @@ export const csvFileToJson = (fileObject) =>
     Papa.parse(fileObject, {
       header: true,
       dynamicTyping: true,
-      skipEmptyLines: true,
+      skipEmptyLines: "greedy",
       complete: function (results) {
         if (results.errors.length !== 0) {
           reject(results.errors);


### PR DESCRIPTION
This PR changes the PapaParse `skipEmptyLines` config from `true` to `"greedy"`. When `true`, PapaParse skips completely empty lines. When `"greedy"` it skips lines with no content (i.e., only white space and delimiters).