### PR TITLE
Admin Enhancements

### DIFF
--- a/src/components/CreateOrgs.vue
+++ b/src/components/CreateOrgs.vue
@@ -342,7 +342,8 @@ const submit = async (event) => {
 
     await roarfirekit.value.createOrg(orgType.value.firestoreCollection, orgData).then(() => {
       toast.add({ severity: 'success', summary: 'Success', detail: 'Org created', life: 3000 });
-      router.push({ name: 'ListOrgs' });
+      submitted.value = false;
+      resetForm();
     })
   } else {
     console.log("Form is invalid");
@@ -367,6 +368,15 @@ if (districts.value.length === 0 || schools.value.length === 0) {
       await refresh();
     }
   });
+}
+
+const resetForm = () => {
+  state.orgName = "";
+  state.orgInitials = "";
+  state.ncesId = undefined;
+  state.address = undefined;
+  state.grade = undefined;
+  state.tags = [];
 }
 </script> 
 

--- a/src/components/ListUsers.vue
+++ b/src/components/ListUsers.vue
@@ -85,10 +85,16 @@ let unsubscribe;
 
 const refresh = async () => {
   refreshing.value = true;
+  isLoading.value = true;
   if (unsubscribe) unsubscribe();
   getUsers().then(() => {
     refreshing.value = false;
-  });
+  }).catch((e) => {
+    // If there are no administrations, catch the 'missing documents' error
+    console.log('Error caught:', e)
+    refreshing.value = false;
+    isLoading.value = false;
+  });;
 }
 
 if (_isEmpty(users.value)) {

--- a/src/pages/Administrator.vue
+++ b/src/pages/Administrator.vue
@@ -16,6 +16,7 @@
             <CardAdministration :id="a.id" :title="a.name" :stats="a.stats" :dates="a.dates" :assignees="a.assignedOrgs"
               :assessments="a.assessments"></CardAdministration>
           </div>
+          <div v-else>There are no administrations to display. Please contact a lab administrator to add you as an admin to an administration.</div>
         </div>
         <div v-else class="loading-container">
           <AppSpinner style="margin-bottom: 1rem;" />

--- a/src/pages/Administrator.vue
+++ b/src/pages/Administrator.vue
@@ -65,6 +65,10 @@ const refresh = async () => {
   await Promise.all([orgsPromise, adminsitrationsPromise]).then(() => {
     administrationsReady.value = true;
     refreshing.value = false;
+  }).catch((e) => {
+    // If there are no administrations, catch the 'missing documents' error
+    administrationsReady.value = true;
+    refreshing.value = false;
   });
 }
 

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -73,7 +73,7 @@ const routes = [
     path: '/register-students',
     name: 'RegisterStudents',
     component: () => import("../pages/RegisterStudents.vue"),
-    meta: {pageTitle: "Register Students", requireAdmin: true}
+    meta: {pageTitle: "Register Students", requireAdmin: true, requireSuperAdmin: true}
   },
   {
     path: "/signin",

--- a/src/router/sidebarActions.js
+++ b/src/router/sidebarActions.js
@@ -21,7 +21,7 @@ export const sidebarActionOptions = [
     title: "Register students",
     icon: "pi pi-users",
     buttonLink: { name: "RegisterStudents" },
-    requiresSuperAdmin: false,
+    requiresSuperAdmin: true,
   },
   {
     title: "Register administrator",


### PR DESCRIPTION
This implements various fixes, enhancements and requests. 
- Adds superAdmin route guard to register students
- Adds register student restriction to require district and school, or group.
- Adds partial reset functionality to create orgs form (instead of routing)
- Once admin landing page loads, display 'no admins' rather than inf spinner.

**ALSO**: I've added some logic to both the admins list and users list for catching a 'FirebaseError: missing or insufficient permissions' when there are no docs to display. I'm not sure if this is the error that is returned when there are no documents to display (which is the case here) OR if there's a permissions issue. May be related to https://app.clickup.com/t/8685e5wrz