### PR TITLE
Fix refresh bug

### DIFF
--- a/src/components/CreateAdministration.vue
+++ b/src/components/CreateAdministration.vue
@@ -307,6 +307,15 @@ if (allVariants.value.length === 0) {
   assessments.value = [allVariants.value, []];
 }
 
+onMounted(async () => {
+  if (roarfirekit.value.getVariants && roarfirekit.value.isAdmin()) {
+    await refreshAssessments();
+  }
+  if (roarfirekit.value.getOrgs && roarfirekit.value.isAdmin()) {
+    await refreshOrgs();
+  }
+})
+
 const submit = async () => {
   pickListError.value = ''
   submitted.value = true;

--- a/src/components/CreateAdministrator.vue
+++ b/src/components/CreateAdministrator.vue
@@ -112,7 +112,7 @@
 </template>
 
 <script setup>
-import { computed, ref } from "vue";
+import { computed, ref, onMounted } from "vue";
 import { useRouter } from 'vue-router';
 import { storeToRefs } from "pinia";
 import { useToast } from "primevue/usetoast";
@@ -242,6 +242,12 @@ const submit = async () => {
     router.push({ name: "Home" });
   });
 }
+
+onMounted(async () => {
+  if(roarfirekit.value.getOrgs && roarfirekit.value.createAdministrator) {
+    await refresh()
+  }
+})
 </script> 
 
 <style lang="scss">

--- a/src/components/CreateOrgs.vue
+++ b/src/components/CreateOrgs.vue
@@ -139,7 +139,7 @@
 </template>
 
 <script setup>
-import { computed, reactive, ref, toRaw } from "vue";
+import { computed, reactive, ref, toRaw, onMounted } from "vue";
 import { useRouter } from 'vue-router';
 import { useToast } from "primevue/usetoast";
 import { useConfirm } from "primevue/useconfirm";
@@ -368,6 +368,12 @@ if (districts.value.length === 0 || schools.value.length === 0) {
     }
   });
 }
+
+onMounted(async () => {
+  if(roarfirekit.value.getOrgs) {
+    await refresh()
+  }
+})
 </script> 
 
 <style lang="scss">

--- a/src/components/ListOrgs.vue
+++ b/src/components/ListOrgs.vue
@@ -27,7 +27,8 @@
           </Column>
           <Column field="" header="" #body="{ node }">
             <router-link :to="{ name: 'ListUsers', params: { orgType: node.data.orgType, orgId: node.data.id } }">
-              <Button v-tooltip.top="'View users'" severity="secondary" text raised label="Users" aria-label="View users" icon="pi pi-users" size="small" />
+              <Button v-tooltip.top="'View users'" severity="secondary" text raised label="Users" aria-label="View users"
+                icon="pi pi-users" size="small" />
             </router-link>
           </Column>
         </TreeTable>
@@ -76,8 +77,9 @@ if (_isEmpty(_union(...Object.values(adminOrgs.value)))) {
   });
 }
 
+const { roarfirekit } = storeToRefs(authStore);
 onMounted(async () => {
-  if(roarfirekit.value.getOrgs) {
+  if (roarfirekit.value.getOrgs) {
     await refresh()
   }
 })

--- a/src/components/ListOrgs.vue
+++ b/src/components/ListOrgs.vue
@@ -37,7 +37,7 @@
 </template>
 
 <script setup>
-import { computed, ref } from "vue";
+import { computed, ref, onMounted } from "vue";
 import { storeToRefs } from "pinia";
 import { useQueryStore } from "@/store/query";
 import { useAuthStore } from "@/store/auth";
@@ -75,6 +75,12 @@ if (_isEmpty(_union(...Object.values(adminOrgs.value)))) {
     }
   });
 }
+
+onMounted(async () => {
+  if(roarfirekit.value.getOrgs) {
+    await refresh()
+  }
+})
 </script> 
 
 <style lang="scss">

--- a/src/components/ListUsers.vue
+++ b/src/components/ListUsers.vue
@@ -24,7 +24,7 @@
   </main>
 </template>
 <script setup>
-import { ref, computed } from "vue";
+import { ref, computed, onMounted } from "vue";
 import AdministratorSidebar from "@/components/AdministratorSidebar.vue";
 import { getSidebarActions } from "../router/sidebarActions";
 import { useAuthStore } from "@/store/auth";
@@ -37,6 +37,7 @@ import _set from 'lodash/set';
 import _union from 'lodash/union';
 import _head from 'lodash/head'
 import AppSpinner from "./AppSpinner.vue";
+import { storeToRefs } from "pinia";
 
 const authStore = useAuthStore();
 const queryStore = useQueryStore();
@@ -46,6 +47,8 @@ const props = defineProps({
   orgType: String,
   orgId: String,
 })
+
+const { roarfirekit } = storeToRefs(authStore);
 
 const orgName = ref(props.orgId)
 
@@ -99,6 +102,12 @@ if (_isEmpty(users.value)) {
     }
   });
 }
+
+onMounted(async () => {
+  if(roarfirekit.value.getUsersBySingleOrg) {
+    await refresh()
+  }
+})
 
 const columns = ref([
   {

--- a/src/pages/AdministrationProgress.vue
+++ b/src/pages/AdministrationProgress.vue
@@ -28,7 +28,7 @@
 </template>
 
 <script setup>
-import { computed, ref } from 'vue';
+import { computed, ref, onMounted } from 'vue';
 import { storeToRefs } from 'pinia';
 import _capitalize from 'lodash/capitalize';
 import { useAuthStore } from '@/store/auth';
@@ -140,6 +140,11 @@ unsubscribe = authStore.$subscribe(async (mutation, state) => {
   }
 });
 
+onMounted(async () => {
+  if(roarfirekit.value.getUsersByAssignment) {
+    await refresh()
+  }
+})
 </script>
 
 <style>

--- a/src/pages/AdministrationProgress.vue
+++ b/src/pages/AdministrationProgress.vue
@@ -140,8 +140,9 @@ unsubscribe = authStore.$subscribe(async (mutation, state) => {
   }
 });
 
+const { roarfirekit } = storeToRefs(authStore);
 onMounted(async () => {
-  if(roarfirekit.value.getUsersByAssignment) {
+  if (roarfirekit.value.getUsersByAssignment) {
     await refresh()
   }
 })

--- a/src/pages/Administrator.vue
+++ b/src/pages/Administrator.vue
@@ -27,7 +27,7 @@
 </template>
 
 <script setup>
-import { computed, ref } from "vue";
+import { computed, ref, onMounted } from "vue";
 import { storeToRefs } from "pinia";
 import CardAdministration from "@/components/CardAdministration.vue";
 import AdministratorSidebar from "@/components/AdministratorSidebar.vue";
@@ -44,6 +44,7 @@ const spinIcon = computed(() => {
 const authStore = useAuthStore();
 const queryStore = useQueryStore();
 
+const { roarfirekit } = storeToRefs(authStore);
 const { administrations } = storeToRefs(queryStore);
 const administrationsReady = ref(administrations.value.length);
 
@@ -72,6 +73,13 @@ const unsubscribe = authStore.$subscribe(async (mutation, state) => {
     await refresh();
   }
 });
+
+onMounted(async () => {
+  if(roarfirekit.value.getOrgs && roarfirekit.value.getMyAdministrations) {
+    await refresh()
+  }
+})
+
 </script>
 
 <style scoped>


### PR DESCRIPTION
I believe the issue here is that we were relying on the `$subscribe` method solely. `$subscribe` is fantastic for waiting for changes to firekit to trigger the refresh function. However this fails when firekit is already initialized, such as navigating to a page well after the user has logged in. 

This PR adds a simple check to `onMounted()`, where we check whether firekit is ready. If so, we want to call refresh and start gathering data. If not, simply do nothing and wait for `$subscribe` to take care of it.