### PR TITLE
Correctly grab administration info in authStore

### DIFF
--- a/src/store/auth.js
+++ b/src/store/auth.js
@@ -64,7 +64,7 @@ export const useAuthStore = () => {
       },
       async getAdministration(administration) {
         try {
-          const reply = await this.roarfirekit.getAdministrations(administration)
+          const reply = await Promise.all(this.roarfirekit.getAdministrations(administration))
           this.firekitAdminInfo = reply
           return this.firekitAdminInfo
         } catch(e) {


### PR DESCRIPTION
This PR fixes grabbing the admin data from the participant view. This error manifested in a breakdown of the sequential logic, which relies on the field grabbed from this call