### PR TITLE
Enh/admin sidebar

### DIFF
--- a/src/assets/styles/components/sidebar.scss
+++ b/src/assets/styles/components/sidebar.scss
@@ -6,27 +6,12 @@
 	gap: 1rem;
 }
 
-.sidebar-info,
 .sidebar-actions {
-	border: 1px solid var(--surface-d);
-	border-radius: 5px;
-	background-color: var(--surface-b);
-	padding: 1rem;
-	list-style: none;
-	margin: 0;
-	line-height: 1.5;
 	display: flex;
 	flex-direction: column;
-	gap: .25rem;
+	gap: .5rem;
 	
-	.sidebar-title {
-		border-bottom: 1px solid var(--surface-d);
-		padding-bottom: 1rem;
-		margin-bottom: 1rem;
+	button {
+		
 	}
-
-}
-
-.sidebar-actions {
-	gap: 1rem;
 }

--- a/src/components/AdministratorSidebar.vue
+++ b/src/components/AdministratorSidebar.vue
@@ -1,20 +1,20 @@
 <template>
   <div class="sidebar-container">
-	<ul v-if="userInfo" class="sidebar-info">
-	  <li class="sidebar-title"><strong>Your Info</strong></li>
-	  <li>District: {{userInfo.district}}</li>
-	  <li>School: {school}</li>
-	  <li>Class: {class}</li>
-	</ul>
+	<Panel v-if="userInfo" header="Your Info">
+	  <div>District: {{userInfo.district}}</div>
+	  <div>School: {school}</div>
+	  <div>Class: {class}</div>
+	</Panel>
 	
-	<ul v-if="actions" class="sidebar-actions">
-	  <li class="sidebar-title"><strong>Actions</strong></li>
-	  <li v-for="(action, index) in actions">
-		<router-link :to="action.buttonLink" :key="index">
-			<Button :label="action.title" rounded :icon="action.icon" />
-		</router-link>
-	  </li>
-	</ul>
+	<Panel header="Actions" toggleable>
+		<div class="sidebar-actions">
+			<div v-for="(action, index) in actions">
+				<router-link :to="action.buttonLink" :key="index">
+					<Button :label="action.title" rounded :icon="action.icon" />
+				</router-link>
+			</div>
+		</div>
+	</Panel>
 
   </div>
 </template>

--- a/src/components/AdministratorSidebar.vue
+++ b/src/components/AdministratorSidebar.vue
@@ -1,10 +1,10 @@
 <template>
   <div class="sidebar-container">
-	<Panel v-if="userInfo" header="Your Info">
+	<!-- <Panel v-if="userInfo" header="Your Info">
 	  <div>District: {{userInfo.district}}</div>
 	  <div>School: {school}</div>
 	  <div>Class: {class}</div>
-	</Panel>
+	</Panel> -->
 	
 	<Panel header="Actions" toggleable>
 		<div class="sidebar-actions">


### PR DESCRIPTION
This PR does two things:

1. A simple enhancement to make the admin sidebar menu collapsible. a future enhancement should look at a new placement for this (or to use a different Primevue component) so that it does not get in the way.  
2. Removes the "Your Info" section of sidebar. Let's rethink what this should say – showing a list of all districts, classes, etc... will be too information intense. 