### PR TITLE
Update auth domain to avoid third-party cookie requirements

### DIFF
--- a/src/config/firebase.js
+++ b/src/config/firebase.js
@@ -1,7 +1,8 @@
 export default {
   app: {
     apiKey: "AIzaSyDw0TnTXbvRyoVo5_oa_muhXk9q7783k_g",
-    authDomain: "gse-roar-assessment.firebaseapp.com",
+    authDomain: "roar.education",
+    // authDomain: "gse-roar-assessment.firebaseapp.com",
     // authDomain: "localhost:5173",
     projectId: "gse-roar-assessment",
     storageBucket: "gse-roar-assessment.appspot.com",
@@ -10,7 +11,8 @@ export default {
   },
   admin: {
     apiKey: "AIzaSyBz0CTdyfgNXr7VJqcYOPlG609XDs97Tn8",
-    authDomain: "gse-roar-admin.firebaseapp.com",
+    authDomain: "roar.education",
+    // authDomain: "gse-roar-admin.firebaseapp.com",
     // authDomain: "localhost:5173",
     projectId: "gse-roar-admin",
     storageBucket: "gse-roar-admin.appspot.com",


### PR DESCRIPTION
This PR changes the auth domain as described here:

https://cloud.google.com/identity-platform/docs/show-custom-domain

I’m changing this because Carrie wasn’t able to log in without allowing third-party cookies. The third-party cookies are required when the auth domain is different from roar.education. See these pages for details and examples:
- https://stackoverflow.com/a/48816737
- https://dev.to/killdozerx2/fixing-3rd-party-cookies-issue-with-firebase-auth-28ng