### PR TITLE
Handle Multiple Admins on Participant

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "roar-dashboard",
       "version": "0.0.0",
       "dependencies": {
-        "@bdelab/roar-firekit": "^3.12.6",
+        "@bdelab/roar-firekit": "^3.12.7",
         "@bdelab/roar-letter": "^1.1.2",
         "@bdelab/roar-pa": "^1.1.1",
         "@bdelab/roar-sre": "^1.1.2",
@@ -1893,9 +1893,9 @@
       "integrity": "sha512-uq7O52wvo2Lggsx1x21tKZgqkJpvwCseBBPtX/nKQfpVlEsLOb11zZ1CRsWUKvJF0+lzuA9jwvA7Pr2Wt7i3xw=="
     },
     "node_modules/@bdelab/roar-firekit": {
-      "version": "3.12.6",
-      "resolved": "https://registry.npmjs.org/@bdelab/roar-firekit/-/roar-firekit-3.12.6.tgz",
-      "integrity": "sha512-vCRhGK6R/wbQi/U2Y4YofNjvWeqqc5o1PY5kEF3XR06FCeLjRKw+/ZDXQl2dYk2pltDznCwcn9YSKgcd2zzSjg==",
+      "version": "3.12.7",
+      "resolved": "https://registry.npmjs.org/@bdelab/roar-firekit/-/roar-firekit-3.12.7.tgz",
+      "integrity": "sha512-PKEa86uP0KIjOzeShqjLYO4XfljH8B1Vqmv/u9dvxZzJcZW2F+xAJGfWVOWDqH2V85BUcSdi9bN1GwtDnCDKMw==",
       "dependencies": {
         "crc-32": "^1.2.2",
         "dot-object": "^2.1.4",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@bdelab/roar-firekit": "^3.12.6",
+    "@bdelab/roar-firekit": "^3.12.7",
     "@bdelab/roar-letter": "^1.1.2",
     "@bdelab/roar-pa": "^1.1.1",
     "@bdelab/roar-sre": "^1.1.2",

--- a/src/components/ParticipantSidebar.vue
+++ b/src/components/ParticipantSidebar.vue
@@ -14,7 +14,7 @@
   </div>
 </template>
 <script setup>
-import { ref, onMounted } from "vue";
+import { ref, computed } from "vue";
 
 const props = defineProps({
   totalGames: {required: true, default: 0},
@@ -22,13 +22,11 @@ const props = defineProps({
   studentInfo: {required: true}
 })
 
-onMounted(() => {
+const chartData = computed(() => {
   const completed = props.completedGames;
   const incomplete = (props.totalGames - props.completedGames);
-  chartData.value = setChartData(completed, incomplete);
+  return setChartData(completed, incomplete)
 });
-
-const chartData = ref();
 const chartOptions = ref({
     cutout: '60%',
     showToolTips: false,

--- a/src/pages/CleverLanding.vue
+++ b/src/pages/CleverLanding.vue
@@ -18,9 +18,9 @@ const { roarfirekit } = storeToRefs(authStore);
 let userDataCheckInterval;
 
 function checkForUserType() {
-  if(roarfirekit.value.userData) {
+  if (roarfirekit.value.userData) {
     const userType = _get(roarfirekit.value, 'userData.userType')
-    if(userType !== 'guest') {
+    if (userType !== 'guest') {
       clearInterval(userDataCheckInterval)
       router.push({ name: "Home" })
     }

--- a/src/pages/Home.vue
+++ b/src/pages/Home.vue
@@ -42,7 +42,7 @@ async function updateConsent() {
   authStore.updateConsentStatus(consentType.value, consentVersion.value)
 }
 
-async function touchFirekit() {
+function touchFirekit() {
   roarfirekit.value.newField = 0;
   roarfirekit.value.newField = undefined;
 }
@@ -60,6 +60,7 @@ async function checkConsent() {
 
 onMounted(async () => {
   if (isFirekitInit.value) {
+    touchFirekit();
     isAdmin.value = authStore.isUserAdmin();
     loading.value = false;
     await checkConsent();

--- a/src/store/game.js
+++ b/src/store/game.js
@@ -1,0 +1,21 @@
+import { defineStore } from "pinia";
+import { parse, stringify } from "zipson";
+
+export const useGameStore = () => {
+  return defineStore({
+    id: "gameStore",
+    state: () => {
+      return {
+        selectedAdmin: "",
+      };
+    },
+    persist: {
+      storage: sessionStorage,
+      debug: false,
+      serializer: {
+        deserialize: parse,
+        serialize: stringify,
+      },
+    },
+  })();
+};


### PR DESCRIPTION
This PR changes the logic of participant view to cope with multiple administrations being assigned to the user. The dropdown appears when more than one administration is detected, and allows the user to swap between the admins at will. 

You can test a user with multiple admins using `labtest1` and `password1`. To test a user with just one admin, use any clever student assigned to the BRSSD admin via clever. 

I tried to test this in most scenarios but I would appreciate if you tested this one a bit more rigorously as essentially every user will be touching this functionality. 