### PR TITLE
Add a key to router view

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -14,7 +14,7 @@
   <div>
     <Toast />
     <Navbar v-if="!navbarBlacklist.includes($route.name)" />
-    <router-view />
+    <router-view :key="$route.fullPath" />
   </div>
 
   <!-- <AppSpinner v-show="!showPage" /> -->

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -109,7 +109,6 @@ const routes = [
       return { name: "SignIn" };
     },
     meta: { pageTitle: "Sign Out" },
-
   },
   {
     path: "/auth-clever",


### PR DESCRIPTION
Resolves https://github.com/yeatmanlab/roar/issues/45

@kellyel, can you take a look to make sure this doesn't have any unintended consequences. I tested with username/password students and some Clever users (make sure to test with Demo district users because we have live Clever users now.

For the above linked issue, I was able to reproduce on Chrome but not Brave. Logging out and then trying to log in **as another user** did not work. Same user was okay. With this change, it forces a replacement of the `<router-view>` element/component every time a navigation event occurs. See https://dev.to/brylie/reload-router-view-when-vue-route-changes-3cck