### PR TITLE
Fix the game completion replay bug

### DIFF
--- a/src/components/tasks/Letter.vue
+++ b/src/components/tasks/Letter.vue
@@ -71,9 +71,9 @@ const selectBestRun = async () => {
 
 window.addEventListener('beforeunload', selectBestRun, { once: true });
 onBeforeUnmount(async () => {
-  if (roarApp && completed.value === false) {
-    roarApp.abort();
-  }
+  // if (roarApp && completed.value === false) {
+  //   roarApp.abort();
+  // }
   selectBestRun();
 });
 
@@ -95,7 +95,11 @@ async function startTask() {
   await roarApp.run().then(async () => {
     // Handle any post-game actions.
     await authStore.roarfirekit.completeAssessment(selectedAdmin.value, taskId)
-    router.replace({ name: "Home" });
+    completed.value = true;
+    // Here we refresh instead of routing home, with the knowledge that a
+    // refresh is intercepted above and sent home.
+    router.go(0);
+    // router.replace({ name: "Home" });
   });
 }
 </script>

--- a/src/components/tasks/Multichoice.vue
+++ b/src/components/tasks/Multichoice.vue
@@ -1,113 +1,117 @@
 <template>
-    <div id="jspsych-target" class="game-target" />
-    <div v-if="!gameStarted" class="col-full text-center">
-      <h1>Preparing your game!</h1>
-      <AppSpinner />
-    </div>
-  </template>
-  <script setup>
-  import RoarMultichoice from '@bdelab/roar-multichoice';
-  import { toRaw, onMounted, watch, ref, onBeforeUnmount } from 'vue';
-  import { onBeforeRouteLeave, useRouter } from 'vue-router';
-  import { storeToRefs } from 'pinia';
-  import { useAuthStore } from '@/store/auth';
-  import { useGameStore } from '@/store/game';
-  import _head from 'lodash/head';
-  import _get from 'lodash/get';
-  
-  const taskId = "multichoice"
-  const router = useRouter();
-  const gameStarted = ref(false);
-  const authStore = useAuthStore();
-  const gameStore = useGameStore();
-  const { roarfirekit, firekitUserData, isFirekitInit } = storeToRefs(authStore);
-  
-  // Send user back to Home if page is reloaded
-  const entries = performance.getEntriesByType("navigation");
-  entries.forEach((entry) => {
-    if (entry.type === "reload") {
-      // Detect if our previous reload was on this page, AND if the last naviagtion was a replace.
-      if (entry.name === window.location.href && history.state.replaced === true) {
-        router.replace({ name: "Home" })
-      }
+  <div id="jspsych-target" class="game-target" />
+  <div v-if="!gameStarted" class="col-full text-center">
+    <h1>Preparing your game!</h1>
+    <AppSpinner />
+  </div>
+</template>
+<script setup>
+import RoarMultichoice from '@bdelab/roar-multichoice';
+import { toRaw, onMounted, watch, ref, onBeforeUnmount } from 'vue';
+import { onBeforeRouteLeave, useRouter } from 'vue-router';
+import { storeToRefs } from 'pinia';
+import { useAuthStore } from '@/store/auth';
+import { useGameStore } from '@/store/game';
+import _head from 'lodash/head';
+import _get from 'lodash/get';
+
+const taskId = "multichoice"
+const router = useRouter();
+const gameStarted = ref(false);
+const authStore = useAuthStore();
+const gameStore = useGameStore();
+const { roarfirekit, firekitUserData, isFirekitInit } = storeToRefs(authStore);
+
+// Send user back to Home if page is reloaded
+const entries = performance.getEntriesByType("navigation");
+entries.forEach((entry) => {
+  if (entry.type === "reload") {
+    // Detect if our previous reload was on this page, AND if the last naviagtion was a replace.
+    if (entry.name === window.location.href && history.state.replaced === true) {
+      router.replace({ name: "Home" })
     }
-  });
-  
-  // The following code intercepts the back button and instead forces a refresh.
-  // We use the ``preventBack`` variable to prevent an infinite loop. I.e., we
-  // only want to intercept this the first time.
-  let preventBack = true;
-  onBeforeRouteLeave((to, from, next) => {
-    if (window.event.type === "popstate" && preventBack) {
-      preventBack = false;
-      // router.go(router.currentRoute);
-      router.go(0);
-    } else {
-      next();
-    }
-  });
-  
-  onMounted(async () => {
-    if (isFirekitInit.value) {
-      await startTask();
-    }
-  })
-  
-  watch(isFirekitInit, async (newValue, oldValue) => {
+  }
+});
+
+// The following code intercepts the back button and instead forces a refresh.
+// We use the ``preventBack`` variable to prevent an infinite loop. I.e., we
+// only want to intercept this the first time.
+let preventBack = true;
+onBeforeRouteLeave((to, from, next) => {
+  if (window.event.type === "popstate" && preventBack) {
+    preventBack = false;
+    // router.go(router.currentRoute);
+    router.go(0);
+  } else {
+    next();
+  }
+});
+
+onMounted(async () => {
+  if (isFirekitInit.value) {
     await startTask();
+  }
+})
+
+watch(isFirekitInit, async (newValue, oldValue) => {
+  await startTask();
+})
+
+let roarApp;
+
+const completed = ref(false);
+const { selectedAdmin } = storeToRefs(gameStore);
+
+const selectBestRun = async () => {
+  await authStore.roarfirekit.selectBestRun({
+    assignmentId: selectedAdmin.value,
+    taskId,
   })
-  
-  let roarApp;
-  
-  const completed = ref(false);
-  const { selectedAdmin } = storeToRefs(gameStore);
-  
-  const selectBestRun = async () => {
-    await authStore.roarfirekit.selectBestRun({
-      assignmentId: selectedAdmin.value,
-      taskId,
-    })
+}
+
+window.addEventListener('beforeunload', selectBestRun, { once: true });
+onBeforeUnmount(async () => {
+  // if (roarApp && completed.value === false) {
+  //   roarApp.abort();
+  // }
+  selectBestRun();
+});
+
+async function startTask() {
+  const appKit = await authStore.roarfirekit.startAssessment(selectedAdmin.value, taskId)
+
+  const userDob = _get(roarfirekit.value, 'userData.studentData.dob') || _get(firekitUserData.value, 'studentData.dob')
+  const userDateObj = new Date(toRaw(userDob).seconds * 1000)
+
+  const userParams = {
+    birthMonth: userDateObj.getMonth() + 1,
+    birthYear: userDateObj.getFullYear(),
   }
-  
-  window.addEventListener('beforeunload', selectBestRun, { once: true });
-  onBeforeUnmount(async () => {
-    if (roarApp && completed.value === false) {
-      roarApp.abort();
-    }
-    selectBestRun();
+
+  const gameParams = appKit._taskInfo.variantParams
+  roarApp = new RoarMultichoice(appKit, gameParams, userParams, 'jspsych-target');
+
+  gameStarted.value = true;
+  await roarApp.run().then(async () => {
+    // Handle any post-game actions.
+    await authStore.roarfirekit.completeAssessment(selectedAdmin.value, taskId)
+    completed.value = true;
+    // Here we refresh instead of routing home, with the knowledge that a
+    // refresh is intercepted above and sent home.
+    router.go(0);
+    // router.replace({ name: "Home" });
   });
-  
-  async function startTask() {
-    const appKit = await authStore.roarfirekit.startAssessment(selectedAdmin.value, taskId)
-  
-    const userDob = _get(roarfirekit.value, 'userData.studentData.dob') || _get(firekitUserData.value, 'studentData.dob')
-    const userDateObj = new Date(toRaw(userDob).seconds * 1000)
-  
-    const userParams = {
-      birthMonth: userDateObj.getMonth() + 1,
-      birthYear: userDateObj.getFullYear(),
-    }
-  
-    const gameParams = appKit._taskInfo.variantParams
-    roarApp = new RoarMultichoice(appKit, gameParams, userParams, 'jspsych-target');
-  
-    gameStarted.value = true;
-    await roarApp.run().then(async () => {
-      // Handle any post-game actions.
-      await authStore.roarfirekit.completeAssessment(selectedAdmin.value, taskId)
-      router.replace({ name: "Home" });
-    });
-  }
-  </script>
-  <style scoped> .game-target {
-     position: absolute;
-     top: 0;
-     left: 0;
-     width: 100%;
-     height: 100%;
-   }
-  
-   .game-target:focus {
-     outline: none;
-   }
-  </style>
+}
+</script>
+<style scoped> .game-target {
+   position: absolute;
+   top: 0;
+   left: 0;
+   width: 100%;
+   height: 100%;
+ }
+
+ .game-target:focus {
+   outline: none;
+ }
+</style>

--- a/src/components/tasks/PA.vue
+++ b/src/components/tasks/PA.vue
@@ -71,9 +71,9 @@ const selectBestRun = async () => {
 
 window.addEventListener('beforeunload', selectBestRun, { once: true });
 onBeforeUnmount(async () => {
-  if (roarApp && completed.value === false) {
-    roarApp.abort();
-  }
+  // if (roarApp && completed.value === false) {
+  //   roarApp.abort();
+  // }
   selectBestRun();
 });
 
@@ -95,7 +95,11 @@ async function startTask() {
   await roarApp.run().then(async () => {
     // Handle any post-game actions.
     await authStore.roarfirekit.completeAssessment(selectedAdmin.value, taskId)
-    router.replace({ name: "Home" });
+    completed.value = true;
+    // Here we refresh instead of routing home, with the knowledge that a
+    // refresh is intercepted above and sent home.
+    router.go(0);
+    // router.replace({ name: "Home" });
   });
 }
 </script>

--- a/src/components/tasks/SRE.vue
+++ b/src/components/tasks/SRE.vue
@@ -71,9 +71,9 @@ const selectBestRun = async () => {
 
 window.addEventListener('beforeunload', selectBestRun, { once: true });
 onBeforeUnmount(async () => {
-  if (roarApp && completed.value === false) {
-    roarApp.abort();
-  }
+  // if (roarApp && completed.value === false) {
+  //   roarApp.abort();
+  // }
   selectBestRun();
 });
 
@@ -96,10 +96,15 @@ async function startTask() {
   await roarApp.run().then(async () => {
     // Handle any post-game actions.
     await authStore.roarfirekit.completeAssessment(selectedAdmin.value, taskId)
-    router.replace({ name: "Home" });
+    completed.value = true;
+    // Here we refresh instead of routing home, with the knowledge that a
+    // refresh is intercepted above and sent home.
+    router.go(0);
+    // router.replace({ name: "Home" });
   });
 }
 </script>
+
 <style scoped> .game-target {
    position: absolute;
    top: 0;

--- a/src/components/tasks/SWR-ES.vue
+++ b/src/components/tasks/SWR-ES.vue
@@ -71,9 +71,9 @@ const selectBestRun = async () => {
 
 window.addEventListener('beforeunload', selectBestRun, { once: true });
 onBeforeUnmount(async () => {
-  if (roarApp && completed.value === false) {
-    roarApp.abort();
-  }
+  // if (roarApp && completed.value === false) {
+  //   roarApp.abort();
+  // }
   selectBestRun();
 });
 
@@ -96,7 +96,11 @@ async function startTask() {
   await roarApp.run().then(async () => {
     // Handle any post-game actions.
     await authStore.roarfirekit.completeAssessment(selectedAdmin.value, taskId)
-    router.replace({ name: "Home" });
+    completed.value = true;
+    // Here we refresh instead of routing home, with the knowledge that a
+    // refresh is intercepted above and sent home.
+    router.go(0);
+    // router.replace({ name: "Home" });
   });
 }
 </script>

--- a/src/components/tasks/SWR.vue
+++ b/src/components/tasks/SWR.vue
@@ -74,9 +74,9 @@ const selectBestRun = async () => {
 
 window.addEventListener('beforeunload', selectBestRun, { once: true });
 onBeforeUnmount(async () => {
-  if (roarApp && completed.value === false) {
-    roarApp.abort();
-  }
+  // if (roarApp && completed.value === false) {
+  //   roarApp.abort();
+  // }
   selectBestRun();
 });
 
@@ -99,7 +99,11 @@ async function startTask() {
   await roarApp.run().then(async () => {
     // Handle any post-game actions.
     await authStore.roarfirekit.completeAssessment(selectedAdmin.value, taskId)
-    router.replace({ name: "Home" });
+    completed.value = true;
+    // Here we refresh instead of routing home, with the knowledge that a
+    // refresh is intercepted above and sent home.
+    router.go(0);
+    // router.replace({ name: "Home" });
   });
 }
 </script>


### PR DESCRIPTION
This PR resolves a bug in which games with keyboard responses (e.g., SWR, SWR-ES, SRE) are unable to progress past the first keyboard response screen under the following conditions:

- A game from the above list has been previously completed
- The page has not been refreshed

When these conditions were satisfied, the keyboard listeners that are normally active are no longer there.

Here is a screenshot of what it looks like when it's working:
![Screenshot 2023-09-16 at 2 36 56 PM](https://github.com/yeatmanlab/roar-dashboard/assets/7978135/6175b765-0921-49d7-957c-8df19ca272c0)

And here's what it looks like when it fails (no `keyup` or `keydown` listeners):
![IMG_4910](https://github.com/yeatmanlab/roar-dashboard/assets/7978135/2b330607-67e1-4009-bf80-1f4f86b7c93f)

Since the failure did not reproduce on page reload, this PR provides a somewhat hacky solution: simply reloading the page after the task is complete.