### PR TITLE
Restore tab switching to previous state

### DIFF
--- a/src/components/GameTabs.vue
+++ b/src/components/GameTabs.vue
@@ -1,7 +1,7 @@
 <template>
   <div id="games">
     <TabView v-model:activeIndex="currentGameIndex">
-      <TabPanel v-for="game in games" :key="game.taskData.taskId" :disabled="(sequential && allGamesComplete && (!game.completedOn || allGamesComplete) && (currentGameId !== game.taskId))">
+      <TabPanel v-for="game in games" :key="game.taskData.taskId" :disabled="(sequential && (!game.completedOn || !allGamesComplete) && (currentGameId !== game.taskId))">
         <template #header>
           <!--Complete Game-->
           <i v-if="game.completedOn" class="pi pi-check-circle mr-2" data-game-status="complete" />


### PR DESCRIPTION
It seems my change (here)[https://github.com/yeatmanlab/roar-dashboard/commit/3e06bcad77b72e9e521441e0b8208e7d7523195e] broke sequential functionality. I have rolled back the changes to tabs entirely, considering that we have implemented a more secure allGamesComplete condition. Thus it should not matter that the user is able to browse between tabs- they will still be unable to relaunch.