### PR TITLE
Reroute to sign-in if email-link auth is taking too long

### DIFF
--- a/src/components/auth/AuthEmailLink.vue
+++ b/src/components/auth/AuthEmailLink.vue
@@ -23,9 +23,11 @@ import { useRouter } from 'vue-router'
 const router = useRouter();
 const authStore = useAuthStore();
 const { roarfirekit } = storeToRefs(authStore);
+const success = ref(false);
 
 authStore.$subscribe((mutation, state) => {
   if (state.roarfirekit.userData) {
+    success.value = true;
     router.push({ name: "Home" });
   }
 });
@@ -74,5 +76,13 @@ const unsubscribe = authStore.$subscribe(async (mutation, state) => {
 
 onMounted(() => {
   localStorageEmail.value = window.localStorage.getItem('emailForSignIn');
+  setTimeout(() => {
+    if (!success.value) {
+      addMessages();
+      setTimeout(() => {
+        router.replace({ name: "SignIn" });
+      }, 5000);
+    }
+  }, 6000)
 })
 </script>


### PR DESCRIPTION
This PR mitigates the failure of email-link sign in. I tried to replicate this issue on my localhost and could only get it to reproduce perhaps 10% of the time. This PR does not actually fix the issue but rather tries to mitigate the failure mod by setting a timer and redirecting to sign-in if the auth workflow is taking too long. This reuses the pre-existing error message.

This isn't an ideal solution but is a good enough bandaid for now.