### PR TITLE
Paginate the progress table

### DIFF
--- a/src/pages/AdministrationProgress.vue
+++ b/src/pages/AdministrationProgress.vue
@@ -52,7 +52,7 @@ import AdministratorSidebar from "@/components/AdministratorSidebar.vue";
 import { getSidebarActions } from "@/router/sidebarActions";
 import { useQuery } from '@tanstack/vue-query';
 import { orderByDefault, fetchDocById, exportCsv } from '../helpers/query/utils';
-import { scoresPageFetcher, assignmentCounter, scoresFetchAll } from "@/helpers/query/assignments";
+import { assignmentPageFetcher, assignmentCounter, assignmentFetchAll } from "@/helpers/query/assignments";
 import { orgFetcher } from "@/helpers/query/orgs";
 import { pluralizeFirestoreCollection } from "@/helpers";
 
@@ -117,8 +117,8 @@ const { isLoading: isLoadingSchools, isFetching: isFetchingSchools, data: school
 // Scores Query
 let { isLoading: isLoadingScores, isFetching: isFetchingScores, data: assignmentData } =
   useQuery({
-    queryKey: ['scores', props.administrationId, props.orgId, pageLimit, page],
-    queryFn: () => scoresPageFetcher(props.administrationId, props.orgType, props.orgId, pageLimit, page),
+    queryKey: ['assignments', props.administrationId, props.orgId, pageLimit, page],
+    queryFn: () => assignmentPageFetcher(props.administrationId, props.orgType, props.orgId, pageLimit, page),
     keepPreviousData: true,
     enabled: (initialized && claimsLoaded),
     staleTime: 5 * 60 * 1000, // 5 mins
@@ -127,7 +127,7 @@ let { isLoading: isLoadingScores, isFetching: isFetchingScores, data: assignment
 // Scores count query
 const { isLoading: isLoadingCount, data: assignmentCount } =
   useQuery({
-    queryKey: ['scores', props.administrationId, props.orgId],
+    queryKey: ['assignments', props.administrationId, props.orgId],
     queryFn: () => assignmentCounter(props.administrationId, props.orgType, props.orgId),
     keepPreviousData: true,
     enabled: (initialized && claimsLoaded),
@@ -181,7 +181,7 @@ const exportSelected = (selectedRows) => {
 }
 
 const exportAll = async () => {
-  const exportData = await scoresFetchAll(props.administrationId, props.orgType, props.orgId)
+  const exportData = await assignmentFetchAll(props.administrationId, props.orgType, props.orgId)
   const computedExportData = _map(exportData, ({ user, assignment }) => {
     let tableRow = {
       Username: _get(user, 'username'),

--- a/src/pages/ScoreReport.vue
+++ b/src/pages/ScoreReport.vue
@@ -158,7 +158,7 @@ import AdministratorSidebar from "@/components/AdministratorSidebar.vue";
 import { getSidebarActions } from "@/router/sidebarActions";
 import { getGrade } from "@bdelab/roar-utils";
 import { orderByDefault, fetchDocById, exportCsv } from '../helpers/query/utils';
-import { scoresPageFetcher, assignmentCounter, scoresFetchAll } from "@/helpers/query/assignments";
+import { assignmentPageFetcher, assignmentCounter, assignmentFetchAll } from "@/helpers/query/assignments";
 import { orgFetcher } from "@/helpers/query/orgs";
 import { pluralizeFirestoreCollection } from "@/helpers";
 
@@ -225,7 +225,7 @@ const { isLoading: isLoadingSchools, isFetching: isFetchingSchools, data: school
 let { isLoading: isLoadingScores, isFetching: isFetchingScores, data: scoresDataQuery } =
   useQuery({
     queryKey: ['scores', props.administrationId, props.orgId, pageLimit, page],
-    queryFn: () => scoresPageFetcher(props.administrationId, props.orgType, props.orgId, pageLimit, page),
+    queryFn: () => assignmentPageFetcher(props.administrationId, props.orgType, props.orgId, pageLimit, page, true),
     keepPreviousData: true,
     enabled: (initialized && claimsLoaded),
     staleTime: 5 * 60 * 1000, // 5 mins
@@ -234,7 +234,7 @@ let { isLoading: isLoadingScores, isFetching: isFetchingScores, data: scoresData
 // Scores count query
 const { isLoading: isLoadingCount, data: scoresCount } =
   useQuery({
-    queryKey: ['scores', props.administrationId, props.orgId],
+    queryKey: ['assignments', props.administrationId, props.orgId],
     queryFn: () => assignmentCounter(props.administrationId, props.orgType, props.orgId),
     keepPreviousData: true,
     enabled: (initialized && claimsLoaded),
@@ -289,7 +289,7 @@ const exportSelected = (selectedRows) => {
 }
 
 const exportAll = async () => {
-  const exportData = await scoresFetchAll(props.administrationId, props.orgType, props.orgId)
+  const exportData = await assignmentFetchAll(props.administrationId, props.orgType, props.orgId, true)
   const sortedTasks = allTasks.value.sort((p1, p2) => {
     return displayNames[p1].order - displayNames[p2].order
   })


### PR DESCRIPTION
This PR
- Adds pagination to the progress table
- Implements export selected and export all
- Refactor scores fetchers to general assignment fetchers- make including scores optional
- Sync keys between the two pages
  - assignmentCounter should use same key
  - scores and assignments use different keys- including scores and not including scores respectively 