### PR TITLE
Account for zeros in flatten function

### DIFF
--- a/src/helpers/index.js
+++ b/src/helpers/index.js
@@ -99,7 +99,7 @@ export const flattenObj = (obj) => {
         result[camelCase(i + '.' + j)] = temp[j] || "";
       }
     } else {
-      result[i] = obj[i] || "";
+      result[i] = (obj[i] || obj[i] === 0) ? obj[i] : "";
     }
   }
   return result;


### PR DESCRIPTION
The flatten function was checking truthy-ness when setting values. I have changed this to allow zeros as well. This results in the table exporting zeros along with every other truthy value, while still replacing non-zero falsey values.