### PR TITLE
Add report tooltips

### DIFF
--- a/src/components/RoarDataTable.vue
+++ b/src/components/RoarDataTable.vue
@@ -93,7 +93,7 @@
             v-tooltip.top="`${toolTipByHeader(col.header)}`"
             :style="[
               toolTipByHeader(col.header).length > 0
-                ? 'outline: 1px dotted #0000CD; outline-offset: 3px; border-radius: 7px'
+                ? 'text-decoration: underline dotted #0000CD; text-underline-offset: 3px'
                 : null,
             ]"
           >

--- a/src/components/RoarDataTable.vue
+++ b/src/components/RoarDataTable.vue
@@ -138,7 +138,9 @@
             <div
               v-else-if="col.tagOutlined && _get(colData, col.tagColor)"
               class="circle"
-              style="border: 1px solid black"
+              :style="`border: 1px solid black; ${
+                returnScoreTooltip(col.header, colData).length > 0 && 'outline: 1px dotted #0000CD; outline-offset: 3px'
+              }`"
             />
           </div>
           <div v-else-if="col.link">

--- a/src/components/RoarDataTable.vue
+++ b/src/components/RoarDataTable.vue
@@ -137,7 +137,6 @@
 
             <div
               v-else-if="col.tagOutlined && _get(colData, col.tagColor)"
-              v-tooltip.right="`${returnScoreTooltip(col.header, colData)}`"
               class="circle"
               style="border: 1px solid black"
             />

--- a/src/components/reports/SubscoreTable.vue
+++ b/src/components/reports/SubscoreTable.vue
@@ -1,6 +1,6 @@
 <template>
   <div v-if="scoresDataQuery?.length ?? 0 > 0">
-    <h2 class="header-text">ROAR-{{ _toUpper(taskId) }} STUDENT SCORE INFORMATION</h2>
+    <h2 class="header-text">ROAR-{{ _toUpper(taskName) }} STUDENT SCORE INFORMATION</h2>
     <RoarDataTable
       :columns="columns"
       :data="tableData"
@@ -30,6 +30,7 @@ import { storeToRefs } from 'pinia';
 
 const props = defineProps({
   taskId: { type: String, required: true },
+  taskName: { type: String, required: true },
   administrationId: { type: String, required: true, default: '' },
   orgType: { type: String, required: true, default: '' },
   orgId: { type: String, required: true, default: '' },

--- a/src/pages/ScoreReport.vue
+++ b/src/pages/ScoreReport.vue
@@ -22,9 +22,9 @@
             and sounds.
           </div>
           <div v-if="allTasks.includes('pa')" class="task-blurb">
-            <span class="task-header">ROAR-Phonological Awareness (ROAR-Phoneme)</span> assesses some of the most
-            foundational skills for reading: mapping letters to their corresponding sounds. This skill is crucial for
-            building further reading fluency skills, such as decoding.
+            <span class="task-header">ROAR-Phonological Awareness (ROAR-Phoneme)</span>
+            measures the ability to hear and manipulate the individual sounds within words (sound matching and elision).
+            This skill is crucial for building further reading skills, such as decoding.
           </div>
           <div v-if="allTasks.includes('swr') || allTasks.includes('swr-es')" class="task-blurb">
             <span class="task-header">ROAR-Single Word Recognition (ROAR-Word)</span> assesses decoding skills at the
@@ -99,6 +99,7 @@
         <SubscoreTable
           v-if="allTasks.includes('letter')"
           task-id="letter"
+          :task-name="displayNames['letter'].name"
           :administration-id="administrationId"
           :org-type="orgType"
           :org-id="orgId"
@@ -108,6 +109,7 @@
         <SubscoreTable
           v-if="allTasks.includes('pa')"
           task-id="pa"
+          :task-name="displayNames['pa'].name"
           :administration-id="administrationId"
           :org-type="orgType"
           :org-id="orgId"
@@ -330,7 +332,7 @@ const onSort = (event) => {
 const viewMode = ref('color');
 
 const viewOptions = ref([
-  { label: 'Color', value: 'color' },
+  { label: 'Support Level', value: 'color' },
   { label: 'Percentile', value: 'percentile' },
   { label: 'Standard Score', value: 'standard' },
   { label: 'Raw Score', value: 'raw' },


### PR DESCRIPTION
This pull request adds tooltips to the score report. Tooltips are now included in:

- export selected/export whole files
- data table columns for tasks (sentence, phoneme, etc)
- student score swatches

Tool tips are currently implemented for Phoneme, Word, Sentence, Letter, and Palabra tasks.

This PR also includes some small stylistic changes to the score report requested by the partnership team. 