### PR TITLE
Fix administration creation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15157,7 +15157,6 @@
     },
     "node_modules/npm/node_modules/lodash._baseindexof": {
       "version": "3.1.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
@@ -15182,19 +15181,16 @@
     },
     "node_modules/npm/node_modules/lodash._bindcallback": {
       "version": "3.0.1",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/lodash._cacheindexof": {
       "version": "3.0.2",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/lodash._createcache": {
       "version": "3.1.2",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -15203,7 +15199,6 @@
     },
     "node_modules/npm/node_modules/lodash._getnative": {
       "version": "3.9.1",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
@@ -15214,7 +15209,6 @@
     },
     "node_modules/npm/node_modules/lodash.restparam": {
       "version": "3.6.1",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },

--- a/src/helpers/query/tasks.js
+++ b/src/helpers/query/tasks.js
@@ -159,7 +159,10 @@ export const variantsFetcher = async (registered = false) => {
             if (found) {
               return {
                 name: found.name,
-                data: _mapValues(found.fields, (value) => convertValues(value)),
+                data: {
+                  id: found.name.split('/tasks/')[1],
+                  ..._mapValues(found.fields, (value) => convertValues(value))
+                }
               };
             }
             return undefined;


### PR DESCRIPTION
In the new getVariants query, we were missing the taskId inside the task object needed to create admins.