### PR TITLE
Optimize REST batchGet queries

### DIFF
--- a/src/helpers/query/assignments.js
+++ b/src/helpers/query/assignments.js
@@ -713,7 +713,7 @@ export const assignmentPageFetcher = async (
 
         for (const score of scoresObj) {
           const userRuns = runs[score.roarUid];
-          for (const task of score.assignment.assignments) {
+          for (const task of score.assignment.assessments) {
             const runId = task.runId;
             task['scores'] = _get(
               _find(userRuns, (runDoc) => runDoc.name.includes(runId)),

--- a/src/helpers/query/utils.js
+++ b/src/helpers/query/utils.js
@@ -101,7 +101,6 @@ export const fetchDocById = async (collection, docId, select, db = 'admin') => {
 };
 
 export const fetchDocsById = async (documents, db = 'admin') => {
-  console.log('fetching docs', documents);
   const axiosInstance = getAxiosInstance(db);
   const promises = [];
   for (const { collection, docId, select } of documents) {

--- a/src/pages/HomeParticipant.vue
+++ b/src/pages/HomeParticipant.vue
@@ -158,9 +158,7 @@ const noGamesAvailable = computed(() => {
 // Assessments to populate the game tabs.
 // Generated based on the current selected admin Id
 const assessments = computed(() => {
-  console.log('Recomputing assessments');
   if (!isFetching.value && selectedAdmin.value && (taskInfo.value ?? []).length > 0) {
-    console.log('Using map to combine assessment data');
     return selectedAdmin.value.assessments.map((assessment) => {
       // Get the matching assessment from assignmentInfo
       const matchingAssignment = _find(assignmentInfo.value, { id: selectedAdmin.value.id });
@@ -174,11 +172,9 @@ const assessments = computed(() => {
           variantURL: _get(assessment, 'params.variantURL'),
         },
       };
-      console.log('combinedAssessment', combinedAssessment);
       return combinedAssessment;
     });
   }
-  console.log('No assessments found');
   return [];
 });
 

--- a/src/store/scores.js
+++ b/src/store/scores.js
@@ -176,15 +176,15 @@ export function percentileToSupportClassification(taskId, percentile, grade = 1)
           percentile < 25
             ? 'Extra Support Needed'
             : percentile < 50
-            ? 'Some Support Needed'
-            : 'Average or Above Average';
+              ? 'Some Support Needed'
+              : 'Average or Above Average';
       } else {
         support =
           percentile < 15
             ? 'Extra Support Needed'
             : percentile < 30
-            ? 'Some Support Needed'
-            : 'Average or Above Average';
+              ? 'Some Support Needed'
+              : 'Average or Above Average';
       }
       break;
 
@@ -197,8 +197,8 @@ export function percentileToSupportClassification(taskId, percentile, grade = 1)
           percentile < 25
             ? 'Extra Support Needed'
             : percentile < 50
-            ? 'Some Support Needed'
-            : 'Average or Above Average';
+              ? 'Some Support Needed'
+              : 'Average or Above Average';
       }
       break;
 


### PR DESCRIPTION
Many of the batchGet requests had duplicated entries. This PR first uses `_uniq` to reduce the size of the batchGet document lists (sometime reducing to a third of the original size). This also required some downstream changes to the fetchers since the batchGet document array were no longer the same length as the arrays for assessments/runs/scores. Practically, this meant using `_find` instead of `_zip`.

This PR is based on top of #248 