### PR TITLE
Fix/admin show details wrap

### DIFF
--- a/src/components/CardAdministration.vue
+++ b/src/components/CardAdministration.vue
@@ -1,123 +1,88 @@
 <template>
-  <div class="p-card card-administration mb-2">
-    <div v-if="props.stats && isSuperAdmin" class="card-admin-chart">
-      <PvChart type="doughnut" :data="doughnutChartData" :options="doughnutChartOptions" />
+  <div class="card-administration-wrapper">
+    <div class="p-card card-administration mb-2">
+      <div v-if="props.stats && isSuperAdmin" class="card-admin-chart">
+        <PvChart type="doughnut" :data="doughnutChartData" :options="doughnutChartOptions" />
+      </div>
+
+      <div class="card-admin-body">
+        <div class="flex flex-row w-full">
+          <div class="flex-grow-1">
+            <h2>{{ title }}</h2>
+          </div>
+          <div v-if="isSuperAdmin" class="flex flex-row flex-grow-0 justify-content-end p-1">
+            <PvSpeedDial
+:model="speedDialItems" direction="left" :transition-delay="80" show-icon="pi pi-cog"
+              hide-icon="pi pi-times" button-class="p-button-outlined" :pt="{ button: { size: 'small' } }" />
+            <PvConfirmPopup />
+          </div>
+        </div>
+        <div class="card-admin-details">
+          <span class="mr-1"><strong>Dates</strong>:</span>
+          <span> {{ processedDates.start.toLocaleDateString() }} — {{ processedDates.end.toLocaleDateString() }} </span>
+        </div>
+        <div class="card-admin-assessments">
+          <span class="mr-1"><strong>Assessments</strong>:</span>
+          <span v-for="assessmentId in assessmentIds" :key="assessmentId" class="card-inline-list-item">
+            {{ displayNames[assessmentId]?.name ?? assessmentId }}
+            <span
+v-if="showParams" v-tooltip.top="'Click to view params'" class="pi pi-info-circle cursor-pointer"
+              style="font-size: 1rem" @click="toggleParams($event, assessmentId)" />
+          </span>
+          <div v-if="showParams">
+            <PvOverlayPanel v-for="assessmentId in assessmentIds" :key="assessmentId" :ref="paramPanelRefs[assessmentId]">
+              <PvDataTable
+striped-rows class="p-datatable-small" table-style="min-width: 30rem"
+                :value="toEntryObjects(params[assessmentId])">
+                <PvColumn field="key" header="Parameter" style="width: 50%"></PvColumn>
+                <PvColumn field="value" header="Value" style="width: 50%"></PvColumn>
+              </PvDataTable>
+            </PvOverlayPanel>
+          </div>
+        </div>
+
+        <div class="break my-2"></div>
+
+        <div v-if="isAssigned">
+          <PvButton :icon="toggleIcon" size="small" :label="toggleLabel" @click="toggleTable" />
+        </div>
+      </div>
+
     </div>
-
-    <div class="card-admin-body">
-      <div class="flex flex-row w-full">
-        <div class="flex-grow-1">
-          <h2>{{ title }}</h2>
-        </div>
-        <div v-if="isSuperAdmin" class="flex flex-row flex-grow-0 justify-content-end">
-          <PvSpeedDial
-            :model="speedDialItems"
-            direction="left"
-            :transition-delay="80"
-            show-icon="pi pi-cog"
-            hide-icon="pi pi-times"
-            button-class="p-button-outlined"
-            :pt="{ button: { size: 'small' } }"
-          />
-          <PvConfirmPopup />
-        </div>
-      </div>
-      <div class="card-admin-details">
-        <span class="mr-1"><strong>Dates</strong>:</span>
-        <span> {{ processedDates.start.toLocaleDateString() }} — {{ processedDates.end.toLocaleDateString() }} </span>
-      </div>
-      <div class="card-admin-assessments">
-        <span class="mr-1"><strong>Assessments</strong>:</span>
-        <span v-for="assessmentId in assessmentIds" :key="assessmentId" class="card-inline-list-item">
-          {{ displayNames[assessmentId]?.name ?? assessmentId }}
-          <span
-            v-if="showParams"
-            v-tooltip.top="'Click to view params'"
-            class="pi pi-info-circle cursor-pointer"
-            style="font-size: 1rem"
-            @click="toggleParams($event, assessmentId)"
-          />
-        </span>
-        <div v-if="showParams">
-          <PvOverlayPanel v-for="assessmentId in assessmentIds" :key="assessmentId" :ref="paramPanelRefs[assessmentId]">
-            <PvDataTable
-              striped-rows
-              class="p-datatable-small"
-              table-style="min-width: 30rem"
-              :value="toEntryObjects(params[assessmentId])"
-            >
-              <PvColumn field="key" header="Parameter" style="width: 50%"></PvColumn>
-              <PvColumn field="value" header="Value" style="width: 50%"></PvColumn>
-            </PvDataTable>
-          </PvOverlayPanel>
-        </div>
-      </div>
-
-      <div class="break my-2"></div>
-
-      <div v-if="isAssigned">
-        <PvButton :icon="toggleIcon" size="small" :label="toggleLabel" @click="toggleTable" />
-      </div>
-
-      <PvTreeTable
-        v-if="showTable"
-        class="mt-3"
-        lazy
-        row-hover
-        :loading="loadingTreeTable"
-        :value="treeTableOrgs"
-        @node-expand="onExpand"
-      >
-        <PvColumn field="name" header="Name" expander style="width: 20rem"></PvColumn>
-        <PvColumn v-if="props.stats" field="id" header="Completion">
-          <template #body="{ node }">
-            <PvChart type="bar" :data="setBarChartData(node.data.id)" :options="barChartOptions" class="h-3rem" />
-          </template>
-        </PvColumn>
-        <PvColumn field="id" header="" style="width: 14rem">
-          <template #body="{ node }">
-            <div class="flex m-0">
-              <router-link
-                :to="{
-                  name: 'ViewAdministration',
-                  params: { administrationId: props.id, orgId: node.data.id, orgType: node.data.orgType },
-                }"
-                class="no-underline"
-              >
-                <PvButton
-                  v-tooltip.top="'See completion details'"
-                  class="m-0"
-                  severity="secondary"
-                  text
-                  raised
-                  label="Progress"
-                  aria-label="Completion details"
-                  size="small"
-                />
-              </router-link>
-              <router-link
-                :to="{
-                  name: 'ScoreReport',
-                  params: { administrationId: props.id, orgId: node.data.id, orgType: node.data.orgType },
-                }"
-                class="no-underline"
-              >
-                <PvButton
-                  v-tooltip.top="'See Scores'"
-                  class="m-0"
-                  severity="secondary"
-                  text
-                  raised
-                  label="Scores"
-                  aria-label="Scores"
-                  size="small"
-                />
-              </router-link>
-            </div>
-          </template>
-        </PvColumn>
-      </PvTreeTable>
-    </div>
+    <PvTreeTable
+v-if="showTable" class="mt-3" lazy row-hover :loading="loadingTreeTable" :value="treeTableOrgs"
+      @node-expand="onExpand">
+      <PvColumn field="name" header="Name" expander style="width: min-content"></PvColumn>
+      <PvColumn v-if="props.stats && isWideScreen" field="id" header="Completion">
+        <template #body="{ node }">
+          <PvChart type="bar" :data="setBarChartData(node.data.id)" :options="barChartOptions" class="h-3rem" />
+        </template>
+      </PvColumn>
+      <PvColumn field="id" header="" style="width: 14rem">
+        <template #body="{ node }">
+          <div class="flex m-0">
+            <router-link
+:to="{
+              name: 'ViewAdministration',
+              params: { administrationId: props.id, orgId: node.data.id, orgType: node.data.orgType },
+            }" class="no-underline">
+              <PvButton
+v-tooltip.top="'See completion details'" class="m-0" severity="secondary" text raised
+                label="Progress" aria-label="Completion details" size="small" />
+            </router-link>
+            <router-link
+:to="{
+              name: 'ScoreReport',
+              params: { administrationId: props.id, orgId: node.data.id, orgType: node.data.orgType },
+            }" class="no-underline">
+              <PvButton
+v-tooltip.top="'See Scores'" class="m-0" severity="secondary" text raised label="Scores"
+                aria-label="Scores" size="small" />
+            </router-link>
+          </div>
+        </template>
+      </PvColumn>
+    </PvTreeTable>
   </div>
 </template>
 
@@ -244,6 +209,10 @@ const toggleTable = () => {
   enableQueries.value = true;
   showTable.value = !showTable.value;
 };
+
+const isWideScreen = computed(()=> {
+  return window.innerWidth > 768;
+});
 
 const singularOrgTypes = {
   districts: 'district',
@@ -599,63 +568,67 @@ onMounted(() => {
 </script>
 
 <style lang="scss">
-.card-administration {
-  text-align: left;
-  width: 100%;
+.card-administration-wrapper {
   background: var(--surface-b);
   border: 1px solid var(--surface-d);
   border-radius: var(--border-radius);
-  display: flex;
-  flex-direction: row;
   gap: 2rem;
-  padding: 1rem;
+  padding: .5rem;
+  margin: 0.5rem 0rem;
 
-  .card-admin-chart {
-    padding: 1rem;
-    width: 23ch;
-  }
-
-  .card-admin-body {
-    flex: 1 1 auto;
+  .card-administration {
+    text-align: left;
+    width: 100%;
     display: flex;
     flex-direction: row;
-    flex-wrap: wrap;
-    align-content: start;
 
-    p {
-      margin-block: 0.5rem;
+    .card-admin-chart {
+      padding: 1rem;
+      width: 23ch;
     }
-  }
 
-  .break {
-    flex-basis: 100%;
-    height: 0;
-  }
+    .card-admin-body {
+      flex: 1 1 auto;
+      display: flex;
+      flex-direction: row;
+      flex-wrap: wrap;
+      align-content: start;
 
-  .card-admin-title {
-    font-weight: bold;
-    width: 100%;
-    padding-bottom: 0.5rem;
-    border-bottom: 1px solid var(--surface-d);
-    flex: 1 1 100%;
-  }
+      p {
+        margin-block: 0.5rem;
+      }
+    }
 
-  .card-admin-details {
-    width: 45%;
-  }
+    .break {
+      flex-basis: 100%;
+      height: 0;
+    }
 
-  .card-admin-link {
-    margin-top: 2rem;
-    width: 100%;
-  }
+    .card-admin-title {
+      font-weight: bold;
+      width: 100%;
+      padding-bottom: 0.5rem;
+      border-bottom: 1px solid var(--surface-d);
+      flex: 1 1 100%;
+    }
 
-  .card-admin-class-list {
-    width: 100%;
-    margin-top: 2rem;
-  }
+    .card-admin-details {
+      width: 45%;
+    }
 
-  .cursor-pointer {
-    cursor: pointer;
+    .card-admin-link {
+      margin-top: 2rem;
+      width: 100%;
+    }
+
+    .card-admin-class-list {
+      width: 100%;
+      margin-top: 2rem;
+    }
+
+    .cursor-pointer {
+      cursor: pointer;
+    }
   }
 }
 

--- a/src/components/CardAdministration.vue
+++ b/src/components/CardAdministration.vue
@@ -12,8 +12,14 @@
           </div>
           <div v-if="isSuperAdmin" class="flex flex-row flex-grow-0 justify-content-end p-1">
             <PvSpeedDial
-:model="speedDialItems" direction="left" :transition-delay="80" show-icon="pi pi-cog"
-              hide-icon="pi pi-times" button-class="p-button-outlined" :pt="{ button: { size: 'small' } }" />
+              :model="speedDialItems"
+              direction="left"
+              :transition-delay="80"
+              show-icon="pi pi-cog"
+              hide-icon="pi pi-times"
+              button-class="p-button-outlined"
+              :pt="{ button: { size: 'small' } }"
+            />
             <PvConfirmPopup />
           </div>
         </div>
@@ -26,14 +32,25 @@
           <span v-for="assessmentId in assessmentIds" :key="assessmentId" class="card-inline-list-item">
             {{ displayNames[assessmentId]?.name ?? assessmentId }}
             <span
-v-if="showParams" v-tooltip.top="'Click to view params'" class="pi pi-info-circle cursor-pointer"
-              style="font-size: 1rem" @click="toggleParams($event, assessmentId)" />
+              v-if="showParams"
+              v-tooltip.top="'Click to view params'"
+              class="pi pi-info-circle cursor-pointer"
+              style="font-size: 1rem"
+              @click="toggleParams($event, assessmentId)"
+            />
           </span>
           <div v-if="showParams">
-            <PvOverlayPanel v-for="assessmentId in assessmentIds" :key="assessmentId" :ref="paramPanelRefs[assessmentId]">
+            <PvOverlayPanel
+              v-for="assessmentId in assessmentIds"
+              :key="assessmentId"
+              :ref="paramPanelRefs[assessmentId]"
+            >
               <PvDataTable
-striped-rows class="p-datatable-small" table-style="min-width: 30rem"
-                :value="toEntryObjects(params[assessmentId])">
+                striped-rows
+                class="p-datatable-small"
+                table-style="min-width: 30rem"
+                :value="toEntryObjects(params[assessmentId])"
+              >
                 <PvColumn field="key" header="Parameter" style="width: 50%"></PvColumn>
                 <PvColumn field="value" header="Value" style="width: 50%"></PvColumn>
               </PvDataTable>
@@ -47,11 +64,16 @@ striped-rows class="p-datatable-small" table-style="min-width: 30rem"
           <PvButton :icon="toggleIcon" size="small" :label="toggleLabel" @click="toggleTable" />
         </div>
       </div>
-
     </div>
     <PvTreeTable
-v-if="showTable" class="mt-3" lazy row-hover :loading="loadingTreeTable" :value="treeTableOrgs"
-      @node-expand="onExpand">
+      v-if="showTable"
+      class="mt-3"
+      lazy
+      row-hover
+      :loading="loadingTreeTable"
+      :value="treeTableOrgs"
+      @node-expand="onExpand"
+    >
       <PvColumn field="name" header="Name" expander style="width: min-content"></PvColumn>
       <PvColumn v-if="props.stats && isWideScreen" field="id" header="Completion">
         <template #body="{ node }">
@@ -62,22 +84,40 @@ v-if="showTable" class="mt-3" lazy row-hover :loading="loadingTreeTable" :value=
         <template #body="{ node }">
           <div class="flex m-0">
             <router-link
-:to="{
-              name: 'ViewAdministration',
-              params: { administrationId: props.id, orgId: node.data.id, orgType: node.data.orgType },
-            }" class="no-underline">
+              :to="{
+                name: 'ViewAdministration',
+                params: { administrationId: props.id, orgId: node.data.id, orgType: node.data.orgType },
+              }"
+              class="no-underline"
+            >
               <PvButton
-v-tooltip.top="'See completion details'" class="m-0" severity="secondary" text raised
-                label="Progress" aria-label="Completion details" size="small" />
+                v-tooltip.top="'See completion details'"
+                class="m-0"
+                severity="secondary"
+                text
+                raised
+                label="Progress"
+                aria-label="Completion details"
+                size="small"
+              />
             </router-link>
             <router-link
-:to="{
-              name: 'ScoreReport',
-              params: { administrationId: props.id, orgId: node.data.id, orgType: node.data.orgType },
-            }" class="no-underline">
+              :to="{
+                name: 'ScoreReport',
+                params: { administrationId: props.id, orgId: node.data.id, orgType: node.data.orgType },
+              }"
+              class="no-underline"
+            >
               <PvButton
-v-tooltip.top="'See Scores'" class="m-0" severity="secondary" text raised label="Scores"
-                aria-label="Scores" size="small" />
+                v-tooltip.top="'See Scores'"
+                class="m-0"
+                severity="secondary"
+                text
+                raised
+                label="Scores"
+                aria-label="Scores"
+                size="small"
+              />
             </router-link>
           </div>
         </template>
@@ -210,7 +250,7 @@ const toggleTable = () => {
   showTable.value = !showTable.value;
 };
 
-const isWideScreen = computed(()=> {
+const isWideScreen = computed(() => {
   return window.innerWidth > 768;
 });
 
@@ -573,7 +613,6 @@ onMounted(() => {
   border: 1px solid var(--surface-d);
   border-radius: var(--border-radius);
   gap: 2rem;
-  padding: .5rem;
   margin: 0.5rem 0rem;
 
   .card-administration {


### PR DESCRIPTION
this pr slightly modifies the structure of the administration card component to render groups under the administration as a full container width. whereas small width screens would cause the previous table to clip, this update makes the table a bit more responsive. 

<img width="816" alt="image" src="https://github.com/yeatmanlab/roar-dashboard/assets/20426569/2ba4c627-bdea-4e1c-b015-f3b8669ff88a">