### PR TITLE
Make distribution graphs super-admin only again

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15336,6 +15336,7 @@
     },
     "node_modules/npm/node_modules/lodash._baseindexof": {
       "version": "3.1.0",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
@@ -15360,16 +15361,19 @@
     },
     "node_modules/npm/node_modules/lodash._bindcallback": {
       "version": "3.0.1",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/lodash._cacheindexof": {
       "version": "3.0.2",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/lodash._createcache": {
       "version": "3.1.2",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -15378,6 +15382,7 @@
     },
     "node_modules/npm/node_modules/lodash._getnative": {
       "version": "3.9.1",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
@@ -15388,6 +15393,7 @@
     },
     "node_modules/npm/node_modules/lodash.restparam": {
       "version": "3.6.1",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },

--- a/src/pages/ScoreReport.vue
+++ b/src/pages/ScoreReport.vue
@@ -20,7 +20,7 @@
               <AppSpinner style="margin: 1rem 0rem" />
               <div class="uppercase text-sm">Loading Overview Charts</div>
             </div>
-            <div class="chart-wrapper">
+            <div v-if="isSuperAdmin" class="chart-wrapper">
               <div v-for="taskId of Object.keys(runsByTaskId)" :key="taskId" class="">
                 <DistributionChartOverview
                   :runs="runsByTaskId[taskId]"
@@ -138,7 +138,7 @@
           <AppSpinner style="margin: 1rem 0rem" />
           <div class="uppercase text-sm">Loading Task Reports</div>
         </div>
-        <PvTabView>
+        <PvTabView v-if="isSuperAdmin">
           <PvTabPanel
             v-for="taskId of Object.keys(runsByTaskId)"
             :key="taskId"
@@ -157,6 +157,56 @@
             />
           </PvTabPanel>
         </PvTabView>
+        <div v-else>
+          <!-- In depth breakdown of each task -->
+          <div v-if="allTasks.includes('letter')" class="task-card">
+            <div class="task-title">ROAR-LETTER</div>
+            <span style="text-transform: uppercase">Letter Names and Letter-Sound Matching</span>
+            <p class="task-description">
+              ROAR-Letter assesses a student’s knowledge of letter names and letter sounds. Knowing letter names supports
+              the learning of letter sounds, and knowing letter sounds supports the learning of letter names. Initial
+              knowledge of letter names and letter sounds on entry to kindergarten has been shown to predict success in
+              learning to read. Learning the connection between letters and the sounds they represent is fundamental for
+              learning to decode and spell words. This assessment provides educators with valuable insights to customize
+              instruction and address any gaps in these foundational skills.
+            </p>
+          </div>
+          <div v-if="allTasks.includes('pa')" class="task-card">
+            <div class="task-title">ROAR-PHONEME</div>
+            <span style="text-transform: uppercase">Phonological Awareness</span>
+            <p class="task-description">
+              ROAR - Phoneme assesses a student's mastery of phonological awareness through elision and sound matching
+              tasks. Research indicates that phonological awareness, as a foundational pre-reading skill, is crucial for
+              achieving reading fluency. Without support for their foundational reading abilities, students may struggle
+              to catch up in overall reading proficiency. The student's score will range between 0-57 and can be viewed by
+              selecting 'Raw Score' on the table above.
+            </p>
+          </div>
+          <div v-if="allTasks.includes('swr') || allTasks.includes('swr-es')" class="task-card">
+            <div class="task-title">ROAR-WORD</div>
+            <span style="text-transform: uppercase">Single Word Recognition</span>
+            <p class="task-description">
+              ROAR - Word evaluates a student's ability to quickly and automatically recognize individual words. To read
+              fluently, students must master fundamental skills of decoding and automaticity. This test measures a
+              student's ability to detect real and made-up words, which can then translate to a student's reading levels
+              and need for support. The student's score will range between 100-900 and can be viewed by selecting 'Raw
+              Score' on the table above.
+            </p>
+          </div>
+          <div v-if="allTasks.includes('sre')" class="task-card">
+            <div class="task-title">ROAR-SENTENCE</div>
+            <span style="text-transform: uppercase">Sentence Reading Efficiency</span>
+            <p class="task-description">
+              ROAR - Sentence examines silent reading fluency and comprehension for individual sentences. To become fluent
+              readers, students need to decode words accurately and read sentences smoothly. Poor fluency can make it
+              harder for students to understand what they're reading. Students who don't receive support for their basic
+              reading skills may find it challenging to improve their overall reading ability. This assessment is helpful
+              for identifying students who may struggle with reading comprehension due to difficulties with decoding words
+              accurately or reading slowly and with effort. The student's score will range between 0-130 and can be viewed
+              by selecting 'Raw Score' on the table above.
+            </p>
+          </div>
+        </div>
         <div class="bg-gray-200 px-4 py-2 mt-4">
           <h2 class="extra-info-title">HOW ROAR SCORES INFORM PLANNING TO PROVIDE SUPPORT</h2>
           <p>


### PR DESCRIPTION
This PR changes Score Reports so that the new graphs are a feature for super admins only. The graphs above the table are hidden, and the graphs below the table are replaced with the old text when a non-super admin views the report.
![Screenshot 2024-01-16 at 2 18 57 PM](https://github.com/yeatmanlab/roar-dashboard/assets/127352507/f5abca15-33ef-4437-ab19-51a04f866509)
![Screenshot 2024-01-16 at 2 18 49 PM](https://github.com/yeatmanlab/roar-dashboard/assets/127352507/f5a8b659-f725-4c74-a7a5-fd1c09cc3a1b)
