### PR TITLE
Only display graphs for SRE, SWR, and PA

### DIFF
--- a/src/components/reports/tasks/TaskReport.vue
+++ b/src/components/reports/tasks/TaskReport.vue
@@ -16,7 +16,7 @@
     </Accordion>
   </div>
   <!-- <div class="grid grid-cols-2 w-full space-around items-center p-3"> -->
-  <div class="chart-wrapper">
+  <div v-if="tasksToDisplayGraphs.includes(taskId)" class="chart-wrapper">
     <div>
       <DistributionChartSupport
         :initialized="initialized"
@@ -66,7 +66,7 @@ import DistributionChartFacet from '@/components/reports/DistributionChartFacet.
 import DistributionChartSupport from '@/components/reports/DistributionChartSupport.vue';
 import Accordion from 'primevue/accordion';
 import AccordionTab from 'primevue/accordiontab';
-import { taskDisplayNames } from '@/helpers/reports.js';
+import { taskDisplayNames, tasksToDisplayGraphs } from '@/helpers/reports.js';
 import SubscoreTable from '@/components/reports/SubscoreTable.vue';
 
 // eslint-disable-next-line no-unused-vars

--- a/src/helpers/reports.js
+++ b/src/helpers/reports.js
@@ -31,6 +31,8 @@ export const descriptionsByTaskId = {
   },
 };
 
+export const tasksToDisplayGraphs = ['swr', 'sre', 'pa'];
+
 export const excludedTasks = ['cva', 'morphology'];
 
 export const supportLevelColors = {

--- a/src/pages/ScoreReport.vue
+++ b/src/pages/ScoreReport.vue
@@ -21,7 +21,7 @@
             </div>
             <div v-if="isSuperAdmin" class="overview-wrapper bg-gray-100 py-3 mb-2">
               <div class="chart-wrapper">
-                <div v-for="taskId of sortedTaskIds" :key="taskId" class="">
+                <div v-for="taskId of sortedAndFilteredTaskIds" :key="taskId" class="">
                   <div class="distribution-overview-wrapper">
                     <DistributionChartOverview
                       :runs="runsByTaskId[taskId]"
@@ -281,6 +281,7 @@ import {
   excludedTasks,
   supportLevelColors,
   getSupportLevel,
+  tasksToDisplayGraphs,
 } from '@/helpers/reports.js';
 import TaskReport from '@/components/reports/tasks/TaskReport.vue';
 import DistributionChartOverview from '@/components/reports/DistributionChartOverview.vue';
@@ -833,6 +834,12 @@ const sortedTaskIds = computed(() => {
     } else {
       return -1;
     }
+  });
+});
+
+const sortedAndFilteredTaskIds = computed(() => {
+  return sortedTaskIds.value.filter((taskId) => {
+    return tasksToDisplayGraphs.includes(taskId);
   });
 });
 


### PR DESCRIPTION
Fixes behavior where graphs of unsupported tasks like ROAR letter would show up empty. 