### PR TITLE
Fix/dist charts ordering and toggles

### DIFF
--- a/src/assets/styles/components/selectbutton.scss
+++ b/src/assets/styles/components/selectbutton.scss
@@ -38,3 +38,15 @@
 .p-selectbutton.p-invalid > .p-button {
   border-color: var(--red-100);
 }
+
+.select-button .p-button {
+  margin: 0px;
+}
+.select-button .p-button:last-of-type:not(:only-of-type) {
+  border-top-left-radius: 0px;
+  border-bottom-left-radius: 0px;
+}
+.select-button .p-button:first-of-type:not(:only-of-type) {
+  border-top-right-radius: 0px;
+  border-bottom-right-radius: 0px;
+}

--- a/src/components/reports/DistributionChartFacet.vue
+++ b/src/components/reports/DistributionChartFacet.vue
@@ -1,5 +1,5 @@
 <template>
-  <div v-if="orgType === 'district'" class="view-by-wrapper">
+  <div class="view-by-wrapper mx-2">
     <div class="flex uppercase text-xs font-light">view scores by</div>
     <PvSelectButton
       v-model="scoreMode"
@@ -52,16 +52,16 @@ const props = defineProps({
   },
 });
 
-const scoreMode = ref({ name: 'Raw', key: 'rawScore' });
+const scoreMode = ref({ name: 'Raw Score', key: 'rawScore' });
 const scoreModes = [
-  { name: 'Raw', key: 'rawScore' },
+  { name: 'Raw Score', key: 'rawScore' },
   { name: 'Percentile', key: 'stdPercentile' },
 ];
 
 const getRangeLow = (scoreMode, taskId) => {
   if (scoreMode === 'Percentile') {
     return 0;
-  } else if (scoreMode === 'Raw') {
+  } else if (scoreMode === 'Raw Score') {
     if (taskId === 'pa') return 0;
     else if (taskId === 'sre') return 0;
     else if (taskId === 'swr') return 100;
@@ -72,7 +72,7 @@ const getRangeLow = (scoreMode, taskId) => {
 const getRangeHigh = (scoreMode, taskId) => {
   if (scoreMode === 'Percentile') {
     return 100;
-  } else if (scoreMode === 'Raw') {
+  } else if (scoreMode === 'Raw Score') {
     if (taskId === 'pa') return 57;
     else if (taskId === 'sre') return 130;
     else if (taskId === 'swr') return 900;
@@ -85,7 +85,7 @@ const distributionChartFacet = (taskId, runs) => {
     background: null,
     title: {
       text: `ROAR-${taskDisplayNames[taskId].name}`,
-      subtitle: 'Distribution of Percentile By Grade',
+      subtitle: `${scoreMode.value.name} Distribution By ${props.facetMode.name}`,
       anchor: 'middle',
       fontSize: 18,
     },
@@ -125,17 +125,21 @@ const distributionChartFacet = (taskId, runs) => {
 
       color: {
         field: `scores.${scoreMode.value.key}`,
+        scheme: 'blues',
         type: 'quantitative',
         legend: null,
         scale: {
-          range: ['rgb(201, 61, 130)', 'rgb(237, 192, 55)', 'green'],
+          range:
+            scoreMode.value.name === 'Percentile'
+              ? ['rgb(201, 61, 130)', 'rgb(237, 192, 55)', 'green']
+              : ['#ADD8E6', '#000080'],
           domain: scoreMode.value.name === 'Percentile' ? [0, 45, 70, 100] : '',
         },
       },
 
       x: {
         field: `scores.${scoreMode.value.key}`,
-        title: `${scoreMode.value.name} Score`,
+        title: scoreMode.value.name === 'Percentile' ? `${scoreMode.value.name} Score` : `${scoreMode.value.name}`,
         bin: { extent: [getRangeLow(scoreMode.value.name, taskId), getRangeHigh(scoreMode.value.name, taskId)] },
         sort: 'ascending',
         axis: {

--- a/src/components/reports/DistributionChartFacet.vue
+++ b/src/components/reports/DistributionChartFacet.vue
@@ -3,7 +3,8 @@
     <div class="flex uppercase text-xs font-light">view scores by</div>
     <PvSelectButton
       v-model="scoreMode"
-      class="flex flex-row my-2"
+      :allow-empty="false"
+      class="flex flex-row my-2 select-button"
       :options="scoreModes"
       option-label="name"
       @change="handleModeChange"

--- a/src/components/reports/DistributionChartFacet.vue
+++ b/src/components/reports/DistributionChartFacet.vue
@@ -1,5 +1,4 @@
 <template>
-  <!-- <div v-if="orgType === 'district'" class="mode-select-wrapper mt-2"> -->
   <div v-if="orgType === 'district'" class="view-by-wrapper">
     <div class="flex uppercase text-xs font-light">view scores by</div>
     <PvSelectButton
@@ -198,13 +197,6 @@ onMounted(() => {
 </script>
 
 <style lang="scss">
-.mode-select-wrapper {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: flex-end;
-}
-
 .view-by-wrapper {
   display: flex;
   flex-direction: column;

--- a/src/components/reports/DistributionChartFacet.vue
+++ b/src/components/reports/DistributionChartFacet.vue
@@ -19,7 +19,7 @@
       />
     </div>
   </div>
-  <div :id="`roar-dist-chart-${taskId}`"></div>
+  <div :id="`roar-distribution-chart-${taskId}`"></div>
 </template>
 
 <script setup>
@@ -97,7 +97,7 @@ const getRangeHigh = (scoreMode, taskId) => {
   return 100;
 };
 
-const distChartFacet = (taskId, runs) => {
+const distributionChartFacet = (taskId, runs) => {
   return {
     background: null,
     title: {
@@ -193,8 +193,8 @@ const distChartFacet = (taskId, runs) => {
 };
 
 const draw = async () => {
-  let chartSpecDist = distChartFacet(props.taskId, props.runs);
-  await embed(`#roar-dist-chart-${props.taskId}`, chartSpecDist);
+  let chartSpecDist = distributionChartFacet(props.taskId, props.runs);
+  await embed(`#roar-distribution-chart-${props.taskId}`, chartSpecDist);
 };
 
 onMounted(() => {

--- a/src/components/reports/DistributionChartFacet.vue
+++ b/src/components/reports/DistributionChartFacet.vue
@@ -2,11 +2,21 @@
   <div v-if="orgType === 'district'" class="mode-select-wrapper mt-2">
     <div class="view-by-wrapper">
       <div class="flex uppercase text-xs font-light">view rows by</div>
-      <PvSelectButton v-model="facetMode" class="flex flex-row my-2" :options="facetModes" option-label="name"
-        @change="handleModeChange" />
+      <PvSelectButton
+        v-model="facetMode"
+        class="flex flex-row my-2"
+        :options="facetModes"
+        option-label="name"
+        @change="handleModeChange"
+      />
       <div class="flex uppercase text-xs font-light">view scores by</div>
-      <PvSelectButton v-model="scoreMode" class="flex flex-row my-2" :options="scoreModes" option-label="name"
-        @change="handleModeChange" />
+      <PvSelectButton
+        v-model="scoreMode"
+        class="flex flex-row my-2"
+        :options="scoreModes"
+        option-label="name"
+        @change="handleModeChange"
+      />
     </div>
   </div>
   <div :id="`roar-dist-chart-${taskId}`"></div>
@@ -70,7 +80,6 @@ const getRangeLow = (scoreMode, taskId) => {
     return 0;
   } else if (scoreMode === 'Raw') {
     if (taskId === 'pa') return 0;
-
     else if (taskId === 'sre') return 0;
     else if (taskId === 'swr') return 100;
   }
@@ -82,7 +91,6 @@ const getRangeHigh = (scoreMode, taskId) => {
     return 100;
   } else if (scoreMode === 'Raw') {
     if (taskId === 'pa') return 57;
-
     else if (taskId === 'sre') return 130;
     else if (taskId === 'swr') return 900;
   }
@@ -120,14 +128,16 @@ const distChartFacet = (taskId, runs) => {
           labelAnchor: 'middle',
           labelAngle: 0,
           labelAlign: 'left',
-          labelOrient: 'left',   
+          labelOrient: 'left',
           labelExpr:
-            facetMode.value.name === 'Grade' ? "join(['Grade ',if(datum.value == '0', 'K', datum.value ), ], '')" : 'slice(datum.value, 1, datum.value.length)',
+            facetMode.value.name === 'Grade'
+              ? "join(['Grade ',if(datum.value == '0', 'K', datum.value ), ], '')"
+              : 'slice(datum.value, 1, datum.value.length)',
           labelLimit: 150,
           labelSeparation: 5, // Set the spacing between lines in pixels
         },
         spacing: 10,
-        sort: 'ascending'
+        sort: 'ascending',
       },
 
       color: {
@@ -136,7 +146,7 @@ const distChartFacet = (taskId, runs) => {
         legend: null,
         scale: {
           range: ['rgb(201, 61, 130)', 'rgb(237, 192, 55)', 'green'],
-          domain: scoreMode.value.name === 'Percentile' ? [0, 45, 70, 100] : "",
+          domain: scoreMode.value.name === 'Percentile' ? [0, 45, 70, 100] : '',
         },
       },
 
@@ -164,7 +174,12 @@ const distChartFacet = (taskId, runs) => {
         },
       },
       tooltip: [
-        { field: `scores.${scoreMode.value.key}`, title: `${scoreMode.value.name}`, type: 'quantitative', format: `.0f` },
+        {
+          field: `scores.${scoreMode.value.key}`,
+          title: `${scoreMode.value.name}`,
+          type: 'quantitative',
+          format: `.0f`,
+        },
         { field: 'user.grade', title: 'Student Grade' },
         { aggregate: 'count', title: 'Student Count' },
       ],

--- a/src/components/reports/DistributionChartSupport.vue
+++ b/src/components/reports/DistributionChartSupport.vue
@@ -268,13 +268,6 @@ onMounted(() => {
 </script>
 
 <style lang="scss">
-.mode-select-wrapper {
-  display: flex;
-  flex-direction: column;
-  align-items: space-around;
-  justify-content: flex-start;
-  // justify-content: flex-end;
-}
 .view-by-wrapper {
   display: flex;
   flex-direction: column;

--- a/src/components/reports/DistributionChartSupport.vue
+++ b/src/components/reports/DistributionChartSupport.vue
@@ -9,7 +9,7 @@
       @change="handleXModeChange"
     />
   </div>
-  <div :id="`roar-dist-chart-support-${taskId}`"></div>
+  <div :id="`roar-distribution-chart-support-${taskId}`"></div>
 </template>
 
 <script setup>
@@ -108,7 +108,7 @@ const returnSupportLevelValues = computed(() => {
   return values;
 });
 
-const distBySupport = computed(() => {
+const distributionBySupport = computed(() => {
   let spec = {
     mark: 'bar',
     height: 450,
@@ -212,8 +212,8 @@ const props = defineProps({
 });
 
 const draw = async () => {
-  let chartSpecSupport = distBySupport.value;
-  await embed(`#roar-dist-chart-support-${props.taskId}`, chartSpecSupport);
+  let chartSpecSupport = distributionBySupport.value;
+  await embed(`#roar-distribution-chart-support-${props.taskId}`, chartSpecSupport);
   // Other chart types can be added via this if/then pattern
 };
 

--- a/src/components/reports/DistributionChartSupport.vue
+++ b/src/components/reports/DistributionChartSupport.vue
@@ -3,7 +3,8 @@
     <div class="flex uppercase text-xs font-light">view support levels by</div>
     <PvSelectButton
       v-model="xMode"
-      class="flex flex-row my-2"
+      class="flex flex-row my-2 select-button"
+      :allow-empty="false"
       :options="xModes"
       option-label="name"
       @change="handleXModeChange"

--- a/src/components/reports/DistributionChartSupport.vue
+++ b/src/components/reports/DistributionChartSupport.vue
@@ -1,6 +1,6 @@
 <template>
-  <div class="view-by-wrapper">
-    <div class="flex uppercase text-xs font-light">view by</div>
+  <div class="view-by-wrapper mx-2">
+    <div class="flex uppercase text-xs font-light">view support levels by</div>
     <PvSelectButton
       v-model="xMode"
       class="flex flex-row my-2"

--- a/src/components/reports/tasks/TaskReport.vue
+++ b/src/components/reports/tasks/TaskReport.vue
@@ -35,7 +35,6 @@
         :org-id="orgId"
         :task-id="taskId"
         :runs="runs"
-        :schoolsInfo="schoolsInfo"
       />
     </div>
   </div>
@@ -103,10 +102,6 @@ const props = defineProps({
   runs: {
     type: Array,
     required: true,
-  },
-  schoolsInfo: {
-    type: Array,
-    required: false,
   },
 });
 

--- a/src/components/reports/tasks/TaskReport.vue
+++ b/src/components/reports/tasks/TaskReport.vue
@@ -17,7 +17,7 @@
   </div>
   <!-- <div class="grid grid-cols-2 w-full space-around items-center p-3"> -->
   <div v-if="tasksToDisplayGraphs.includes(taskId)" class="chart-toggle-wrapper">
-    <div class="mb-3">
+    <div v-if="orgType === 'district'" class="mb-3">
       <div class="flex uppercase text-xs font-light">view rows by</div>
       <PvSelectButton
         v-model="facetMode"

--- a/src/components/reports/tasks/TaskReport.vue
+++ b/src/components/reports/tasks/TaskReport.vue
@@ -16,26 +16,40 @@
     </Accordion>
   </div>
   <!-- <div class="grid grid-cols-2 w-full space-around items-center p-3"> -->
-  <div v-if="tasksToDisplayGraphs.includes(taskId)" class="chart-wrapper">
-    <div>
-      <DistributionChartSupport
-        :initialized="initialized"
-        :administration-id="administrationId"
-        :org-type="orgType"
-        :org-id="orgId"
-        :task-id="taskId"
-        :runs="runs"
+  <div v-if="tasksToDisplayGraphs.includes(taskId)" class="chart-toggle-wrapper">
+    <div class="mb-3">
+      <div class="flex uppercase text-xs font-light">view rows by</div>
+      <PvSelectButton
+        v-model="facetMode"
+        class="flex flex-row my-2"
+        :options="facetModes"
+        option-label="name"
+        @change="handleModeChange"
       />
     </div>
-    <div>
-      <DistributionChartFacet
-        :initialized="initialized"
-        :administration-id="administrationId"
-        :org-type="orgType"
-        :org-id="orgId"
-        :task-id="taskId"
-        :runs="runs"
-      />
+    <div class="chart-wrapper">
+      <div>
+        <DistributionChartSupport
+          :initialized="initialized"
+          :administration-id="administrationId"
+          :org-type="orgType"
+          :org-id="orgId"
+          :task-id="taskId"
+          :runs="runs"
+          :facet-mode="facetMode"
+        />
+      </div>
+      <div>
+        <DistributionChartFacet
+          :initialized="initialized"
+          :administration-id="administrationId"
+          :org-type="orgType"
+          :org-id="orgId"
+          :task-id="taskId"
+          :runs="runs"
+          :facet-mode="facetMode"
+        />
+      </div>
     </div>
   </div>
   <div class="my-2 mx-4">
@@ -68,6 +82,7 @@ import Accordion from 'primevue/accordion';
 import AccordionTab from 'primevue/accordiontab';
 import { taskDisplayNames, tasksToDisplayGraphs } from '@/helpers/reports.js';
 import SubscoreTable from '@/components/reports/SubscoreTable.vue';
+import { ref } from 'vue';
 
 // eslint-disable-next-line no-unused-vars
 const props = defineProps({
@@ -104,6 +119,12 @@ const props = defineProps({
     required: true,
   },
 });
+
+const facetMode = ref({ name: 'Grade', key: 'grade' });
+const facetModes = [
+  { name: 'Grade', key: 'grade' },
+  { name: 'School', key: 'schoolName' },
+];
 
 let tasksInfoById = {
   swr: {
@@ -178,6 +199,12 @@ let tasksInfoById = {
   flex-wrap: wrap;
   align-items: center;
   justify-content: space-around;
+}
+
+.chart-toggle-wrapper {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
 }
 
 .task-card {

--- a/src/components/reports/tasks/TaskReport.vue
+++ b/src/components/reports/tasks/TaskReport.vue
@@ -35,6 +35,7 @@
         :org-id="orgId"
         :task-id="taskId"
         :runs="runs"
+        :schoolsInfo="schoolsInfo"
       />
     </div>
   </div>
@@ -102,6 +103,10 @@ const props = defineProps({
   runs: {
     type: Array,
     required: true,
+  },
+  schoolsInfo: {
+    type: Array,
+    required: false,
   },
 });
 

--- a/src/components/reports/tasks/TaskReport.vue
+++ b/src/components/reports/tasks/TaskReport.vue
@@ -21,7 +21,8 @@
       <div class="flex uppercase text-xs font-light">view rows by</div>
       <PvSelectButton
         v-model="facetMode"
-        class="flex flex-row my-2"
+        class="flex flex-row my-2 select-button"
+        :allow-empty="false"
         :options="facetModes"
         option-label="name"
         @change="handleModeChange"

--- a/src/pages/ScoreReport.vue
+++ b/src/pages/ScoreReport.vue
@@ -23,8 +23,14 @@
               <div class="chart-wrapper">
                 <div v-for="taskId of sortedAndFilteredTaskIds" :key="taskId" class="">
                   <div class="distribution-overview-wrapper">
-                    <DistributionChartOverview :runs="runsByTaskId[taskId]" :initialized="initialized" :task-id="taskId"
-                      :org-type="props.orgType" :org-id="props.orgId" :administration-id="props.administrationId" />
+                    <DistributionChartOverview
+                      :runs="runsByTaskId[taskId]"
+                      :initialized="initialized"
+                      :task-id="taskId"
+                      :org-type="props.orgType"
+                      :org-id="props.orgId"
+                      :administration-id="props.administrationId"
+                    />
                     <div className="task-description mt-3">
                       <span class="font-bold">
                         {{ descriptionsByTaskId[taskId]?.header ? descriptionsByTaskId[taskId].header : '' }}
@@ -71,19 +77,35 @@
         <!-- Main table -->
         <div v-else-if="scoresCount === 0" class="no-scores-container">
           <h3>No scores found.</h3>
-          <span>The filters applied have no matching scores.
+          <span
+            >The filters applied have no matching scores.
             <PvButton text @click="resetFilters">Reset filters</PvButton>
           </span>
         </div>
         <div v-else-if="scoresDataQuery?.length ?? 0 > 0">
           <div class="toggle-container">
             <span>View</span>
-            <PvDropdown v-model="viewMode" :options="viewOptions" option-label="label" option-value="value"
-              class="ml-2" />
+            <PvDropdown
+              v-model="viewMode"
+              :options="viewOptions"
+              option-label="label"
+              option-value="value"
+              class="ml-2"
+            />
           </div>
-          <RoarDataTable :data="tableData" :columns="columns" :total-records="scoresCount" lazy :page-limit="pageLimit"
-            :loading="isLoadingScores || isFetchingScores" @page="onPage($event)" @sort="onSort($event)"
-            @filter="onFilter($event)" @export-all="exportAll" @export-selected="exportSelected" />
+          <RoarDataTable
+            :data="tableData"
+            :columns="columns"
+            :total-records="scoresCount"
+            lazy
+            :page-limit="pageLimit"
+            :loading="isLoadingScores || isFetchingScores"
+            @page="onPage($event)"
+            @sort="onSort($event)"
+            @filter="onFilter($event)"
+            @export-all="exportAll"
+            @export-selected="exportSelected"
+          />
         </div>
         <div v-if="!isLoadingRunResults" class="legend-container">
           <div class="legend-entry">
@@ -118,11 +140,23 @@
           <div class="uppercase text-sm">Loading Task Reports</div>
         </div>
         <PvTabView v-if="isSuperAdmin">
-          <PvTabPanel v-for="taskId of sortedTaskIds" :key="taskId"
-            :header="taskDisplayNames[taskId]?.name ? ('ROAR-' + taskDisplayNames[taskId]?.name).toUpperCase() : ''">
-            <TaskReport v-if="taskId" :task-id="taskId" :initialized="initialized" :administration-id="administrationId"
-              :runs="runsByTaskId[taskId]" :org-type="orgType" :org-id="orgId" :org-info="orgInfo"
-              :schools-dict="schoolsDict" :schools-info="schoolsInfo" :administration-info="administrationInfo" />
+          <PvTabPanel
+            v-for="taskId of sortedTaskIds"
+            :key="taskId"
+            :header="taskDisplayNames[taskId]?.name ? ('ROAR-' + taskDisplayNames[taskId]?.name).toUpperCase() : ''"
+          >
+            <TaskReport
+              v-if="taskId"
+              :task-id="taskId"
+              :initialized="initialized"
+              :administration-id="administrationId"
+              :runs="runsByTaskId[taskId]"
+              :org-type="orgType"
+              :org-id="orgId"
+              :org-info="orgInfo"
+              :schools-dict="schoolsDict"
+              :administration-info="administrationInfo"
+            />
           </PvTabPanel>
         </PvTabView>
         <div v-else>
@@ -320,7 +354,7 @@ const { data: schoolsInfo } = useQuery({
 const schoolsDict = computed(() => {
   if (schoolsInfo.value) {
     return schoolsInfo.value.reduce((acc, school) => {
-      acc[school.id] = parseLowGrade(school.lowGrade) + " " + school.name;
+      acc[school.id] = parseLowGrade(school.lowGrade) + ' ' + school.name;
       return acc;
     }, {});
   } else {
@@ -773,7 +807,7 @@ const parseLowGrade = (grade) => {
   else {
     return parseInt(grade);
   }
-}
+};
 
 const runsByTaskId = computed(() => {
   if (runResults.value === undefined) return {};

--- a/src/pages/ScoreReport.vue
+++ b/src/pages/ScoreReport.vue
@@ -19,7 +19,7 @@
               <AppSpinner style="margin: 1rem 0rem" />
               <div class="uppercase text-sm">Loading Overview Charts</div>
             </div>
-            <div v-if="isSuperAdmin" class="overview-wrapper bg-gray-100 py-3 mb-2">
+            <div v-if="isSuperAdmin && !isLoadingRunResults" class="overview-wrapper bg-gray-100 py-3 mb-2">
               <div class="chart-wrapper">
                 <div v-for="taskId of sortedAndFilteredTaskIds" :key="taskId" class="">
                   <div class="distribution-overview-wrapper">


### PR DESCRIPTION
This PR adds some updates to the distribution charts, namely:
- Sort school facetted chart by lowGrade attribute -- elementary schools should come first, then middle schools, and finally high schools. 
- Add toggle to facetted chart to display data based on raw score as well as percentile. Toggle defaults to raw score.
- Conditionally render `At a Glance` score legend for administrations that have `At a Glance` charts. 