### PR TITLE
Fix some query failures

### DIFF
--- a/src/components/RoarDataTable.vue
+++ b/src/components/RoarDataTable.vue
@@ -437,7 +437,7 @@ let returnScoreTooltip = (colHeader, colData) => {
     toolTip += 'Percentile: ' + colData.scores?.swr?.percentile + '\n';
     toolTip += 'Raw Score: ' + colData.scores?.swr?.raw + '\n';
     toolTip += 'Standardized Score: ' + colData.scores?.swr?.standard + '\n';
-  } else if (colHeader === 'Sentence' && colData.scores?.sre.standard) {
+  } else if (colHeader === 'Sentence' && colData.scores?.sre?.standard) {
     toolTip += colData.scores?.sre?.support_level + '\n' + '\n';
     toolTip += 'Percentile: ' + colData.scores?.sre?.percentile + '\n';
     toolTip += 'Raw Score: ' + colData.scores?.sre?.raw + '\n';

--- a/src/helpers/query/assignments.js
+++ b/src/helpers/query/assignments.js
@@ -741,19 +741,15 @@ export const assignmentPageFetcher = async (
         const scoredAssessments = _without(
           assignment.data.assessments.map((assessment) => {
             const runId = assessment.runId;
-            if (runId) {
-              const scoresObject = _get(_find(scoresData, { id: runId }), 'scores');
-              if (!scoresObject) {
-                const runPath = `projects/gse-roar-assessment/databases/(default)/documents/users/${assignment.userId}/runs/${runId}`;
-                unretrievedScores.push(runPath);
-              }
-              return {
-                ...assessment,
-                scores: scoresObject,
-              };
-            } else {
-              return undefined;
+            const scoresObject = _get(_find(scoresData, { id: runId }), 'scores');
+            if (!scoresObject && runId) {
+              const runPath = `projects/gse-roar-assessment/databases/(default)/documents/users/${assignment.userId}/runs/${runId}`;
+              unretrievedScores.push(runPath);
             }
+            return {
+              ...assessment,
+              scores: scoresObject,
+            };
           }),
           undefined,
         );


### PR DESCRIPTION
This fixes intermittent query failures due to missed scores. This solution should allow ALL users (superadmin, partner admins) to perform filter queries.