### PR TITLE
Implement whitelist of fully scored tasks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22884,9 +22884,11 @@
       }
     },
     "node_modules/vega-embed/node_modules/yallist": {
+      "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "inBundle": true
+      "inBundle": true,
+      "license": "ISC"
     },
     "node_modules/vega-encode": {
       "version": "4.9.2",

--- a/src/helpers/reports.js
+++ b/src/helpers/reports.js
@@ -1,3 +1,9 @@
+/*
+ *  Task Display Names
+ *  A map of all tasks, including their taskId, display name, and index for ordering
+ *  Key: taskId
+ *  Value: { orderindex, displayName }
+ */
 export const taskDisplayNames = {
   letter: { name: 'Letter Names and Sounds', order: 1 },
   pa: { name: 'Phoneme', order: 2 },
@@ -14,6 +20,10 @@ export const taskDisplayNames = {
   ExternalTest: { name: 'External Test', order: 13 },
 };
 
+/*
+ *  Descriptions By Task Id
+ *  A map to correlate taskId with a proper header and description for use in the distribution graphs.
+ */
 export const descriptionsByTaskId = {
   // "letter": { header: "ROAR-Letter Sound Matching (ROAR-Letter)", description: " assesses knowledge of letter names and sounds." },
   pa: {
@@ -31,21 +41,47 @@ export const descriptionsByTaskId = {
   },
 };
 
+/*
+ *  Tasks to Display Graphs
+ *  A list of tasks who, when included in a score report, will generate breaskdown graphs.
+ */
 export const tasksToDisplayGraphs = ['swr', 'sre', 'pa'];
 
-export const excludedTasks = ['cva', 'morphology'];
+/*
+ *  Raw Only Tasks
+ *  A list of tasks to only display raw scores when included in a RoarDataTable.
+ */
+export const rawOnlyTasks = ['letter', 'multichoice', 'vocab', 'fluency'];
 
-export const taskFilterBlacklist = ['letter'];
+/*
+ *  Scored Tasks
+ *  A list of tasks to be included
+ */
+export const scoredTasks = ['swr', 'pa', 'sre'];
 
+/*
+ *  Support Level Colors
+ *  Colors corresponding to each support level.
+ */
 export const supportLevelColors = {
   above: 'green',
   some: '#edc037',
   below: '#c93d82',
 };
 
+/*
+ *  Get Support Level
+ *
+ */
 export const getSupportLevel = (grade, percentile, rawScore, taskId) => {
   let support_level = null;
   let tag_color = null;
+  if (!scoredTasks.includes(taskId) && (rawScore || percentile)) {
+    return {
+      support_level: 'Scores Under Development',
+      tag_color: 'white',
+    };
+  }
   if (percentile !== undefined && grade < 6) {
     if (percentile >= 50) {
       support_level = 'Achieved Skill';

--- a/src/helpers/reports.js
+++ b/src/helpers/reports.js
@@ -55,7 +55,7 @@ export const rawOnlyTasks = ['letter', 'multichoice', 'vocab', 'fluency'];
 
 /*
  *  Scored Tasks
- *  A list of tasks to be included
+ *  A list of tasks to be included in the generation of support levels
  */
 export const scoredTasks = ['swr', 'pa', 'sre'];
 
@@ -71,7 +71,7 @@ export const supportLevelColors = {
 
 /*
  *  Get Support Level
- *
+ *  Function to take scores, taskId, and grade and return the proper support category for the run.
  */
 export const getSupportLevel = (grade, percentile, rawScore, taskId) => {
   let support_level = null;


### PR DESCRIPTION
This PR changes the way we handle control over how individual tasks are displayed in the score reports. Rather than having a blacklist, `excludedTasks`, we want to have a whitelist of fully scored tasks and a whitelist of raw-only tasks. All other tasks will still display, just with an outlined circle with tooltip 'These scores are under development'. 