### PR TITLE
Fix parse grade bug

### DIFF
--- a/src/pages/ScoreReport.vue
+++ b/src/pages/ScoreReport.vue
@@ -1008,7 +1008,7 @@ function rawScoreByTaskId(taskId) {
 
 const parseGrade = (grade) => {
   const gradeZero = ['kindergarten', 'preschool', 'k', 'pk', 'tk', 'prekindergarten'];
-  return gradeZero.includes(grade?.toLowerCase()) ? 0 : parseInt(grade);
+  return gradeZero.includes(String(grade)?.toLowerCase()) ? 0 : parseInt(grade);
 };
 
 const runsByTaskId = computed(() => {


### PR DESCRIPTION
I believe one of the student's grade attributes may have been a number, causing the `grade.toLowerCase()` call to fail.