### PR TITLE
Update Cypress Tests for Standardized Names

### DIFF
--- a/cypress/e2e/participant/default-tests/playPA.cy.js
+++ b/cypress/e2e/participant/default-tests/playPA.cy.js
@@ -29,7 +29,7 @@ describe('Testing playthrough of ROAR-Phoneme as a participant', () => {
     cy.wait(0.2 * timeout);
     cy.selectAdministration(Cypress.env('testRoarAppsAdministration'));
     cy.get('.tabview-nav-link-label', { timeout: 2 * timeout })
-      .contains('ROAR-Phoneme')
+      .contains('ROAR - Phoneme')
       .should('have.attr', 'data-game-status', 'complete');
   });
 });

--- a/cypress/e2e/participant/default-tests/playSRE.cy.js
+++ b/cypress/e2e/participant/default-tests/playSRE.cy.js
@@ -7,7 +7,7 @@ describe('Test playthrough of SRE as a participant', () => {
 
     cy.selectAdministration(Cypress.env('testRoarAppsAdministration'));
 
-    cy.get('.p-tabview').contains('ROAR-Sentence');
+    cy.get('.p-tabview').contains('ROAR - Sentence');
     cy.visit(`/game/sre`);
 
     cy.get('.jspsych-btn', { timeout: 5 * timeout })
@@ -15,10 +15,6 @@ describe('Test playthrough of SRE as a participant', () => {
       .click();
 
     cy.wait(0.2 * timeout);
-
-    // cy.get('b').contains('I agree').click();
-    // cy.get('.jspsych-btn', { timeout: 10000 }).should('be.visible').click();
-    // cy.get('.jspsych-btn', { timeout: 10000 }).should('be.visible').click();
 
     // handles error where full screen throws a permissions error
     cy.wait(0.2 * timeout);
@@ -35,7 +31,7 @@ describe('Test playthrough of SRE as a participant', () => {
     cy.visit('/');
     cy.wait(0.2 * timeout);
     cy.selectAdministration(Cypress.env('testRoarAppsAdministration'));
-    cy.get('.tabview-nav-link-label').contains('ROAR-Sentence').should('have.attr', 'data-game-status', 'complete');
+    cy.get('.tabview-nav-link-label').contains('ROAR - Sentence').should('have.attr', 'data-game-status', 'complete');
   });
 });
 

--- a/cypress/e2e/participant/default-tests/playSWR.cy.js
+++ b/cypress/e2e/participant/default-tests/playSWR.cy.js
@@ -9,7 +9,7 @@ describe('Testing playthrough of SWR as a participant', () => {
 
     cy.selectAdministration(Cypress.env('testRoarAppsAdministration'));
 
-    cy.get('.p-tabview').contains('ROAR-Word');
+    cy.get('.p-tabview').contains('ROAR - Word');
     cy.visit(`/game/swr`);
 
     cy.get('.jspsych-btn', { timeout: timeout }).should('be.visible').click();

--- a/cypress/e2e/participant/network-tests/roar-swr/playSWR-2G.cy.js
+++ b/cypress/e2e/participant/network-tests/roar-swr/playSWR-2G.cy.js
@@ -18,7 +18,7 @@ describe('Testing playthrough of SWR as a participant under a 2G Mobile connecti
       .should('be.visible')
       .click();
 
-    cy.get('.p-tabview').contains('ROAR-Word');
+    cy.get('.p-tabview').contains('ROAR - Word');
     cy.visit(`/game/swr`);
 
     cy.get('.jspsych-btn', { timeout: 3 * timeout })

--- a/cypress/e2e/participant/network-tests/roar-swr/playSWR-3G.cy.js
+++ b/cypress/e2e/participant/network-tests/roar-swr/playSWR-3G.cy.js
@@ -18,7 +18,7 @@ describe('Testing playthrough of SWR as a participant under a 3G Mobile connecti
       .should('be.visible')
       .click();
 
-    cy.get('.p-tabview').contains('ROAR-Word');
+    cy.get('.p-tabview').contains('ROAR - Word');
     cy.visit(`/game/swr`);
 
     cy.get('.jspsych-btn', { timeout: 2 * timeout })

--- a/cypress/e2e/participant/network-tests/roar-swr/playSWR-HighLatency.cy.js
+++ b/cypress/e2e/participant/network-tests/roar-swr/playSWR-HighLatency.cy.js
@@ -18,7 +18,7 @@ describe('Testing playthrough of SWR as a participant under a 2G Mobile connecti
       .should('be.visible')
       .click();
 
-    cy.get('.p-tabview', { timeout: 6 * timeout }).contains('ROAR-Word');
+    cy.get('.p-tabview', { timeout: 6 * timeout }).contains('ROAR - Word');
     cy.visit(`/game/swr`);
 
     cy.get('.jspsych-btn', { timeout: 6 * timeout })

--- a/cypress/fixtures/buttonGamesList.js
+++ b/cypress/fixtures/buttonGamesList.js
@@ -1,6 +1,6 @@
 export const games = [
   {
-    name: 'ROAR Picture Vocabulary',
+    name: 'ROAR - Picture Vocabulary',
     id: 'vocab',
     startBtn: '.jspsych-btn',
     introBtn: '.continue',
@@ -13,7 +13,7 @@ export const games = [
     numIter: 4,
   },
   {
-    name: 'ROAR Written Vocabulary',
+    name: 'ROAR - Written Vocabulary',
     id: 'cva',
     startBtn: '.jspsych-btn',
     introBtn: '.go-button',
@@ -26,7 +26,7 @@ export const games = [
     numIter: 9,
   },
   {
-    name: 'Roar-Morphology',
+    name: 'ROAR - Morphology',
     id: 'morphology',
     startBtn: '.jspsych-btn',
     introBtn: '.go-button',
@@ -40,7 +40,7 @@ export const games = [
     numIter: 6,
   },
   {
-    name: 'Letter',
+    name: 'ROAR - Letter',
     id: 'letter',
     startBtn: '.jspsych-btn',
     introBtn: '.go-button',

--- a/cypress/support/helperFunctions/roar-swr/swrHelpers.js
+++ b/cypress/support/helperFunctions/roar-swr/swrHelpers.js
@@ -27,7 +27,7 @@ export function playSWRGame() {
   cy.visit('/');
   cy.wait(0.2 * timeout);
   cy.selectAdministration(Cypress.env('testRoarAppsAdministration'));
-  cy.get('.tabview-nav-link-label').contains('ROAR-Word').should('have.attr', 'data-game-status', 'complete');
+  cy.get('.tabview-nav-link-label').contains('ROAR - Word').should('have.attr', 'data-game-status', 'complete');
 }
 
 function playIntro() {


### PR DESCRIPTION
Task names are now updated in firebase with the `ROAR-{taskName}` schema, so the tests must be updated as such.