### PR TITLE
Enable Verbose Firekit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.7.1",
       "dependencies": {
         "@bdelab/roam-fluency": "^1.9.14",
-        "@bdelab/roar-firekit": "^4.8.4",
+        "@bdelab/roar-firekit": "^4.8.7",
         "@bdelab/roar-letter": "^1.6.7",
         "@bdelab/roar-multichoice": "^1.9.4",
         "@bdelab/roar-pa": "^1.6.4",
@@ -1605,9 +1605,9 @@
       }
     },
     "node_modules/@bdelab/roar-firekit": {
-      "version": "4.8.6",
-      "resolved": "https://registry.npmjs.org/@bdelab/roar-firekit/-/roar-firekit-4.8.6.tgz",
-      "integrity": "sha512-2qyZ42vsMqEpyMGfSTvGSBXqzN1VdihDhx74gf96LbYicHscefkZHdeXSZIovxuU0uX7s77AHyPjBb8d17Saqg==",
+      "version": "4.8.7",
+      "resolved": "https://registry.npmjs.org/@bdelab/roar-firekit/-/roar-firekit-4.8.7.tgz",
+      "integrity": "sha512-MPSwxSszHiWOY4j9BcxM3WmBzkA1oY6gX+Lln0ZNC0HhnYM5k1ipcYj0CtdKeFf97ddKNog1pTqzOZAaZhxbUg==",
       "dependencies": {
         "@bdelab/roar-firekit": "^4.1.1",
         "crc-32": "^1.2.2",
@@ -24701,9 +24701,11 @@
       }
     },
     "node_modules/vega-embed/node_modules/yallist": {
+      "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "inBundle": true
+      "inBundle": true,
+      "license": "ISC"
     },
     "node_modules/vega-encode": {
       "version": "4.9.2",
@@ -26880,9 +26882,9 @@
       }
     },
     "@bdelab/roar-firekit": {
-      "version": "4.8.6",
-      "resolved": "https://registry.npmjs.org/@bdelab/roar-firekit/-/roar-firekit-4.8.6.tgz",
-      "integrity": "sha512-2qyZ42vsMqEpyMGfSTvGSBXqzN1VdihDhx74gf96LbYicHscefkZHdeXSZIovxuU0uX7s77AHyPjBb8d17Saqg==",
+      "version": "4.8.7",
+      "resolved": "https://registry.npmjs.org/@bdelab/roar-firekit/-/roar-firekit-4.8.7.tgz",
+      "integrity": "sha512-MPSwxSszHiWOY4j9BcxM3WmBzkA1oY6gX+Lln0ZNC0HhnYM5k1ipcYj0CtdKeFf97ddKNog1pTqzOZAaZhxbUg==",
       "requires": {
         "@bdelab/roar-firekit": "^4.1.1",
         "crc-32": "^1.2.2",
@@ -43178,7 +43180,8 @@
           }
         },
         "yallist": {
-          "version": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
           "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
           "bundled": true
         }

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "dependencies": {
     "@bdelab/roam-fluency": "^1.9.14",
-    "@bdelab/roar-firekit": "^4.8.4",
+    "@bdelab/roar-firekit": "^4.8.7",
     "@bdelab/roar-letter": "^1.6.7",
     "@bdelab/roar-multichoice": "^1.9.4",
     "@bdelab/roar-pa": "^1.6.4",

--- a/src/firebaseInit.js
+++ b/src/firebaseInit.js
@@ -11,6 +11,7 @@ export async function initNewFirekit() {
       db: false,
       functions: false,
     },
+    verboseLogging: true,
   });
   return await firekit.init();
 }


### PR DESCRIPTION
This PR turns on verbose Firekit output, for the purpose of debugging. This will be undone in production once we have solved an issue.