### PR TITLE
Prevent ESC closing consent modal

### DIFF
--- a/src/components/ConsentModal.vue
+++ b/src/components/ConsentModal.vue
@@ -1,6 +1,6 @@
 <template>
   <PvToast />
-  <PvConfirmDialog group="templating" class="confirm">
+  <PvConfirmDialog group="templating" class="confirm" :closeOnEscape="false">
     <template #message>
       <div class="scrolling-box">
         <!-- eslint-disable-next-line vue/no-v-html -->


### PR DESCRIPTION
I found a neat un-documented prop to prevent the esc event from closing the modal.