### PR TITLE
Remove nulls from both sets of params before comparing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.5.5",
       "dependencies": {
         "@bdelab/roam-fluency": "^1.11.19",
-        "@bdelab/roar-firekit": "^4.9.2",
+        "@bdelab/roar-firekit": "^4.9.3",
         "@bdelab/roar-letter": "^1.11.4",
         "@bdelab/roar-multichoice": "^1.11.3",
         "@bdelab/roar-pa": "^2.2.0",
@@ -1676,9 +1676,9 @@
       }
     },
     "node_modules/@bdelab/roar-firekit": {
-      "version": "4.9.2",
-      "resolved": "https://registry.npmjs.org/@bdelab/roar-firekit/-/roar-firekit-4.9.2.tgz",
-      "integrity": "sha512-6w91xUxkWnyvBxxNKW0jBKV6vDslWMxiWDz9B/fAPSGpJbySBNq0SNZPj2GgVTlcgRHKsbxRwu8DNh6wJrhZjw==",
+      "version": "4.9.3",
+      "resolved": "https://registry.npmjs.org/@bdelab/roar-firekit/-/roar-firekit-4.9.3.tgz",
+      "integrity": "sha512-YByCNMflECK6l3835E+1Ie+DIVvKHRb+ABVhN2Ht2epuU1H6wvg0DhOVpXGlJeQj5VnnHZKswa3cdNjs9GDL2g==",
       "dependencies": {
         "@bdelab/roar-firekit": "^4.1.1",
         "crc-32": "^1.2.2",
@@ -30827,9 +30827,9 @@
       }
     },
     "@bdelab/roar-firekit": {
-      "version": "4.9.2",
-      "resolved": "https://registry.npmjs.org/@bdelab/roar-firekit/-/roar-firekit-4.9.2.tgz",
-      "integrity": "sha512-6w91xUxkWnyvBxxNKW0jBKV6vDslWMxiWDz9B/fAPSGpJbySBNq0SNZPj2GgVTlcgRHKsbxRwu8DNh6wJrhZjw==",
+      "version": "4.9.3",
+      "resolved": "https://registry.npmjs.org/@bdelab/roar-firekit/-/roar-firekit-4.9.3.tgz",
+      "integrity": "sha512-YByCNMflECK6l3835E+1Ie+DIVvKHRb+ABVhN2Ht2epuU1H6wvg0DhOVpXGlJeQj5VnnHZKswa3cdNjs9GDL2g==",
       "requires": {
         "@bdelab/roar-firekit": "^4.1.1",
         "crc-32": "^1.2.2",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@bdelab/roam-fluency": "^1.11.19",
-    "@bdelab/roar-firekit": "^4.9.2",
+    "@bdelab/roar-firekit": "^4.9.3",
     "@bdelab/roar-letter": "^1.11.4",
     "@bdelab/roar-multichoice": "^1.11.3",
     "@bdelab/roar-pa": "^2.2.0",

--- a/src/components/CreateAdministration.vue
+++ b/src/components/CreateAdministration.vue
@@ -533,7 +533,9 @@ watch([preExistingAdminInfo, allVariants], ([adminInfo, allVariantInfo]) => {
     state.sequential = adminInfo.sequential;
     _forEach(adminInfo.assessments, (assessment) => {
       const assessmentParams = assessment.params;
-      const found = findVariantWithParams(allVariants.value, assessmentParams);
+      const taskId = assessment.taskId;
+      const allVariantsForThisTask = _filter(allVariantInfo, (variant) => variant.task.id === taskId);
+      const found = findVariantWithParams(allVariantsForThisTask, assessmentParams);
       if (found) {
         preSelectedVariants.value = _union(preSelectedVariants.value, [found]);
       }
@@ -541,12 +543,22 @@ watch([preExistingAdminInfo, allVariants], ([adminInfo, allVariantInfo]) => {
   }
 });
 
+const removeNull = (obj) => {
+  return Object.fromEntries(Object.entries(obj).filter(([_, v]) => v !== null));
+};
+
 function findVariantWithParams(variants, params) {
+  console.log(`attempting to find variant of ${variants[0].task.id}`);
+
   const found = _find(variants, (variant) => {
-    const cleanParams = { ...variant.variant.params };
-    Object.keys(cleanParams).forEach((key) => cleanParams[key] === null && delete cleanParams[key]);
-    return _isEqual(params, cleanParams);
+    const cleanVariantParams = removeNull(variant.variant.params);
+    const cleanInputParams = removeNull(params);
+    return _isEqual(cleanInputParams, cleanVariantParams);
   });
+
+  if (found) {
+    console.log('found', found);
+  }
   // TODO: implement tie breakers if found.length > 1
   return found;
 }

--- a/src/components/EditVariantDialog.vue
+++ b/src/components/EditVariantDialog.vue
@@ -1,5 +1,4 @@
 <template>
-  <!-- <PvButton @click="visible = true"> -->
   <PvButton
     class="surface-hover border-1 border-300 border-circle m-0 hover:bg-primary p-0 m-2"
     data-cy="button-edit-variant"

--- a/src/components/OrgPicker.vue
+++ b/src/components/OrgPicker.vue
@@ -3,12 +3,7 @@
     <div class="col-12 md:col-6">
       <PvPanel class="m-0 p-0" header="Select organizations here">
         <PvTabView v-if="claimsLoaded" v-model:activeIndex="activeIndex" class="m-0 p-0" lazy>
-          <PvTabPanel
-            v-for="orgType in orgHeaders"
-            :key="orgType"
-            :header="orgType.header"
-            data-cy="tab-panel-org-header"
-          >
+          <PvTabPanel v-for="orgType in orgHeaders" :key="orgType" :header="orgType.header">
             <div class="grid column-gap-3">
               <div
                 v-if="activeOrgType === 'schools' || activeOrgType === 'classes'"

--- a/src/components/TaskPicker.vue
+++ b/src/components/TaskPicker.vue
@@ -42,7 +42,7 @@
                   :data-task-id="element.task.id"
                   style="cursor: grab"
                 >
-                  <VariantCard :variant="element" data-cy="card-variant" @select="selectCard" />
+                  <VariantCard :variant="element" @select="selectCard" />
                 </div>
               </transition-group>
             </VueDraggableNext>
@@ -79,12 +79,7 @@
                   :data-task-id="element.task.id"
                   style="cursor: grab"
                 >
-                  <VariantCard
-                    :variant="element"
-                    :update-variant="updateVariant"
-                    data-cy="card-variant"
-                    @select="selectCard"
-                  />
+                  <VariantCard :variant="element" :update-variant="updateVariant" @select="selectCard" />
                 </div>
               </transition-group>
             </VueDraggableNext>
@@ -124,7 +119,6 @@
                   :variant="element"
                   has-controls
                   :update-variant="updateVariant"
-                  data-cy="card-variant"
                   @remove="removeCard"
                   @move-up="moveCardUp"
                   @move-down="moveCardDown"

--- a/src/components/VariantCard.vue
+++ b/src/components/VariantCard.vue
@@ -153,7 +153,7 @@
       </PvOverlayPanel>
     </div>
     <div class="mr-0 pl-0 flex flex-column">
-      <EditVariantDialog :visible="visible" :assessment="variant" :update-variant="updateVariant" />
+      <EditVariantDialog :assessment="variant" :update-variant="updateVariant" />
       <PvButton
         v-if="variant.variant?.conditions?.assigned || variant.variant?.conditions?.optional"
         class="surface-hover border-1 border-300 border-circle m-0 hover:bg-primary p-0 m-2"


### PR DESCRIPTION
This PR fixes an issue with the edit administration form to better match with existing variants. Previously, the form would remove null values from the params in `allVariants` before comparing to the parameters of the administration. But sometimes the administration parameters contained those null values. This PR removes the null values from both before comparing.