### PR TITLE
Only Fetch Registered Variants

### DIFF
--- a/src/components/CreateAdministration.vue
+++ b/src/components/CreateAdministration.vue
@@ -209,7 +209,7 @@ const { roarfirekit, administrationQueryKeyIndex } = storeToRefs(authStore);
 
 const { data: allVariants } = useQuery({
   queryKey: ['variants', 'all'],
-  queryFn: () => variantsFetcher(),
+  queryFn: () => variantsFetcher(true),
   keepPreviousData: true,
   enabled: initialized,
   staleTime: 5 * 60 * 1000, // 5 minutes


### PR DESCRIPTION
This PR sets the parameter for 'registered' to 'true' in variantsFetcher(), so that only variants with boolean value 'registered' set to 'true' will be fetched when creating an administration.