### PR TITLE
Changing org form feedback when submitting

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
         "axios": "^1.5.1",
         "buffer": "^6.0.3",
         "chart.js": "^4.3.3",
-        "core-tasks": "^1.0.0-beta.11",
+        "core-tasks": "^1.0.0-beta.12",
         "dotenv": "^16.3.1",
         "html2canvas": "^1.4.1",
         "jspdf": "^2.5.1",
@@ -11588,9 +11588,9 @@
       }
     },
     "node_modules/core-tasks": {
-      "version": "1.0.0-beta.11",
-      "resolved": "https://registry.npmjs.org/core-tasks/-/core-tasks-1.0.0-beta.11.tgz",
-      "integrity": "sha512-WVnfR8hSIdmfXXcDAjG0N+Xo6+NkoHcrdDLKIJmQUSxH9bdpzoL2UNVbSK0ODZZbyePFgtrk/Q7XJrNG2r6sHg==",
+      "version": "1.0.0-beta.12",
+      "resolved": "https://registry.npmjs.org/core-tasks/-/core-tasks-1.0.0-beta.12.tgz",
+      "integrity": "sha512-MbRNTzbH/iuX2JveRJCYKSD84wCU1QiYlq2orBMxlpB3lVITGUzDJK3i8kv782qP36Emu85z3WIWPscD/KvZVw==",
       "dependencies": {
         "@bdelab/jscat": "^3.0.3",
         "@bdelab/roar-firekit": "^3.12.8",
@@ -39120,9 +39120,9 @@
       }
     },
     "core-tasks": {
-      "version": "1.0.0-beta.11",
-      "resolved": "https://registry.npmjs.org/core-tasks/-/core-tasks-1.0.0-beta.11.tgz",
-      "integrity": "sha512-WVnfR8hSIdmfXXcDAjG0N+Xo6+NkoHcrdDLKIJmQUSxH9bdpzoL2UNVbSK0ODZZbyePFgtrk/Q7XJrNG2r6sHg==",
+      "version": "1.0.0-beta.12",
+      "resolved": "https://registry.npmjs.org/core-tasks/-/core-tasks-1.0.0-beta.12.tgz",
+      "integrity": "sha512-MbRNTzbH/iuX2JveRJCYKSD84wCU1QiYlq2orBMxlpB3lVITGUzDJK3i8kv782qP36Emu85z3WIWPscD/KvZVw==",
       "requires": {
         "@bdelab/jscat": "^3.0.3",
         "@bdelab/roar-firekit": "^3.12.8",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "axios": "^1.5.1",
     "buffer": "^6.0.3",
     "chart.js": "^4.3.3",
-    "core-tasks": "^1.0.0-beta.11",
+    "core-tasks": "^1.0.0-beta.12",
     "dotenv": "^16.3.1",
     "html2canvas": "^1.4.1",
     "jspdf": "^2.5.1",

--- a/src/components/CreateOrgs.vue
+++ b/src/components/CreateOrgs.vue
@@ -185,8 +185,9 @@
         <div class="grid">
           <div class="col-12">
             <PvButton
-              :label="`Create ${orgTypeLabel}`"
-              :disabled="orgTypeLabel === 'Org'"
+              :label="submitted ? `Creating ${orgTypeLabel}` : `Create ${orgTypeLabel}`"
+              :disabled="orgTypeLabel === 'Org' || v$.$invalid || submitted"
+              :icon="submitted ? 'pi pi-spin pi-spinner' : ''"
               data-cy="button-create-org"
               @click="submit"
             />
@@ -427,6 +428,7 @@ const submit = async () => {
         .catch((error) => {
           toast.add({ severity: 'error', summary: 'Error', detail: error.message, life: 3000 });
           console.error('Error creating org:', error);
+          submitted.value = false;
         });
     } else {
       await roarfirekit.value
@@ -439,6 +441,7 @@ const submit = async () => {
         .catch((error) => {
           toast.add({ severity: 'error', summary: 'Error', detail: error.message, life: 3000 });
           console.error('Error creating org:', error);
+          submitted.value = false;
         });
     }
   } else {

--- a/src/components/CreateOrgs.vue
+++ b/src/components/CreateOrgs.vue
@@ -26,7 +26,7 @@
                 class="w-full"
                 data-cy="dropdown-org-type"
               />
-              <label for="org-type">Org Type</label>
+              <label for="org-type">Org Type<span id="required-asterisk">*</span></label>
             </span>
           </div>
         </div>
@@ -45,7 +45,7 @@
                 class="w-full"
                 data-cy="dropdown-parent-district"
               />
-              <label for="parent-district">District</label>
+              <label for="parent-district">District<span id="required-asterisk">*</span></label>
               <small v-if="v$.parentDistrict.$invalid && submitted" class="p-error"> Please select a district. </small>
             </span>
           </div>
@@ -63,7 +63,7 @@
                 class="w-full"
                 data-cy="dropdown-parent-school"
               />
-              <label for="parent-school">School</label>
+              <label for="parent-school">School<span id="required-asterisk">*</span></label>
               <small v-if="v$.parentSchool.$invalid && submitted" class="p-error"> Please select a district. </small>
             </span>
           </div>
@@ -73,7 +73,7 @@
           <div class="col-12 md:col-6 lg:col-4 mt-3">
             <span class="p-float-label">
               <PvInputText id="org-name" v-model="state.orgName" class="w-full" data-cy="input-org-name" />
-              <label for="org-name">{{ orgTypeLabel }} Name</label>
+              <label for="org-name">{{ orgTypeLabel }} Name<span id="required-asterisk">*</span></label>
               <small v-if="v$.orgName.$invalid && submitted" class="p-error">Please supply a name</small>
             </span>
           </div>
@@ -81,7 +81,7 @@
           <div class="col-12 md:col-6 lg:col-4 mt-3">
             <span class="p-float-label">
               <PvInputText id="org-initial" v-model="state.orgInitials" class="w-full" data-cy="input-org-initials" />
-              <label for="org-initial">{{ orgTypeLabel }} Abbreviation</label>
+              <label for="org-initial">{{ orgTypeLabel }} Abbreviation<span id="required-asterisk">*</span></label>
               <small v-if="v$.orgInitials.$invalid && submitted" class="p-error">Please supply an abbreviation</small>
             </span>
           </div>
@@ -98,7 +98,7 @@
                 class="w-full"
                 data-cy="dropdown-grade"
               />
-              <label for="grade">Grade</label>
+              <label for="grade">Grade<span id="required-asterisk">*</span></label>
               <small v-if="v$.grade.$invalid && submitted" class="p-error">Please select a grade</small>
             </span>
           </div>
@@ -526,5 +526,9 @@ const resetForm = () => {
   .hide {
     display: none;
   }
+}
+
+#required-asterisk {
+  color: #ff0000;
 }
 </style>


### PR DESCRIPTION
- Disable submit button when creating org
- Disable button if vuelidate model is invalid -- any _required_ fields are missing / invalid


Context / Reason: It's a bad and annoying experience as a user to fill out a form, submit it, and only then know what is required. Instead, from the get go they should know what fields they need to fill in. Additional changes should be made in the future to add red asterisks to the required fields, making it abundantly clear. 