### PR TITLE
Update ROAM-Fluency version to 1.11.22

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "roar-dashboard",
       "version": "2.7.3",
       "dependencies": {
-        "@bdelab/roam-fluency": "1.11.21",
+        "@bdelab/roam-fluency": "1.11.22",
         "@bdelab/roar-firekit": "^6.0.1",
         "@bdelab/roar-letter": "^1.11.4",
         "@bdelab/roar-multichoice": "^1.11.3",
@@ -1571,9 +1571,9 @@
       }
     },
     "node_modules/@bdelab/roam-fluency": {
-      "version": "1.11.21",
-      "resolved": "https://registry.npmjs.org/@bdelab/roam-fluency/-/roam-fluency-1.11.21.tgz",
-      "integrity": "sha512-5Um6KUS8ST+4siSfojciO0821CKYslpGKHZ/VzE38bihTAY7ed9FZfxkZvh0KkHYXKYfNelAPZpMkG5rzZpaMg==",
+      "version": "1.11.22",
+      "resolved": "https://registry.npmjs.org/@bdelab/roam-fluency/-/roam-fluency-1.11.22.tgz",
+      "integrity": "sha512-dA5rhKf6YOk50GLTvCuO1HlAGG0udxz9Dx3Q/5/TwUOb0dtHlIfhSXfftEzv5ftkJahgDLIQb2GA+KRJ08/myA==",
       "dependencies": {
         "@bdelab/jscat": "^4.0.0",
         "@bdelab/roar-firekit": "^4.7.0",
@@ -31631,9 +31631,9 @@
       }
     },
     "@bdelab/roam-fluency": {
-      "version": "1.11.21",
-      "resolved": "https://registry.npmjs.org/@bdelab/roam-fluency/-/roam-fluency-1.11.21.tgz",
-      "integrity": "sha512-5Um6KUS8ST+4siSfojciO0821CKYslpGKHZ/VzE38bihTAY7ed9FZfxkZvh0KkHYXKYfNelAPZpMkG5rzZpaMg==",
+      "version": "1.11.22",
+      "resolved": "https://registry.npmjs.org/@bdelab/roam-fluency/-/roam-fluency-1.11.22.tgz",
+      "integrity": "sha512-dA5rhKf6YOk50GLTvCuO1HlAGG0udxz9Dx3Q/5/TwUOb0dtHlIfhSXfftEzv5ftkJahgDLIQb2GA+KRJ08/myA==",
       "requires": {
         "@bdelab/jscat": "^4.0.0",
         "@bdelab/roar-firekit": "^4.7.0",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "version": "npm run format && git add -A"
   },
   "dependencies": {
-    "@bdelab/roam-fluency": "1.11.21",
+    "@bdelab/roam-fluency": "1.11.22",
     "@bdelab/roar-firekit": "^6.0.1",
     "@bdelab/roar-letter": "^1.11.4",
     "@bdelab/roar-multichoice": "^1.11.3",


### PR DESCRIPTION
This PR updates the version of `@bdelab/roam-fluency` to 1.11.22.