### PR TITLE
Update ROAV-Crowding version to 1.1.11

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@bdelab/roar-swr": "^1.12.1",
         "@bdelab/roar-utils": "^1.2.1",
         "@bdelab/roar-vocab": "^1.8.0",
-        "@bdelab/roav-crowding": "^1.1.10",
+        "@bdelab/roav-crowding": "1.1.11",
         "@bdelab/roav-ran": "^1.0.17",
         "@sentry/browser": "^8.0.0",
         "@sentry/integrations": "^7.114.0",
@@ -5464,9 +5464,9 @@
       }
     },
     "node_modules/@bdelab/roav-crowding": {
-      "version": "1.1.10",
-      "resolved": "https://registry.npmjs.org/@bdelab/roav-crowding/-/roav-crowding-1.1.10.tgz",
-      "integrity": "sha512-vlNEQoykRG950jc66pIHvW8XEbuFGt7HlCQu+PJpdsfLbOLSTKvnEIJv6V1+/bCzgULnMRwSvjYsli2wsRJ0iA==",
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/@bdelab/roav-crowding/-/roav-crowding-1.1.11.tgz",
+      "integrity": "sha512-RSlQ6ZdKFGzagyOvVwH3En7m3T7pXS48RdZLxtkQROGFuqFUXTkqRwO59+xPmM58IzyEOnvDl243xP5RD5NtYw==",
       "dependencies": {
         "@bdelab/jscat": "^4.0.0",
         "@bdelab/roar-firekit": "^4.7.0",
@@ -34840,9 +34840,9 @@
       }
     },
     "@bdelab/roav-crowding": {
-      "version": "1.1.10",
-      "resolved": "https://registry.npmjs.org/@bdelab/roav-crowding/-/roav-crowding-1.1.10.tgz",
-      "integrity": "sha512-vlNEQoykRG950jc66pIHvW8XEbuFGt7HlCQu+PJpdsfLbOLSTKvnEIJv6V1+/bCzgULnMRwSvjYsli2wsRJ0iA==",
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/@bdelab/roav-crowding/-/roav-crowding-1.1.11.tgz",
+      "integrity": "sha512-RSlQ6ZdKFGzagyOvVwH3En7m3T7pXS48RdZLxtkQROGFuqFUXTkqRwO59+xPmM58IzyEOnvDl243xP5RD5NtYw==",
       "requires": {
         "@bdelab/jscat": "^4.0.0",
         "@bdelab/roar-firekit": "^4.7.0",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@bdelab/roar-swr": "^1.12.1",
     "@bdelab/roar-utils": "^1.2.1",
     "@bdelab/roar-vocab": "^1.8.0",
-    "@bdelab/roav-crowding": "^1.1.10",
+    "@bdelab/roav-crowding": "1.1.11",
     "@bdelab/roav-ran": "^1.0.17",
     "@sentry/browser": "^8.0.0",
     "@sentry/integrations": "^7.114.0",


### PR DESCRIPTION
This PR updates the version of `@bdelab/roav-crowding` to 1.1.11.