### PR TITLE
Update ROAV-Ran version to 1.0.18

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@bdelab/roar-utils": "^1.2.1",
         "@bdelab/roar-vocab": "^1.8.0",
         "@bdelab/roav-crowding": "^1.1.10",
-        "@bdelab/roav-ran": "^1.0.17",
+        "@bdelab/roav-ran": "1.0.18",
         "@sentry/browser": "^8.0.0",
         "@sentry/integrations": "^7.114.0",
         "@sentry/vite-plugin": "^2.16.1",
@@ -5592,9 +5592,9 @@
       }
     },
     "node_modules/@bdelab/roav-ran": {
-      "version": "1.0.17",
-      "resolved": "https://registry.npmjs.org/@bdelab/roav-ran/-/roav-ran-1.0.17.tgz",
-      "integrity": "sha512-krpbpLLKEihlHL/8ecHajmysbhBgc+vwLCpE1aHZuzkJrU152COIgmWhUR1KUjmjsX2OQaVHpN4lvv4ePE7bqw==",
+      "version": "1.0.18",
+      "resolved": "https://registry.npmjs.org/@bdelab/roav-ran/-/roav-ran-1.0.18.tgz",
+      "integrity": "sha512-c3tqxxtW0hI7FoTrYhaPDH5zCTiQE6WqeNLiC2GEf1RH5IgTS6nK2C2cVN0srXZKrb3gbMVClGeTPlMJWrGKvQ==",
       "dependencies": {
         "@bdelab/jscat": "^1.0.5",
         "@bdelab/roar-firekit": "^4.7.0",
@@ -34957,9 +34957,9 @@
       }
     },
     "@bdelab/roav-ran": {
-      "version": "1.0.17",
-      "resolved": "https://registry.npmjs.org/@bdelab/roav-ran/-/roav-ran-1.0.17.tgz",
-      "integrity": "sha512-krpbpLLKEihlHL/8ecHajmysbhBgc+vwLCpE1aHZuzkJrU152COIgmWhUR1KUjmjsX2OQaVHpN4lvv4ePE7bqw==",
+      "version": "1.0.18",
+      "resolved": "https://registry.npmjs.org/@bdelab/roav-ran/-/roav-ran-1.0.18.tgz",
+      "integrity": "sha512-c3tqxxtW0hI7FoTrYhaPDH5zCTiQE6WqeNLiC2GEf1RH5IgTS6nK2C2cVN0srXZKrb3gbMVClGeTPlMJWrGKvQ==",
       "requires": {
         "@bdelab/jscat": "^1.0.5",
         "@bdelab/roar-firekit": "^4.7.0",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@bdelab/roar-utils": "^1.2.1",
     "@bdelab/roar-vocab": "^1.8.0",
     "@bdelab/roav-crowding": "^1.1.10",
-    "@bdelab/roav-ran": "^1.0.17",
+    "@bdelab/roav-ran": "1.0.18",
     "@sentry/browser": "^8.0.0",
     "@sentry/integrations": "^7.114.0",
     "@sentry/vite-plugin": "^2.16.1",


### PR DESCRIPTION
This PR updates the version of `@bdelab/roav-ran` to 1.0.18.