### PR TITLE
Update ROAV-Ran version to 1.0.19

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@bdelab/roar-utils": "^1.2.1",
         "@bdelab/roar-vocab": "^1.8.0",
         "@bdelab/roav-crowding": "1.1.11",
-        "@bdelab/roav-ran": "1.0.18",
+        "@bdelab/roav-ran": "1.0.19",
         "@sentry/browser": "^8.0.0",
         "@sentry/integrations": "^7.114.0",
         "@sentry/vite-plugin": "^2.16.1",
@@ -5592,9 +5592,9 @@
       }
     },
     "node_modules/@bdelab/roav-ran": {
-      "version": "1.0.18",
-      "resolved": "https://registry.npmjs.org/@bdelab/roav-ran/-/roav-ran-1.0.18.tgz",
-      "integrity": "sha512-c3tqxxtW0hI7FoTrYhaPDH5zCTiQE6WqeNLiC2GEf1RH5IgTS6nK2C2cVN0srXZKrb3gbMVClGeTPlMJWrGKvQ==",
+      "version": "1.0.19",
+      "resolved": "https://registry.npmjs.org/@bdelab/roav-ran/-/roav-ran-1.0.19.tgz",
+      "integrity": "sha512-4RWO4MR+Cylhxw1mDu17jpc8z8WuPYuiXyI/+oE/zxb8TZpQDbc6JfqffAA1TeUclZ7OI+nOVIP1RDQjgZIr9g==",
       "dependencies": {
         "@bdelab/jscat": "^1.0.5",
         "@bdelab/roar-firekit": "^4.7.0",
@@ -34957,9 +34957,9 @@
       }
     },
     "@bdelab/roav-ran": {
-      "version": "1.0.18",
-      "resolved": "https://registry.npmjs.org/@bdelab/roav-ran/-/roav-ran-1.0.18.tgz",
-      "integrity": "sha512-c3tqxxtW0hI7FoTrYhaPDH5zCTiQE6WqeNLiC2GEf1RH5IgTS6nK2C2cVN0srXZKrb3gbMVClGeTPlMJWrGKvQ==",
+      "version": "1.0.19",
+      "resolved": "https://registry.npmjs.org/@bdelab/roav-ran/-/roav-ran-1.0.19.tgz",
+      "integrity": "sha512-4RWO4MR+Cylhxw1mDu17jpc8z8WuPYuiXyI/+oE/zxb8TZpQDbc6JfqffAA1TeUclZ7OI+nOVIP1RDQjgZIr9g==",
       "requires": {
         "@bdelab/jscat": "^1.0.5",
         "@bdelab/roar-firekit": "^4.7.0",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@bdelab/roar-utils": "^1.2.1",
     "@bdelab/roar-vocab": "^1.8.0",
     "@bdelab/roav-crowding": "1.1.11",
-    "@bdelab/roav-ran": "1.0.18",
+    "@bdelab/roav-ran": "1.0.19",
     "@sentry/browser": "^8.0.0",
     "@sentry/integrations": "^7.114.0",
     "@sentry/vite-plugin": "^2.16.1",


### PR DESCRIPTION
This PR updates the version of `@bdelab/roav-ran` to 1.0.19.