### PR TITLE
Update ROAV-Ran version to 1.0.21

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "@bdelab/roar-vocab": "^1.8.0",
         "@bdelab/roav-crowding": "1.1.11",
         "@bdelab/roav-mep": "^1.1.13",
-        "@bdelab/roav-ran": "1.0.19",
+        "@bdelab/roav-ran": "1.0.21",
         "@sentry/browser": "^8.0.0",
         "@sentry/integrations": "^7.114.0",
         "@sentry/vite-plugin": "^2.16.1",
@@ -5642,9 +5642,9 @@
       }
     },
     "node_modules/@bdelab/roav-ran": {
-      "version": "1.0.19",
-      "resolved": "https://registry.npmjs.org/@bdelab/roav-ran/-/roav-ran-1.0.19.tgz",
-      "integrity": "sha512-4RWO4MR+Cylhxw1mDu17jpc8z8WuPYuiXyI/+oE/zxb8TZpQDbc6JfqffAA1TeUclZ7OI+nOVIP1RDQjgZIr9g==",
+      "version": "1.0.21",
+      "resolved": "https://registry.npmjs.org/@bdelab/roav-ran/-/roav-ran-1.0.21.tgz",
+      "integrity": "sha512-aT8pUBgWXdDutE6xccaz2LRvNaDQ8VbAHrBsqwljysbOplyxIhFhzmsmvfAD1RTPRG3saUMlexTHiPHRZymVFQ==",
       "dependencies": {
         "@bdelab/jscat": "^1.0.5",
         "@bdelab/roar-firekit": "^4.7.0",
@@ -35067,9 +35067,9 @@
       }
     },
     "@bdelab/roav-ran": {
-      "version": "1.0.19",
-      "resolved": "https://registry.npmjs.org/@bdelab/roav-ran/-/roav-ran-1.0.19.tgz",
-      "integrity": "sha512-4RWO4MR+Cylhxw1mDu17jpc8z8WuPYuiXyI/+oE/zxb8TZpQDbc6JfqffAA1TeUclZ7OI+nOVIP1RDQjgZIr9g==",
+      "version": "1.0.21",
+      "resolved": "https://registry.npmjs.org/@bdelab/roav-ran/-/roav-ran-1.0.21.tgz",
+      "integrity": "sha512-aT8pUBgWXdDutE6xccaz2LRvNaDQ8VbAHrBsqwljysbOplyxIhFhzmsmvfAD1RTPRG3saUMlexTHiPHRZymVFQ==",
       "requires": {
         "@bdelab/jscat": "^1.0.5",
         "@bdelab/roar-firekit": "^4.7.0",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@bdelab/roar-vocab": "^1.8.0",
     "@bdelab/roav-crowding": "1.1.11",
     "@bdelab/roav-mep": "^1.1.13",
-    "@bdelab/roav-ran": "1.0.19",
+    "@bdelab/roav-ran": "1.0.21",
     "@sentry/browser": "^8.0.0",
     "@sentry/integrations": "^7.114.0",
     "@sentry/vite-plugin": "^2.16.1",


### PR DESCRIPTION
This PR updates the version of `@bdelab/roav-ran` to 1.0.21.