### PR TITLE
Update SWR version to 1.12.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@bdelab/roar-multichoice": "^1.11.3",
         "@bdelab/roar-pa": "2.2.4",
         "@bdelab/roar-sre": "1.15.9",
-        "@bdelab/roar-swr": "^1.12.1",
+        "@bdelab/roar-swr": "1.12.4",
         "@bdelab/roar-utils": "^1.2.1",
         "@bdelab/roar-vocab": "^1.8.0",
         "@bdelab/roav-crowding": "1.1.11",
@@ -4357,9 +4357,9 @@
       }
     },
     "node_modules/@bdelab/roar-swr": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/@bdelab/roar-swr/-/roar-swr-1.12.1.tgz",
-      "integrity": "sha512-nmzQL3srAjjEafJUxWL/SS/hunmYl8UdnkZ/AMADmWP08/9rgOyGy5oJ4iPYkSdutrRhwRgojnn/gqP4zTtMyQ==",
+      "version": "1.12.4",
+      "resolved": "https://registry.npmjs.org/@bdelab/roar-swr/-/roar-swr-1.12.4.tgz",
+      "integrity": "sha512-U7E7tWSdxmwGhlRi4Qig8dABHN0q3vhEo0+9S82hERDNry+RcIFYgbjmAbhJA38tcobyXxg3Av/cyar+cVFA6w==",
       "dependencies": {
         "@bdelab/jscat": "^4.0.0",
         "@bdelab/roar-firekit": "^4.7.0",
@@ -34027,9 +34027,9 @@
       }
     },
     "@bdelab/roar-swr": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/@bdelab/roar-swr/-/roar-swr-1.12.1.tgz",
-      "integrity": "sha512-nmzQL3srAjjEafJUxWL/SS/hunmYl8UdnkZ/AMADmWP08/9rgOyGy5oJ4iPYkSdutrRhwRgojnn/gqP4zTtMyQ==",
+      "version": "1.12.4",
+      "resolved": "https://registry.npmjs.org/@bdelab/roar-swr/-/roar-swr-1.12.4.tgz",
+      "integrity": "sha512-U7E7tWSdxmwGhlRi4Qig8dABHN0q3vhEo0+9S82hERDNry+RcIFYgbjmAbhJA38tcobyXxg3Av/cyar+cVFA6w==",
       "requires": {
         "@bdelab/jscat": "^4.0.0",
         "@bdelab/roar-firekit": "^4.7.0",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@bdelab/roar-multichoice": "^1.11.3",
     "@bdelab/roar-pa": "2.2.4",
     "@bdelab/roar-sre": "1.15.9",
-    "@bdelab/roar-swr": "^1.12.1",
+    "@bdelab/roar-swr": "1.12.4",
     "@bdelab/roar-utils": "^1.2.1",
     "@bdelab/roar-vocab": "^1.8.0",
     "@bdelab/roav-crowding": "1.1.11",


### PR DESCRIPTION
This PR updates the version of `@bdelab/roar-swr` to 1.12.4.