### PR TITLE
Update SRE version to 1.15.11

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@bdelab/roar-letter": "^1.11.4",
         "@bdelab/roar-multichoice": "^1.11.3",
         "@bdelab/roar-pa": "2.2.4",
-        "@bdelab/roar-sre": "1.15.9",
+        "@bdelab/roar-sre": "1.15.11",
         "@bdelab/roar-swr": "^1.12.1",
         "@bdelab/roar-utils": "^1.2.1",
         "@bdelab/roar-vocab": "^1.8.0",
@@ -3774,9 +3774,9 @@
       }
     },
     "node_modules/@bdelab/roar-sre": {
-      "version": "1.15.9",
-      "resolved": "https://registry.npmjs.org/@bdelab/roar-sre/-/roar-sre-1.15.9.tgz",
-      "integrity": "sha512-G8MzjLVT2nJ4TCUjQiuPtneQeUFOQMExAwKK1D9u4q/o9DEwUfuooJiMPHExhuU0K8sIPTanH21snCN8GpOYbQ==",
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/@bdelab/roar-sre/-/roar-sre-1.15.11.tgz",
+      "integrity": "sha512-wFUW3s1Kw7A18p15WhkhMZhoEwFcYS6iW9F7gaTJjWFo4OT8YS+2kuCRgBdy2QGMTYLKIEQMxRL/sLcQVwCjMw==",
       "dependencies": {
         "@babel/core": "^7.19.3",
         "@babel/preset-env": "^7.19.4",
@@ -33541,9 +33541,9 @@
       }
     },
     "@bdelab/roar-sre": {
-      "version": "1.15.9",
-      "resolved": "https://registry.npmjs.org/@bdelab/roar-sre/-/roar-sre-1.15.9.tgz",
-      "integrity": "sha512-G8MzjLVT2nJ4TCUjQiuPtneQeUFOQMExAwKK1D9u4q/o9DEwUfuooJiMPHExhuU0K8sIPTanH21snCN8GpOYbQ==",
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/@bdelab/roar-sre/-/roar-sre-1.15.11.tgz",
+      "integrity": "sha512-wFUW3s1Kw7A18p15WhkhMZhoEwFcYS6iW9F7gaTJjWFo4OT8YS+2kuCRgBdy2QGMTYLKIEQMxRL/sLcQVwCjMw==",
       "requires": {
         "@babel/core": "^7.19.3",
         "@babel/preset-env": "^7.19.4",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@bdelab/roar-letter": "^1.11.4",
     "@bdelab/roar-multichoice": "^1.11.3",
     "@bdelab/roar-pa": "2.2.4",
-    "@bdelab/roar-sre": "1.15.9",
+    "@bdelab/roar-sre": "1.15.11",
     "@bdelab/roar-swr": "^1.12.1",
     "@bdelab/roar-utils": "^1.2.1",
     "@bdelab/roar-vocab": "^1.8.0",


### PR DESCRIPTION
This PR updates the version of `@bdelab/roar-sre` to 1.15.11.