### PR TITLE
Button Style Consistency

### DIFF
--- a/public/worker.js
+++ b/public/worker.js
@@ -1,0 +1,261 @@
+import { getScoreKeys } from '@helpers/reports.js';
+
+const getScoresAndSupportFromAssessment = ({
+  grade,
+  assessment,
+  standardScoreDisplayKey,
+  percentileScoreKey,
+  percentileScoreDisplayKey,
+  rawScoreKey,
+  taskId,
+  optional,
+}) => {
+  let percentile = _get(assessment, `scores.computed.composite.${percentileScoreKey}`);
+  let percentileString = _get(assessment, `scores.computed.composite.${percentileScoreDisplayKey}`);
+  let standardScore = _get(assessment, `scores.computed.composite.${standardScoreDisplayKey}`);
+  let rawScore = _get(assessment, `scores.computed.composite.${rawScoreKey}`);
+
+  const { support_level, tag_color } = getSupportLevel(grade, percentile, rawScore, taskId, optional);
+  if (percentile) percentile = _round(percentile);
+  if (percentileString && !isNaN(_round(percentileString))) percentileString = _round(percentileString);
+
+  return {
+    support_level,
+    tag_color,
+    percentile,
+    percentileString,
+    standardScore,
+    rawScore,
+  };
+};
+
+function getScoreKeysByRow(row, grade) {
+  const taskId = row?.taskId;
+  return getScoreKeys(taskId, grade);
+}
+
+// Function to process assignment data
+
+function processAssignmentData(assignmentData) {
+  if (!assignmentData || assignmentData.length === 0) {
+    return { assignmentTableData: [], runsByTaskId: {} };
+  }
+
+  const assignmentTableDataAcc = [];
+  const runsByTaskIdAcc = {};
+
+  for (const { assignment, user } of assignmentData) {
+    // for each row, compute: username, firstName, lastName, assessmentPID, grade, school, all the scores, and routeParams for report link
+    const grade = user.studentData?.grade;
+    // compute schoolName
+    let schoolName = '';
+    const schoolId = user?.schools?.current[0];
+    // if (schoolId) {
+    //   schoolName = schoolNameDictionary.value[schoolId];
+    // }
+
+    const firstNameOrUsername = user.name.first ?? user.username;
+
+    const currRow = {
+      user: {
+        username: user.username,
+        email: user.email,
+        userId: user.userId,
+        firstName: user.name.first,
+        lastName: user.name.last,
+        grade: grade,
+        assessmentPid: user.assessmentPid,
+        schoolName: schoolName,
+      },
+      tooltip: `View ${firstNameOrUsername}'s Score Report`,
+      routeParams: {
+        // administrationId: props.administrationId,
+        // orgId: props.orgId,
+        // orgType: props.orgType,
+        userId: user.userId,
+      },
+      // compute and add scores data in next step as so
+      // swr: { support_level: 'Needs Extra Support', percentile: 10, raw: 10, reliable: true, engagementFlags: {}},
+    };
+
+    let numAssignmentsCompleted = 0;
+    const currRowScores = {};
+    for (const assessment of assignment.assessments) {
+      // General Logic to grab support level, scores, etc
+      let scoreFilterTags = '';
+      const taskId = assessment.taskId;
+      const isOptional = assessment.optional;
+      if (isOptional) {
+        scoreFilterTags += ' Optional ';
+      } else {
+        scoreFilterTags += ' Required ';
+      }
+      if (assessment.reliable == true) {
+        scoreFilterTags += ' Reliable ';
+      } else {
+        scoreFilterTags += ' Unreliable ';
+      }
+      // Add filter tags for completed/incomplete
+      if (assessment.completedOn != undefined) {
+        numAssignmentsCompleted += 1;
+        scoreFilterTags += ' Completed ';
+      } else if (assessment.startedOn != undefined) {
+        scoreFilterTags += ' Started ';
+      } else {
+        scoreFilterTags += ' Assigned ';
+      }
+      // Add filter tags for assessed (what is this?)
+      if (typeof assessment?.scores?.computed?.composite == 'number') {
+        scoreFilterTags += ' Assessed ';
+      }
+
+      const { percentileScoreKey, rawScoreKey, percentileScoreDisplayKey, standardScoreDisplayKey } = getScoreKeysByRow(
+        assessment,
+        getGrade(_get(user, 'studentData.grade')),
+      );
+      // compute and add scores data in next step as so
+      const { support_level, tag_color, percentile, percentileString, standardScore, rawScore } =
+        getScoresAndSupportFromAssessment({
+          grade: grade,
+          assessment,
+          percentileScoreKey,
+          percentileScoreDisplayKey,
+          standardScoreDisplayKey,
+          rawScoreKey,
+          taskId,
+          isOptional,
+        });
+
+      if (tag_color === supportLevelColors.above) {
+        scoreFilterTags += ' Green ';
+      } else if (tag_color === supportLevelColors.some) {
+        scoreFilterTags += ' Yellow ';
+      } else if (tag_color === supportLevelColors.below) {
+        scoreFilterTags += ' Pink ';
+      }
+
+      const tagColor = returnColorByReliability(assessment, rawScore, support_level, tag_color);
+
+      // Logic to update assignmentTableDataAcc
+      currRowScores[taskId] = {
+        optional: isOptional,
+        supportLevel: support_level,
+        reliable: assessment.reliable,
+        engagementFlags: assessment.engagementFlags ?? [],
+        tagColor: tagColor,
+        percentile: percentile,
+        percentileString: percentileString,
+        rawScore: rawScore,
+        standardScore: standardScore,
+        tags: scoreFilterTags,
+      };
+
+      if (tasksToDisplayCorrectIncorrectDifference.includes(taskId)) {
+        const numCorrect = assessment.scores?.raw?.composite?.test?.numCorrect;
+        const numIncorrect = assessment.scores?.raw?.composite?.test?.numAttempted - numCorrect;
+        currRowScores[taskId].correctIncorrectDifference =
+          numCorrect != null && numIncorrect != null ? numCorrect - numIncorrect : null;
+        currRowScores[taskId].numCorrect = numCorrect;
+        currRowScores[taskId].numIncorrect = numIncorrect;
+        currRowScores[taskId].tagColor = supportLevelColors.Assessed;
+        scoreFilterTags += ' Assessed ';
+      } else if (tasksToDisplayPercentCorrect.includes(taskId)) {
+        const numAttempted = assessment.scores?.raw?.composite?.test?.numAttempted;
+        const numCorrect = assessment.scores?.raw?.composite?.test?.numCorrect;
+        const percentCorrect = numAttempted > 0 ? Math.round((numCorrect * 100) / numAttempted).toString() + '%' : null;
+        currRowScores[taskId].percentCorrect = percentCorrect;
+        currRowScores[taskId].numAttempted = numAttempted;
+        currRowScores[taskId].numCorrect = numCorrect;
+        scoreFilterTags += ' Assessed ';
+      }
+
+      if (taskId === 'letter' && assessment.scores) {
+        currRowScores[taskId].lowerCaseScore = assessment.scores.computed.LowercaseNames?.subScore;
+        currRowScores[taskId].upperCaseScore = assessment.scores.computed.UppercaseNames?.subScore;
+        currRowScores[taskId].phonemeScore = assessment.scores.computed.Phonemes?.subScore;
+        currRowScores[taskId].totalScore = assessment.scores.computed.composite?.totalCorrect;
+        const incorrectLettersArray = [
+          ...(_get(assessment, 'scores.computed.UppercaseNames.upperIncorrect') ?? '').split(','),
+          ...(_get(assessment, 'scores.computed.LowercaseNames.lowerIncorrect') ?? '').split(','),
+        ]
+          .sort((a, b) => _toUpper(a) - _toUpper(b))
+          .filter(Boolean)
+          .join(', ');
+        currRowScores[taskId].incorrectLetters = incorrectLettersArray.length > 0 ? incorrectLettersArray : 'None';
+
+        const incorrectPhonemesArray = (_get(assessment, 'scores.computed.Phonemes.phonemeIncorrect') ?? '')
+          .split(',')
+          .join(', ');
+        currRowScores[taskId].incorrectPhonemes = incorrectPhonemesArray.length > 0 ? incorrectPhonemesArray : 'None';
+      }
+      if (taskId === 'pa' && assessment.scores) {
+        const first = _get(assessment, 'scores.computed.FSM.roarScore');
+        const last = _get(assessment, 'scores.computed.LSM.roarScore');
+        const deletion = _get(assessment, 'scores.computed.DEL.roarScore');
+        let skills = [];
+        if (first < 15) skills.push('First Sound Matching');
+        if (last < 15) skills.push('Last sound matching');
+        if (deletion < 15) skills.push('Deletion');
+        currRowScores[taskId].firstSound = first;
+        currRowScores[taskId].lastSound = last;
+        currRowScores[taskId].deletion = deletion;
+        currRowScores[taskId].total = _get(assessment, 'scores.computed.composite.roarScore');
+        currRowScores[taskId].skills = skills.length > 0 ? skills.join(', ') : 'None';
+      }
+
+      // Logic to update runsByTaskIdAcc
+      const run = {
+        // A bit of a workaround to properly sort grades in facetted graphs (changes Kindergarten to grade 0)
+        grade: getGrade(grade),
+        scores: {
+          support_level: support_level,
+          stdPercentile: percentile,
+          rawScore: rawScore,
+        },
+        taskId,
+        user: {
+          grade: grade,
+          schoolName: schoolsDictWithGrade.value[schoolId],
+        },
+        tag_color: tag_color,
+      };
+
+      if (run.taskId in runsByTaskIdAcc) {
+        runsByTaskIdAcc[run.taskId].push(run);
+      } else {
+        runsByTaskIdAcc[run.taskId] = [run];
+      }
+    }
+
+    // update scores for current row with computed object
+    currRow.scores = currRowScores;
+    currRow.numAssignmentsCompleted = numAssignmentsCompleted;
+    // push currRow to assignmentTableDataAcc
+    assignmentTableDataAcc.push(currRow);
+    // Perform the same processing logic as in your original code
+    // ... (rest of the processing logic)
+  }
+
+  // sort by numAssignmentsCompleted
+  assignmentTableDataAcc.sort((a, b) => b.numAssignmentsCompleted - a.numAssignmentsCompleted);
+
+  const filteredRunsByTaskId = _pickBy(runsByTaskIdAcc, (scores, taskId) => {
+    return Object.keys(taskInfoById).includes(taskId);
+  });
+
+  // Return processed data
+  return { assignmentTableData: assignmentTableDataAcc, runsByTaskId: filteredRunsByTaskId };
+}
+
+// Respond to messages from the main thread
+self.addEventListener('message', async (event) => {
+  console.log('event in worker', event);
+  const assignmentData = JSON.parse(event.data);
+
+  // Process assignment data
+  const result = await processAssignmentData(assignmentData);
+  console.log('result in worker', result);
+
+  // Post the processed data back to the main thread
+  self.postMessage(result);
+});

--- a/src/assets/styles/theme.css
+++ b/src/assets/styles/theme.css
@@ -100,6 +100,14 @@
   box-sizing: border-box;
 }
 
+/* Styles default HTML tags */
+
+button {
+  background-color: #8c1515;
+  color: white;
+  border-radius: 0.2rem 0.3rem;
+}
+
 .p-component {
   font-family:
     Inter,
@@ -2156,8 +2164,8 @@
 
 .p-button.p-button-outlined {
   background-color: transparent;
-  color: #8c1515;
-  border: 1px solid;
+  /* color: #8c1515; */
+  /* border: 1px solid; */
 }
 
 .p-button.p-button-outlined:enabled:hover {

--- a/src/components/CardAdministration.vue
+++ b/src/components/CardAdministration.vue
@@ -63,11 +63,10 @@
       </div>
       <div v-if="isAssigned">
         <PvButton
-          class="mt-2 m-0 bg-primary text-white border-none border-round h-2rem text-sm hover:bg-red-900"
           :icon="toggleIcon"
           style="padding: 1rem; padding-top: 1.2rem; padding-bottom: 1.2rem"
-          size="small"
-          :label="toggleLabel"
+          size="x-small"
+          :label="showDetailsToggle"
           @click="toggleTable"
         />
       </div>
@@ -257,7 +256,7 @@ const toggleIcon = computed(() => {
   return 'pi pi-chevron-right mr-2';
 });
 
-const toggleLabel = computed(() => {
+const showDetailsToggle = computed(() => {
   if (showTable.value) {
     return 'Hide details';
   }

--- a/src/pages/ScoreReport.vue
+++ b/src/pages/ScoreReport.vue
@@ -498,16 +498,6 @@ const schoolsDictWithGrade = computed(() => {
   }
 });
 
-const schoolNameDictionary = computed(() => {
-  if (schoolsInfo.value) {
-    return schoolsInfo.value.reduce((acc, school) => {
-      acc[school.id] = school.name;
-      return acc;
-    }, {});
-  } else {
-    return {};
-  }
-});
 
 const scoresQueryEnabled = computed(() => initialized.value && claimsLoaded.value);
 
@@ -577,6 +567,7 @@ const getScoresAndSupportFromAssessment = ({
 // 1. assignmentTableData: The data that should be passed into the ROARDataTable component
 // 2. runsByTaskId: run data for the TaskReport distribution chartsb
 const computeAssignmentAndRunData = computed(() => {
+<<<<<<< Updated upstream
   if (!assignmentData.value || assignmentData.value.length === 0) {
     return { assignmentTableData: [], runsByTaskId: {} };
   } else {
@@ -584,6 +575,10 @@ const computeAssignmentAndRunData = computed(() => {
     const assignmentTableDataAcc = [];
     // runsByTaskId is an object with keys as taskIds and values as arrays of scores
     const runsByTaskIdAcc = {};
+=======
+  const promise = new Promise((resolve, reject) => {
+    const worker = new Worker('/worker.js', { type: "module" });
+>>>>>>> Stashed changes
 
     for (const { assignment, user } of assignmentData.value) {
       // for each row, compute: username, firstName, lastName, assessmentPID, grade, school, all the scores, and routeParams for report link
@@ -781,8 +776,23 @@ const computeAssignmentAndRunData = computed(() => {
       return Object.keys(taskInfoById).includes(taskId);
     });
 
+<<<<<<< Updated upstream
     return { runsByTaskId: filteredRunsByTaskId, assignmentTableData: assignmentTableDataAcc };
   }
+=======
+    // Handle errors from the worker
+    worker.addEventListener('error', (error) => {
+      reject(error);
+      worker.terminate(); // Terminate the worker in case of an error
+    });
+
+    console.log('jsonstring assndata', JSON.stringify(assignmentData.value))
+    // Send assignmentData to the worker for processing
+    worker.postMessage(JSON.stringify(assignmentData.value));
+  });
+  console.log('worker promise', promise);
+  return promise;
+>>>>>>> Stashed changes
 });
 
 const filteredTableData = ref(computeAssignmentAndRunData.value.assignmentTableData);


### PR DESCRIPTION
## Proposed changes

<img width="1502" alt="Screenshot 2024-06-20 at 1 44 23 PM" src="https://github.com/yeatmanlab/roar-dashboard/assets/20426569/c04ff76f-267c-4e69-bd03-5bb59c632f55">

Our button style consistency has definitely improved over time, but there are a few places on the dashboard where the styling is still a bit splintered. In the above screenshot, you can view a few distinct button styles: 

1. The `Show Details` button, with a background of our primary color  (`#8c1515`) and a text color of white. Let's call this a **_Primary Button_**. 
<img width="106" alt="Screenshot 2024-06-20 at 2 00 44 PM" src="https://github.com/yeatmanlab/roar-dashboard/assets/20426569/c2259c42-cef2-4644-8e40-d8eadd48da84">
 
2. The `Logout` button, with a slight gray background and a text color of our primary color. Let's call this a **_Link Button_** 
.
<img width="280" alt="Screenshot 2024-06-20 at 2 01 02 PM" src="https://github.com/yeatmanlab/roar-dashboard/assets/20426569/fa38383b-d2d6-45af-a0d2-fce8056a69fb">


3. The `Score` and `Progress` report buttons, which have a drop shadow and grey-ish coloring. Let's call this a **_Raised Button_**
<img width="187" alt="Screenshot 2024-06-20 at 2 01 13 PM" src="https://github.com/yeatmanlab/roar-dashboard/assets/20426569/f653fc75-f3c9-43a5-9866-088aef2cfa5a">

4. The `Edit` cog button, which reacts on hover and normally has a primary color background, but loses that background on click and is a bit less visible. This behavior is likely due to the conflicting styles we have declared in custom button styling and PrimeVue's own stylesheets. 
<img width="176" alt="Screenshot 2024-06-20 at 2 01 25 PM" src="https://github.com/yeatmanlab/roar-dashboard/assets/20426569/e0ac9d9d-8ec3-42e3-917a-e8d69f84f925">

5.  The expand button, used to un-nest the organizational structure of each administration. This doesn't react on hover, so it may be a little less apparent that it can be utilized. (As an aside, I believe this can be improved by allowing the user to n-nest an org by clicking anywhere within the card.
<img width="752" alt="Screenshot 2024-06-20 at 2 02 20 PM" src="https://github.com/yeatmanlab/roar-dashboard/assets/20426569/fb6cf5d6-a831-4603-aad0-43a6f40b1695">

This is just on one section of one page, and we have many other button variants in other parts of the app (forms, reports). We can greatly improve the feel of our app by unifying these button stylings and the mappings of `styling -> functionality`. By coming into a consistent pattern of button styling to function, we can make it more intuitive for new users learning how to interact with the site.  

For example, we could chose to find a default variant of button used to expand content. Only use the `primary button` in operations that change the **page** or force a reload. Whatever we end up on, the most important thing is that there is a rough mapping of the type of button and the function it offers to the user. 

Styling wise, we can choose to imitate (or even directly use the [primevue set of buttons ](https://primevue.org/button/). With these buttons, we can directly pass in props like `link` and `outlined` to style these buttons directly, instead of relying on custom css names. 

<img width="534" alt="Screenshot 2024-06-20 at 1 52 02 PM" src="https://github.com/yeatmanlab/roar-dashboard/assets/20426569/2aefc413-4c3a-4b5e-974d-56303ef71580">

This PR is a work in progress. Feel free to contribute where you would like! Or add any commentary in the below thread.

Thanks for reading!
 
## Types of changes

What types of changes does this pull request introduce?

<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (non-breaking change that does not add functionality but makes code cleaner or more efficient)
- [ ] Documentation Update
- [ ] Tests (new or updated tests)
- [ ] Style (changes to code styling)
- [ ] CI (continuous integration changes)
- [ ] Repository Maintenance
- [ ] Other (please describe below)

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask.  We're here
to help! This is simply a reminder of what we are going to look for before
merging your code.
-->

- [ ] I have read the [guidelines for contributing](https://github.com/yeatmanlab/roar-dashboard/blob/main/.github/CONTRIBUTING.md).
- [ ] The changes in this PR are as small as they can be. They represent one and only one fix or enhancement.
- [ ] Linting checks pass with my changes.
- [ ] Any existing unit tests pass with my changes.
- [ ] Any existing end-to-end tests pass with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] If this PR fixes an existing issue, I have added a unit or end-to-end test that will detect if this issue reoccurs.
- [ ] I have added JSDoc comments as appropriate.
- [ ] I have added the necessary documentation to the [roar-docs repository](https://github.com/yeatmanlab/roar-docs).
- [ ] I have shared this PR on the roar-pr-reviews channel (if I have access)
- [ ] I have linked relevant issues (if any)

## Justification of missing checklist items

<!--
If you feel that a checklist item above is not applicable to this PR, please
provide your justification here. Otherwise, delete this section.
-->

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
