### PR TITLE
Update SWR version to 1.12.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@bdelab/roar-multichoice": "^1.11.3",
         "@bdelab/roar-pa": "2.2.4",
         "@bdelab/roar-sre": "1.15.9",
-        "@bdelab/roar-swr": "^1.12.1",
+        "@bdelab/roar-swr": "1.12.5",
         "@bdelab/roar-utils": "^1.2.1",
         "@bdelab/roar-vocab": "^1.8.0",
         "@bdelab/roav-crowding": "1.1.11",
@@ -4383,9 +4383,9 @@
       }
     },
     "node_modules/@bdelab/roar-swr": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/@bdelab/roar-swr/-/roar-swr-1.12.1.tgz",
-      "integrity": "sha512-nmzQL3srAjjEafJUxWL/SS/hunmYl8UdnkZ/AMADmWP08/9rgOyGy5oJ4iPYkSdutrRhwRgojnn/gqP4zTtMyQ==",
+      "version": "1.12.5",
+      "resolved": "https://registry.npmjs.org/@bdelab/roar-swr/-/roar-swr-1.12.5.tgz",
+      "integrity": "sha512-0mdQXNm1CIXQ1qXlP7iYVEMDRBftUXjzQjDqU29eM43Xh1e6E9/b9amcdf9WTMsDAxZ6rtAaeJbu07iywgF1pA==",
       "dependencies": {
         "@bdelab/jscat": "^4.0.0",
         "@bdelab/roar-firekit": "^4.7.0",
@@ -35074,9 +35074,9 @@
       }
     },
     "@bdelab/roar-swr": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/@bdelab/roar-swr/-/roar-swr-1.12.1.tgz",
-      "integrity": "sha512-nmzQL3srAjjEafJUxWL/SS/hunmYl8UdnkZ/AMADmWP08/9rgOyGy5oJ4iPYkSdutrRhwRgojnn/gqP4zTtMyQ==",
+      "version": "1.12.5",
+      "resolved": "https://registry.npmjs.org/@bdelab/roar-swr/-/roar-swr-1.12.5.tgz",
+      "integrity": "sha512-0mdQXNm1CIXQ1qXlP7iYVEMDRBftUXjzQjDqU29eM43Xh1e6E9/b9amcdf9WTMsDAxZ6rtAaeJbu07iywgF1pA==",
       "requires": {
         "@bdelab/jscat": "^4.0.0",
         "@bdelab/roar-firekit": "^4.7.0",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@bdelab/roar-multichoice": "^1.11.3",
     "@bdelab/roar-pa": "2.2.4",
     "@bdelab/roar-sre": "1.15.9",
-    "@bdelab/roar-swr": "^1.12.1",
+    "@bdelab/roar-swr": "1.12.5",
     "@bdelab/roar-utils": "^1.2.1",
     "@bdelab/roar-vocab": "^1.8.0",
     "@bdelab/roav-crowding": "1.1.11",


### PR DESCRIPTION
This PR updates the version of `@bdelab/roar-swr` to 1.12.5.