### PR TITLE
Update ROAV-Crowding version to 1.1.12

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "roar-dashboard",
       "version": "2.7.12",
       "dependencies": {
-        "@bdelab/roam-fluency": "1.11.21",
+        "@bdelab/roam-fluency": "1.11.24",
         "@bdelab/roar-firekit": "^6.1.3",
         "@bdelab/roar-letter": "^1.11.4",
         "@bdelab/roar-multichoice": "^1.11.3",
@@ -17,7 +17,7 @@
         "@bdelab/roar-swr": "^1.12.1",
         "@bdelab/roar-utils": "^1.2.1",
         "@bdelab/roar-vocab": "^1.8.0",
-        "@bdelab/roav-crowding": "1.1.11",
+        "@bdelab/roav-crowding": "1.1.12",
         "@bdelab/roav-mep": "^1.1.16",
         "@bdelab/roav-ran": "^1.0.21",
         "@sentry/browser": "^8.0.0",
@@ -5464,9 +5464,9 @@
       }
     },
     "node_modules/@bdelab/roav-crowding": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/@bdelab/roav-crowding/-/roav-crowding-1.1.11.tgz",
-      "integrity": "sha512-RSlQ6ZdKFGzagyOvVwH3En7m3T7pXS48RdZLxtkQROGFuqFUXTkqRwO59+xPmM58IzyEOnvDl243xP5RD5NtYw==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/@bdelab/roav-crowding/-/roav-crowding-1.1.12.tgz",
+      "integrity": "sha512-Eg2XuOHNnwiciN4LuIDnkrfjKFrJBezDeN+s1DI+ZKU8R5qEksWqhMrkectOrKrHCCVx5UaXlJvnmqEJHJRA6w==",
       "dependencies": {
         "@bdelab/jscat": "^4.0.0",
         "@bdelab/roar-firekit": "^4.7.0",
@@ -34897,9 +34897,9 @@
       }
     },
     "@bdelab/roav-crowding": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/@bdelab/roav-crowding/-/roav-crowding-1.1.11.tgz",
-      "integrity": "sha512-RSlQ6ZdKFGzagyOvVwH3En7m3T7pXS48RdZLxtkQROGFuqFUXTkqRwO59+xPmM58IzyEOnvDl243xP5RD5NtYw==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/@bdelab/roav-crowding/-/roav-crowding-1.1.12.tgz",
+      "integrity": "sha512-Eg2XuOHNnwiciN4LuIDnkrfjKFrJBezDeN+s1DI+ZKU8R5qEksWqhMrkectOrKrHCCVx5UaXlJvnmqEJHJRA6w==",
       "requires": {
         "@bdelab/jscat": "^4.0.0",
         "@bdelab/roar-firekit": "^4.7.0",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@bdelab/roar-swr": "^1.12.1",
     "@bdelab/roar-utils": "^1.2.1",
     "@bdelab/roar-vocab": "^1.8.0",
-    "@bdelab/roav-crowding": "1.1.11",
+    "@bdelab/roav-crowding": "1.1.12",
     "@bdelab/roav-mep": "^1.1.16",
     "@bdelab/roav-ran": "^1.0.21",
     "@sentry/browser": "^8.0.0",


### PR DESCRIPTION
This PR updates the version of `@bdelab/roav-crowding` to 1.1.12.