### PR TITLE
Update ROAV-Crowding version to 1.1.13

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@bdelab/roar-swr": "^1.12.1",
         "@bdelab/roar-utils": "^1.2.1",
         "@bdelab/roar-vocab": "^1.8.0",
-        "@bdelab/roav-crowding": "1.1.12",
+        "@bdelab/roav-crowding": "1.1.13",
         "@bdelab/roav-mep": "^1.1.17",
         "@bdelab/roav-ran": "^1.0.21",
         "@sentry/browser": "^8.0.0",
@@ -5498,9 +5498,9 @@
       }
     },
     "node_modules/@bdelab/roav-crowding": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/@bdelab/roav-crowding/-/roav-crowding-1.1.12.tgz",
-      "integrity": "sha512-Eg2XuOHNnwiciN4LuIDnkrfjKFrJBezDeN+s1DI+ZKU8R5qEksWqhMrkectOrKrHCCVx5UaXlJvnmqEJHJRA6w==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/@bdelab/roav-crowding/-/roav-crowding-1.1.13.tgz",
+      "integrity": "sha512-vGzyqN97miqUzy0jJ/SRnLtBqgTF3dr2npImBRsHpIVUQxQ6ZepqyWyIRXEoZBRnM4Qc/PB/raJ2GDn/fX1BFA==",
       "dependencies": {
         "@bdelab/jscat": "^4.0.0",
         "@bdelab/roar-firekit": "^4.7.0",
@@ -35973,9 +35973,9 @@
       }
     },
     "@bdelab/roav-crowding": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/@bdelab/roav-crowding/-/roav-crowding-1.1.12.tgz",
-      "integrity": "sha512-Eg2XuOHNnwiciN4LuIDnkrfjKFrJBezDeN+s1DI+ZKU8R5qEksWqhMrkectOrKrHCCVx5UaXlJvnmqEJHJRA6w==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/@bdelab/roav-crowding/-/roav-crowding-1.1.13.tgz",
+      "integrity": "sha512-vGzyqN97miqUzy0jJ/SRnLtBqgTF3dr2npImBRsHpIVUQxQ6ZepqyWyIRXEoZBRnM4Qc/PB/raJ2GDn/fX1BFA==",
       "requires": {
         "@bdelab/jscat": "^4.0.0",
         "@bdelab/roar-firekit": "^4.7.0",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@bdelab/roar-swr": "^1.12.1",
     "@bdelab/roar-utils": "^1.2.1",
     "@bdelab/roar-vocab": "^1.8.0",
-    "@bdelab/roav-crowding": "1.1.12",
+    "@bdelab/roav-crowding": "1.1.13",
     "@bdelab/roav-mep": "^1.1.17",
     "@bdelab/roav-ran": "^1.0.21",
     "@sentry/browser": "^8.0.0",


### PR DESCRIPTION
This PR updates the version of `@bdelab/roav-crowding` to 1.1.13.