### PR TITLE
Update Letter version to 1.11.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@bdelab/roam-fluency": "1.11.24",
         "@bdelab/roar-firekit": "^7.1.0",
-        "@bdelab/roar-letter": "^1.11.4",
+        "@bdelab/roar-letter": "1.11.5",
         "@bdelab/roar-multichoice": "^1.11.3",
         "@bdelab/roar-pa": "2.2.4",
         "@bdelab/roar-sre": "1.15.9",
@@ -1756,9 +1756,9 @@
       }
     },
     "node_modules/@bdelab/roar-letter": {
-      "version": "1.11.4",
-      "resolved": "https://registry.npmjs.org/@bdelab/roar-letter/-/roar-letter-1.11.4.tgz",
-      "integrity": "sha512-rNKXr7qJXftUOwKU7FK/v4ohZGVXgA5jLgfda2pqKbKp9hhv06pBayA9kDgJklaGmoemtsilx+gARKu+PFqyrQ==",
+      "version": "1.11.5",
+      "resolved": "https://registry.npmjs.org/@bdelab/roar-letter/-/roar-letter-1.11.5.tgz",
+      "integrity": "sha512-8wUZSajJbDfLIOBcv/e+CbhVQvPnvidhVcRf/gA7RhVr0S959ldql1jO5tBKUyzU0jldha2X7zeqbvcb/KtpNA==",
       "dependencies": {
         "@bdelab/jscat": "^4.0.0",
         "@bdelab/roar-firekit": "^4.7.0",
@@ -32907,9 +32907,9 @@
       }
     },
     "@bdelab/roar-letter": {
-      "version": "1.11.4",
-      "resolved": "https://registry.npmjs.org/@bdelab/roar-letter/-/roar-letter-1.11.4.tgz",
-      "integrity": "sha512-rNKXr7qJXftUOwKU7FK/v4ohZGVXgA5jLgfda2pqKbKp9hhv06pBayA9kDgJklaGmoemtsilx+gARKu+PFqyrQ==",
+      "version": "1.11.5",
+      "resolved": "https://registry.npmjs.org/@bdelab/roar-letter/-/roar-letter-1.11.5.tgz",
+      "integrity": "sha512-8wUZSajJbDfLIOBcv/e+CbhVQvPnvidhVcRf/gA7RhVr0S959ldql1jO5tBKUyzU0jldha2X7zeqbvcb/KtpNA==",
       "requires": {
         "@bdelab/jscat": "^4.0.0",
         "@bdelab/roar-firekit": "^4.7.0",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "@bdelab/roam-fluency": "1.11.24",
     "@bdelab/roar-firekit": "^7.1.0",
-    "@bdelab/roar-letter": "^1.11.4",
+    "@bdelab/roar-letter": "1.11.5",
     "@bdelab/roar-multichoice": "^1.11.3",
     "@bdelab/roar-pa": "2.2.4",
     "@bdelab/roar-sre": "1.15.9",


### PR DESCRIPTION
This PR updates the version of `@bdelab/roar-letter` to 1.11.5.