### PR TITLE
Update ROAM-Fluency version to 1.11.26

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "roar-dashboard",
       "version": "2.9.0",
       "dependencies": {
-        "@bdelab/roam-fluency": "1.11.24",
+        "@bdelab/roam-fluency": "1.11.26",
         "@bdelab/roar-firekit": "^7.1.0",
         "@bdelab/roar-letter": "1.11.5",
         "@bdelab/roar-multichoice": "^1.11.3",
@@ -1605,9 +1605,9 @@
       }
     },
     "node_modules/@bdelab/roam-fluency": {
-      "version": "1.11.24",
-      "resolved": "https://registry.npmjs.org/@bdelab/roam-fluency/-/roam-fluency-1.11.24.tgz",
-      "integrity": "sha512-Tag2e3oF6dxNcWk2bWVlQXue9LBv0ZC1QQwjtvDIcqfWDVl4KRc3OFhxGqQLsLwBvMoZ6kQAtBP5LhF44CF/Vg==",
+      "version": "1.11.26",
+      "resolved": "https://registry.npmjs.org/@bdelab/roam-fluency/-/roam-fluency-1.11.26.tgz",
+      "integrity": "sha512-XpaCXy+CtEIsp6CmKo+3vo55g7ZJL+g6l7KNCaiqvh9M7QAi+xS6QpsUh3PQkbQkAPlQzcc6f4P3+b4Oe2m6VA==",
       "dependencies": {
         "@bdelab/jscat": "^4.0.0",
         "@bdelab/roar-firekit": "^4.7.0",
@@ -32764,9 +32764,9 @@
       }
     },
     "@bdelab/roam-fluency": {
-      "version": "1.11.24",
-      "resolved": "https://registry.npmjs.org/@bdelab/roam-fluency/-/roam-fluency-1.11.24.tgz",
-      "integrity": "sha512-Tag2e3oF6dxNcWk2bWVlQXue9LBv0ZC1QQwjtvDIcqfWDVl4KRc3OFhxGqQLsLwBvMoZ6kQAtBP5LhF44CF/Vg==",
+      "version": "1.11.26",
+      "resolved": "https://registry.npmjs.org/@bdelab/roam-fluency/-/roam-fluency-1.11.26.tgz",
+      "integrity": "sha512-XpaCXy+CtEIsp6CmKo+3vo55g7ZJL+g6l7KNCaiqvh9M7QAi+xS6QpsUh3PQkbQkAPlQzcc6f4P3+b4Oe2m6VA==",
       "requires": {
         "@bdelab/jscat": "^4.0.0",
         "@bdelab/roar-firekit": "^4.7.0",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "version": "npm run format && git add -A"
   },
   "dependencies": {
-    "@bdelab/roam-fluency": "1.11.24",
+    "@bdelab/roam-fluency": "1.11.26",
     "@bdelab/roar-firekit": "^7.1.0",
     "@bdelab/roar-letter": "1.11.5",
     "@bdelab/roar-multichoice": "^1.11.3",


### PR DESCRIPTION
This PR updates the version of `@bdelab/roam-fluency` to 1.11.26.