### PR TITLE
Update SRE version to 1.15.13

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@bdelab/roar-letter": "1.11.5",
         "@bdelab/roar-multichoice": "^1.11.3",
         "@bdelab/roar-pa": "2.2.4",
-        "@bdelab/roar-sre": "1.15.9",
+        "@bdelab/roar-sre": "1.15.13",
         "@bdelab/roar-swr": "^1.12.1",
         "@bdelab/roar-utils": "^1.2.1",
         "@bdelab/roar-vocab": "^1.8.0",
@@ -3824,9 +3824,9 @@
       }
     },
     "node_modules/@bdelab/roar-sre": {
-      "version": "1.15.9",
-      "resolved": "https://registry.npmjs.org/@bdelab/roar-sre/-/roar-sre-1.15.9.tgz",
-      "integrity": "sha512-G8MzjLVT2nJ4TCUjQiuPtneQeUFOQMExAwKK1D9u4q/o9DEwUfuooJiMPHExhuU0K8sIPTanH21snCN8GpOYbQ==",
+      "version": "1.15.13",
+      "resolved": "https://registry.npmjs.org/@bdelab/roar-sre/-/roar-sre-1.15.13.tgz",
+      "integrity": "sha512-QwxDg1il7MJEBEz70rezbreSAY+I41TCYZvOl1sbduemghtChklqCVwF7a9Kc6ge8x96lUJvJry79F2BRGiExQ==",
       "dependencies": {
         "@babel/core": "^7.19.3",
         "@babel/preset-env": "^7.19.4",
@@ -36872,9 +36872,9 @@
       }
     },
     "@bdelab/roar-sre": {
-      "version": "1.15.9",
-      "resolved": "https://registry.npmjs.org/@bdelab/roar-sre/-/roar-sre-1.15.9.tgz",
-      "integrity": "sha512-G8MzjLVT2nJ4TCUjQiuPtneQeUFOQMExAwKK1D9u4q/o9DEwUfuooJiMPHExhuU0K8sIPTanH21snCN8GpOYbQ==",
+      "version": "1.15.13",
+      "resolved": "https://registry.npmjs.org/@bdelab/roar-sre/-/roar-sre-1.15.13.tgz",
+      "integrity": "sha512-QwxDg1il7MJEBEz70rezbreSAY+I41TCYZvOl1sbduemghtChklqCVwF7a9Kc6ge8x96lUJvJry79F2BRGiExQ==",
       "requires": {
         "@babel/core": "^7.19.3",
         "@babel/preset-env": "^7.19.4",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@bdelab/roar-letter": "1.11.5",
     "@bdelab/roar-multichoice": "^1.11.3",
     "@bdelab/roar-pa": "2.2.4",
-    "@bdelab/roar-sre": "1.15.9",
+    "@bdelab/roar-sre": "1.15.13",
     "@bdelab/roar-swr": "^1.12.1",
     "@bdelab/roar-utils": "^1.2.1",
     "@bdelab/roar-vocab": "^1.8.0",


### PR DESCRIPTION
This PR updates the version of `@bdelab/roar-sre` to 1.15.13.