### PR TITLE
Extend `useUserType` with super admin capability check

### DIFF
--- a/src/composables/useUserType.js
+++ b/src/composables/useUserType.js
@@ -21,11 +21,11 @@ export default function useUserType(userClaims) {
 
     // Check if the user is a super admin.
     if (claims?.super_admin) {
-      return AUTH_USER_TYPE.ADMIN;
+      return AUTH_USER_TYPE.SUPER_ADMIN;
     }
 
     // Check if the user has any minimal admin organizations.
-    const minimalAdminOrgs = claims.minimalAdminOrgs || {};
+    const minimalAdminOrgs = claims?.minimalAdminOrgs || {};
     const hasMinimalAdminOrgs = Object.values(minimalAdminOrgs).some((org) => !_isEmpty(org));
 
     if (hasMinimalAdminOrgs) {
@@ -38,10 +38,12 @@ export default function useUserType(userClaims) {
 
   const isAdmin = computed(() => userType.value === AUTH_USER_TYPE.ADMIN);
   const isParticipant = computed(() => userType.value === AUTH_USER_TYPE.PARTICIPANT);
+  const isSuperAdmin = computed(() => userType.value === AUTH_USER_TYPE.SUPER_ADMIN);
 
   return {
     userType,
     isAdmin,
     isParticipant,
+    isSuperAdmin,
   };
 }

--- a/src/composables/useUserType.test.js
+++ b/src/composables/useUserType.test.js
@@ -4,13 +4,14 @@ import { AUTH_USER_TYPE } from '@/constants/auth';
 import useUserType from './useUserType';
 
 describe('useUserType', () => {
-  it('should return admin user type when user is a super admin', () => {
+  it('should return super admin user type when user is a super admin', () => {
     const userClaims = computed(() => ({ claims: { super_admin: true } }));
-    const { userType, isAdmin, isParticipant } = useUserType(userClaims);
+    const { userType, isAdmin, isParticipant, isSuperAdmin } = useUserType(userClaims);
 
-    expect(userType.value).toBe(AUTH_USER_TYPE.ADMIN);
-    expect(isAdmin.value).toBe(true);
+    expect(userType.value).toBe(AUTH_USER_TYPE.SUPER_ADMIN);
+    expect(isAdmin.value).toBe(false);
     expect(isParticipant.value).toBe(false);
+    expect(isSuperAdmin.value).toBe(true);
   });
 
   it('should return admin user type when user has minimal admin orgs', () => {
@@ -22,11 +23,12 @@ describe('useUserType', () => {
         },
       },
     }));
-    const { userType, isAdmin, isParticipant } = useUserType(userClaims);
+    const { userType, isAdmin, isParticipant, isSuperAdmin } = useUserType(userClaims);
 
     expect(userType.value).toBe(AUTH_USER_TYPE.ADMIN);
     expect(isAdmin.value).toBe(true);
     expect(isParticipant.value).toBe(false);
+    expect(isSuperAdmin.value).toBe(false);
   });
 
   it('should return participant user type when user is not a super admin and has no minimal admin orgs', () => {
@@ -36,19 +38,21 @@ describe('useUserType', () => {
         minimalAdminOrgs: {},
       },
     }));
-    const { userType, isAdmin, isParticipant } = useUserType(userClaims);
+    const { userType, isAdmin, isParticipant, isSuperAdmin } = useUserType(userClaims);
 
     expect(userType.value).toBe(AUTH_USER_TYPE.PARTICIPANT);
     expect(isAdmin.value).toBe(false);
     expect(isParticipant.value).toBe(true);
+    expect(isSuperAdmin.value).toBe(false);
   });
 
   it('should return undefined user type when no claims are provided', () => {
     const userClaims = computed(() => null);
-    const { userType, isAdmin, isParticipant } = useUserType(userClaims);
+    const { userType, isAdmin, isParticipant, isSuperAdmin } = useUserType(userClaims);
 
     expect(userType.value).toBe(undefined);
     expect(isAdmin.value).toBe(false);
     expect(isParticipant.value).toBe(false);
+    expect(isSuperAdmin.value).toBe(false);
   });
 });

--- a/src/constants/auth.js
+++ b/src/constants/auth.js
@@ -19,4 +19,5 @@ export const AUTH_SESSION_TIMEOUT_COUNTDOWN_DURATION =
 export const AUTH_USER_TYPE = {
   ADMIN: 'admin',
   PARTICIPANT: 'participant',
+  SUPER_ADMIN: 'super_admin',
 };


### PR DESCRIPTION
## Proposed changes
This PR extends the `useUserType` composable introduced in #751 with the capability to check for super admin status.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (non-breaking change that does not add functionality but makes code cleaner or more efficient)
- [ ] Documentation Update
- [ ] Tests (new or updated tests)
- [ ] Style (changes to code styling)
- [ ] CI (continuous integration changes)
- [ ] Repository Maintenance
- [ ] Other (please describe below)

## Checklist
- [x] I have read the [guidelines for contributing](https://github.com/yeatmanlab/roar-dashboard/blob/main/.github/CONTRIBUTING.md).
- [x] The changes in this PR are as small as they can be. They represent one and only one fix or enhancement.
- [x] Linting checks pass with my changes.
- [x] Any existing unit tests pass with my changes.
- [x] Any existing end-to-end tests pass with my changes.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] If this PR fixes an existing issue, I have added a unit or end-to-end test that will detect if this issue reoccurs.
- [x] I have added JSDoc comments as appropriate.
- [ ] I have added the necessary documentation to the [roar-docs repository](https://github.com/yeatmanlab/roar-docs).
- [x] I have shared this PR on the roar-pr-reviews channel (if I have access)
- [ ] I have linked relevant issues (if any)

## Justification of missing checklist items
n/a

## Further comments
n/a