### PR TITLE
Migrate Participant Homepage to composable TanStack queries

### DIFF
--- a/src/components/tasks/ManageTasks.vue
+++ b/src/components/tasks/ManageTasks.vue
@@ -505,7 +505,7 @@ onMounted(() => {
   if (roarfirekit.value.restConfig) init();
 });
 
-const { data: tasks } = useTasksQuery(registeredTasksOnly, {
+const { data: tasks } = useTasksQuery(registeredTasksOnly, null, {
   enabled: initialized,
 });
 

--- a/src/components/views/OfflineSettings.vue
+++ b/src/components/views/OfflineSettings.vue
@@ -148,8 +148,8 @@
       <div class="mr-2">
         <PvButton
           class="m-0 bg-primary text-white border-none border-round h-2rem text-md hover:bg-red-900"
-          @click="saveOfflineSettings"
           :disabled="isSubmitting"
+          @click="saveOfflineSettings"
         >
           <i v-if="isSubmitting" class="pi pi-spinner pi-spin mr-2" />
           Save Settings
@@ -165,7 +165,7 @@ import { useAuthStore } from '@/store/auth';
 import { storeToRefs } from 'pinia';
 import { useToast } from 'primevue/usetoast';
 import { orderByDefault } from '@/helpers/query/utils';
-import useAdministrationsQuery from '@/composables/queries/useAdministrationsQuery';
+import useAdministrationsListQuery from '@/composables/queries/useAdministrationsListQuery';
 import useUserDataQuery from '@/composables/queries/useUserDataQuery';
 import useTasksQuery from '@/composables/queries/useTasksQuery';
 import useUpdateUserMutation from '@/composables/mutations/useUpdateUserMutation';
@@ -194,11 +194,11 @@ const { data: userData, isLoading: isLoadingUserData } = useUserDataQuery({
 const offlineEnabled = ref(userData?.offlineEnabled ?? false);
 
 const { data: tasks } = useTasksQuery(false, {
-  enabled: initialized && offlineEnabled,
+  enabled: initialized.value && offlineEnabled,
 });
 
-const { isLoading: isLoadingAdministrations, data: administrations } = useAdministrationsQuery(orderBy, {
-  enabled: initialized && offlineEnabled,
+const { isLoading: isLoadingAdministrations, data: administrations } = useAdministrationsListQuery(orderBy, {
+  enabled: initialized.value && offlineEnabled,
 });
 
 const formattedTasks = computed(() => {

--- a/src/components/views/OfflineSettings.vue
+++ b/src/components/views/OfflineSettings.vue
@@ -193,7 +193,7 @@ const { data: userData, isLoading: isLoadingUserData } = useUserDataQuery({
 
 const offlineEnabled = ref(userData?.offlineEnabled ?? false);
 
-const { data: tasks } = useTasksQuery(false, {
+const { data: tasks } = useTasksQuery(false, null, {
   enabled: initialized.value && offlineEnabled,
 });
 

--- a/src/composables/queries/useAdministrationsListQuery.js
+++ b/src/composables/queries/useAdministrationsListQuery.js
@@ -1,0 +1,60 @@
+import { computed, ref, toValue } from 'vue';
+import { useQuery } from '@tanstack/vue-query';
+import _isEmpty from 'lodash/isEmpty';
+import { administrationPageFetcher } from '@/helpers/query/administrations';
+import useUserClaimsQuery from '@/composables/queries/useUserClaimsQuery';
+import useUserType from '@/composables/useUserType';
+import { ADMINISTRATIONS_LIST_QUERY_KEY } from '@/constants/queryKeys';
+
+/**
+ * Administrations list query.
+ *
+ * @param {ref<String>} orderBy – A Vue ref containing the field to order the query by.
+ * @param {ref<Boolean>} [testAdministrationsOnly=false] – A Vue ref containing whether to fetch only test data.
+ * @param {QueryOptions|undefined} queryOptions – Optional TanStack query options.
+ * @returns {UseQueryResult} The TanStack query result.
+ */
+const useAdministrationsListQuery = (orderBy, testAdministrationsOnly = false, queryOptions = undefined) => {
+  // Fetch the user claims.
+  const { data: userClaims } = useUserClaimsQuery({
+    enabled: queryOptions?.enabled ?? true,
+  });
+
+  // Get admin status and administation orgs.
+  const { isSuperAdmin } = useUserType(userClaims);
+  const administrationOrgs = computed(() => userClaims.value?.claims?.minimalAdminOrgs);
+  const exhaustiveAdministrationOrgs = computed(() => userClaims.value?.claims?.adminOrgs);
+
+  // Ensure all necessary data is loaded before enabling the query.
+  const claimsLoaded = computed(() => !_isEmpty(userClaims?.value?.claims));
+  const isQueryEnabled = computed(() => claimsLoaded.value && (queryOptions?.enabled ?? true));
+
+  // Set pagination data to fetch all administrations since pagination is not yet supported.
+  const currentPage = ref(0);
+  const itemsPerPage = ref(10000);
+
+  // Build query key, based on whether or not we only fetch test administrations.
+  const queryKey = computed(() =>
+    toValue(testAdministrationsOnly)
+      ? [ADMINISTRATIONS_LIST_QUERY_KEY, 'test-data', currentPage, itemsPerPage, orderBy]
+      : [ADMINISTRATIONS_LIST_QUERY_KEY, currentPage, itemsPerPage, orderBy],
+  );
+
+  return useQuery({
+    queryKey,
+    queryFn: () =>
+      administrationPageFetcher(
+        orderBy,
+        itemsPerPage,
+        currentPage,
+        isSuperAdmin,
+        administrationOrgs,
+        exhaustiveAdministrationOrgs,
+        testAdministrationsOnly,
+      ),
+    enabled: isQueryEnabled,
+    ...queryOptions,
+  });
+};
+
+export default useAdministrationsListQuery;

--- a/src/composables/queries/useAdministrationsQuery.js
+++ b/src/composables/queries/useAdministrationsQuery.js
@@ -1,58 +1,28 @@
-import { computed, ref, toValue } from 'vue';
 import { useQuery } from '@tanstack/vue-query';
-import _isEmpty from 'lodash/isEmpty';
-import { administrationPageFetcher } from '@/helpers/query/administrations';
-import useUserClaimsQuery from '@/composables/queries/useUserClaimsQuery';
-import useUserType from '@/composables/useUserType';
+import { fetchDocsById } from '@/helpers/query/utils';
 import { ADMINISTRATIONS_QUERY_KEY } from '@/constants/queryKeys';
+import { FIRESTORE_COLLECTIONS } from '@/constants/firebase';
 
 /**
  * Administrations query.
  *
- * @param {ref<String>} orderBy – A Vue ref containing the field to order the query by.
- * @param {ref<Boolean>} [testAdministrationsOnly=false] – A Vue ref containing whether to fetch only test data.
+ * @param {ref<Array<String>>} administrationIds – A Vue ref containing an array of administration IDs to fetch.
  * @param {QueryOptions|undefined} queryOptions – Optional TanStack query options.
  * @returns {UseQueryResult} The TanStack query result.
  */
-const useAdministrationsQuery = (orderBy, testAdministrationsOnly = false, queryOptions = undefined) => {
-  // Fetch the user claims.
-  const { data: userClaims } = useUserClaimsQuery({
-    enabled: queryOptions?.enabled ?? true,
-  });
-
-  // Get admin status and administation orgs.
-  const { isSuperAdmin } = useUserType(userClaims);
-  const administrationOrgs = computed(() => userClaims.value?.claims?.minimalAdminOrgs);
-  const exhaustiveAdministrationOrgs = computed(() => userClaims.value?.claims?.adminOrgs);
-
-  // Ensure all necessary data is loaded before enabling the query.
-  const claimsLoaded = computed(() => !_isEmpty(userClaims?.value?.claims));
-  const isQueryEnabled = computed(() => claimsLoaded.value && (queryOptions?.enabled ?? true));
-
-  // Set pagination data to fetch all administrations since pagination is not yet supported.
-  const currentPage = ref(0);
-  const itemsPerPage = ref(10000);
-
-  // Build query key, based on whether or not we only fetch test administrations.
-  const queryKey = computed(() =>
-    toValue(testAdministrationsOnly)
-      ? [ADMINISTRATIONS_QUERY_KEY, 'test-data', currentPage, itemsPerPage, orderBy]
-      : [ADMINISTRATIONS_QUERY_KEY, currentPage, itemsPerPage, orderBy],
-  );
-
+const useAdministrationsQuery = (administrationIds, queryOptions = undefined) => {
   return useQuery({
-    queryKey,
+    queryKey: [ADMINISTRATIONS_QUERY_KEY, administrationIds],
     queryFn: () =>
-      administrationPageFetcher(
-        orderBy,
-        itemsPerPage,
-        currentPage,
-        isSuperAdmin,
-        administrationOrgs,
-        exhaustiveAdministrationOrgs,
-        testAdministrationsOnly,
+      fetchDocsById(
+        administrationIds?.value.map((administrationId) => {
+          return {
+            collection: FIRESTORE_COLLECTIONS.ADMINISTRATIONS,
+            docId: administrationId,
+            select: ['name', 'publicName', 'sequential', 'assessments', 'legal'],
+          };
+        }),
       ),
-    enabled: isQueryEnabled,
     ...queryOptions,
   });
 };

--- a/src/composables/queries/useSurveyResponsesQuery.js
+++ b/src/composables/queries/useSurveyResponsesQuery.js
@@ -1,4 +1,4 @@
-import { computed } from 'vue';
+import { computed, toValue } from 'vue';
 import { useQuery } from '@tanstack/vue-query';
 import { storeToRefs } from 'pinia';
 import { useAuthStore } from '@/store/auth';
@@ -16,7 +16,7 @@ const useSurveyResponsesQuery = (queryOptions = undefined) => {
   const authStore = useAuthStore();
   const { uid } = storeToRefs(authStore);
 
-  const isQueryEnabled = computed(() => !!uid.value && (queryOptions?.enabled ?? true));
+  const isQueryEnabled = computed(() => !!uid.value && (toValue(queryOptions?.enabled) ?? true));
 
   const options = queryOptions ? { ...queryOptions } : {};
   delete options.enabled;

--- a/src/composables/queries/useSurveyResponsesQuery.js
+++ b/src/composables/queries/useSurveyResponsesQuery.js
@@ -1,0 +1,32 @@
+import { computed } from 'vue';
+import { useQuery } from '@tanstack/vue-query';
+import { storeToRefs } from 'pinia';
+import { useAuthStore } from '@/store/auth';
+import { fetchSubcollection } from '@/helpers/query/utils';
+import { SURVEY_RESPONSES_QUERY_KEY } from '@/constants/queryKeys';
+import { FIRESTORE_COLLECTIONS } from '@/constants/firebase';
+
+/**
+ * Survey responses query.
+ *
+ * @param {QueryOptions|undefined} queryOptions – Optional TanStack query options.
+ * @returns {UseQueryResult} The TanStack query result.
+ */
+const useSurveyResponsesQuery = (queryOptions = undefined) => {
+  const authStore = useAuthStore();
+  const { uid } = storeToRefs(authStore);
+
+  const isQueryEnabled = computed(() => !!uid.value && (queryOptions?.enabled ?? true));
+
+  const options = queryOptions ? { ...queryOptions } : {};
+  delete options.enabled;
+
+  return useQuery({
+    queryKey: [SURVEY_RESPONSES_QUERY_KEY],
+    queryFn: () => fetchSubcollection(`${FIRESTORE_COLLECTIONS.USERS}/${uid.value}`, 'surveyResponses'),
+    enabled: isQueryEnabled,
+    ...options,
+  });
+};
+
+export default useSurveyResponsesQuery;

--- a/src/composables/queries/useSurveyResponsesQuery.js
+++ b/src/composables/queries/useSurveyResponsesQuery.js
@@ -14,16 +14,16 @@ import { FIRESTORE_COLLECTIONS } from '@/constants/firebase';
  */
 const useSurveyResponsesQuery = (queryOptions = undefined) => {
   const authStore = useAuthStore();
-  const { uid } = storeToRefs(authStore);
+  const { roarUid } = storeToRefs(authStore);
 
-  const isQueryEnabled = computed(() => !!uid.value && (toValue(queryOptions?.enabled) ?? true));
+  const isQueryEnabled = computed(() => !!roarUid.value && (toValue(queryOptions?.enabled) ?? true));
 
   const options = queryOptions ? { ...queryOptions } : {};
   delete options.enabled;
 
   return useQuery({
     queryKey: [SURVEY_RESPONSES_QUERY_KEY],
-    queryFn: () => fetchSubcollection(`${FIRESTORE_COLLECTIONS.USERS}/${uid.value}`, 'surveyResponses'),
+    queryFn: () => fetchSubcollection(`${FIRESTORE_COLLECTIONS.USERS}/${roarUid.value}`, 'surveyResponses'),
     enabled: isQueryEnabled,
     ...options,
   });

--- a/src/composables/queries/useSurveyResponsesQuery.test.js
+++ b/src/composables/queries/useSurveyResponsesQuery.test.js
@@ -34,7 +34,7 @@ describe('useSurveyResponsesQuery', () => {
 
   it('should call useQuery with correct parameters', () => {
     const authStore = useAuthStore(piniaInstance);
-    authStore.uid = 'mock-uid-1';
+    authStore.roarUid = 'mock-roarUid-1';
 
     vi.spyOn(VueQuery, 'useQuery');
 
@@ -55,18 +55,18 @@ describe('useSurveyResponsesQuery', () => {
 
   it('should call fetchSubcollection with correct parameters', () => {
     const authStore = useAuthStore(piniaInstance);
-    authStore.uid = 'mock-uid-1';
+    authStore.roarUid = 'mock-roarUid-1';
 
     withSetup(() => useSurveyResponsesQuery(), {
       plugins: [[VueQuery.VueQueryPlugin, { queryClient }]],
     });
 
-    expect(fetchSubcollection).toHaveBeenCalledWith('users/mock-uid-1', 'surveyResponses');
+    expect(fetchSubcollection).toHaveBeenCalledWith('users/mock-roarUid-1', 'surveyResponses');
   });
 
   it('should correctly control the enabled state of the query', async () => {
     const authStore = useAuthStore(piniaInstance);
-    authStore.uid = 'mock-uid-1';
+    authStore.roarUid = 'mock-roarUid-1';
 
     const enableQuery = ref(false);
 

--- a/src/composables/queries/useSurveyResponsesQuery.test.js
+++ b/src/composables/queries/useSurveyResponsesQuery.test.js
@@ -1,0 +1,110 @@
+import { computed, ref, nextTick } from 'vue';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { createTestingPinia } from '@pinia/testing';
+import * as VueQuery from '@tanstack/vue-query';
+import { withSetup } from '@/test-support/withSetup.js';
+import { useAuthStore } from '@/store/auth';
+import { fetchSubcollection } from '@/helpers/query/utils';
+import useSurveyResponsesQuery from './useSurveyResponsesQuery';
+
+vi.mock('@/helpers/query/utils', () => ({
+  fetchSubcollection: vi.fn().mockImplementation(() => []),
+}));
+
+vi.mock('@tanstack/vue-query', async (getModule) => {
+  const original = await getModule();
+  return {
+    ...original,
+    useQuery: vi.fn().mockImplementation(original.useQuery),
+  };
+});
+
+describe('useSurveyResponsesQuery', () => {
+  let piniaInstance;
+  let queryClient;
+
+  beforeEach(() => {
+    piniaInstance = createTestingPinia();
+    queryClient = new VueQuery.QueryClient();
+  });
+
+  afterEach(() => {
+    queryClient?.clear();
+  });
+
+  it('should call useQuery with correct parameters', () => {
+    const authStore = useAuthStore(piniaInstance);
+    authStore.uid = 'mock-uid-1';
+
+    vi.spyOn(VueQuery, 'useQuery');
+
+    withSetup(() => useSurveyResponsesQuery(), {
+      plugins: [[VueQuery.VueQueryPlugin, { queryClient }]],
+    });
+
+    expect(VueQuery.useQuery).toHaveBeenCalledWith({
+      queryKey: ['survey-responses'],
+      queryFn: expect.any(Function),
+      enabled: expect.objectContaining({
+        _value: true,
+        __v_isRef: true,
+        __v_isReadonly: true,
+      }),
+    });
+  });
+
+  it('should call fetchSubcollection with correct parameters', () => {
+    const authStore = useAuthStore(piniaInstance);
+    authStore.uid = 'mock-uid-1';
+
+    withSetup(() => useSurveyResponsesQuery(), {
+      plugins: [[VueQuery.VueQueryPlugin, { queryClient }]],
+    });
+
+    expect(fetchSubcollection).toHaveBeenCalledWith('users/mock-uid-1', 'surveyResponses');
+  });
+
+  it('should correctly control the enabled state of the query', async () => {
+    const authStore = useAuthStore(piniaInstance);
+    authStore.uid = 'mock-uid-1';
+
+    const enableQuery = ref(false);
+
+    const queryOptions = {
+      enabled: computed(() => enableQuery.value),
+    };
+
+    withSetup(() => useSurveyResponsesQuery(queryOptions), {
+      plugins: [[VueQuery.VueQueryPlugin, { queryClient }]],
+    });
+
+    expect(VueQuery.useQuery).toHaveBeenCalledWith({
+      queryKey: ['survey-responses'],
+      queryFn: expect.any(Function),
+      enabled: expect.objectContaining({
+        _value: false,
+        __v_isRef: true,
+        __v_isReadonly: true,
+      }),
+    });
+
+    expect(fetchSubcollection).not.toHaveBeenCalled();
+
+    enableQuery.value = true;
+    await nextTick();
+
+    expect(fetchSubcollection).toHaveBeenCalled();
+  });
+
+  // it('should call fetchSubcollection with correct parameters', async () => {
+  //   const authStore = useAuthStore(piniaInstance);
+  //   authStore.roarUid = 'mock-roar-uid-2';
+  //   authStore.userQueryKeyIndex = 2;
+
+  //   withSetup(() => useSurveyResponsesQuery(), {
+  //     plugins: [[VueQuery.VueQueryPlugin, { queryClient }]],
+  //   });
+
+  //   expect(fetchSubcollection).toHaveBeenCalledWith('users', authStore.roarUid);
+  // });
+});

--- a/src/composables/queries/useTasksQuery.js
+++ b/src/composables/queries/useTasksQuery.js
@@ -21,6 +21,8 @@ const useTasksQuery = (registeredTasksOnly = false, taskIds = undefined, queryOp
 
   const queryFn = !_isEmpty(taskIds) ? () => fetchByTaskId(taskIds) : () => taskFetcher(registeredTasksOnly, true);
 
+  console.log(!_isEmpty(taskIds) ? 'fetchByTaskId' : 'taskFetcher');
+
   return useQuery({
     queryKey,
     queryFn,

--- a/src/composables/queries/useTasksQuery.js
+++ b/src/composables/queries/useTasksQuery.js
@@ -1,6 +1,8 @@
 import { toValue } from 'vue';
 import { useQuery } from '@tanstack/vue-query';
+import _isEmpty from 'lodash/isEmpty';
 import { taskFetcher } from '@/helpers/query/tasks';
+import { fetchDocsById } from '@/helpers/query/utils';
 import { TASKS_QUERY_KEY } from '@/constants/queryKeys';
 
 /**
@@ -10,12 +12,27 @@ import { TASKS_QUERY_KEY } from '@/constants/queryKeys';
  * @param {QueryOptions|undefined} queryOptions – Optional TanStack query options.
  * @returns {UseQueryResult} The TanStack query result.
  */
-const useTasksQuery = (registeredTasksOnly = false, queryOptions = undefined) => {
-  const queryKey = toValue(registeredTasksOnly) ? [TASKS_QUERY_KEY, 'registered'] : [TASKS_QUERY_KEY];
+const useTasksQuery = (registeredTasksOnly = false, taskIds = undefined, queryOptions = undefined) => {
+  const queryKey = toValue(registeredTasksOnly)
+    ? [TASKS_QUERY_KEY, 'registered']
+    : !_isEmpty(taskIds)
+    ? [TASKS_QUERY_KEY, taskIds]
+    : [TASKS_QUERY_KEY];
+
+  const queryFn = taskIds
+    ? () =>
+        fetchDocsById(
+          taskIds.value.map((taskId) => ({
+            collection: 'tasks',
+            docId: taskId,
+          })),
+          'app',
+        )
+    : () => taskFetcher(registeredTasksOnly, true);
 
   return useQuery({
     queryKey,
-    queryFn: () => taskFetcher(registeredTasksOnly, true),
+    queryFn,
     ...queryOptions,
   });
 };

--- a/src/composables/queries/useTasksQuery.js
+++ b/src/composables/queries/useTasksQuery.js
@@ -21,8 +21,6 @@ const useTasksQuery = (registeredTasksOnly = false, taskIds = undefined, queryOp
 
   const queryFn = !_isEmpty(taskIds) ? () => fetchByTaskId(taskIds) : () => taskFetcher(registeredTasksOnly, true);
 
-  console.log(!_isEmpty(taskIds) ? 'fetchByTaskId' : 'taskFetcher');
-
   return useQuery({
     queryKey,
     queryFn,

--- a/src/composables/queries/useTasksQuery.js
+++ b/src/composables/queries/useTasksQuery.js
@@ -1,14 +1,14 @@
 import { toValue } from 'vue';
 import { useQuery } from '@tanstack/vue-query';
 import _isEmpty from 'lodash/isEmpty';
-import { taskFetcher } from '@/helpers/query/tasks';
-import { fetchDocsById } from '@/helpers/query/utils';
+import { taskFetcher, fetchByTaskId } from '@/helpers/query/tasks';
 import { TASKS_QUERY_KEY } from '@/constants/queryKeys';
 
 /**
  * Tasks query.
  *
- * @param {Boolean} [registeredTasksOnly=false] – Whether to fetch only registered tasks.
+ * @param {ref<Boolean>} [registeredTasksOnly=false] – Whether to fetch only registered tasks.
+ * @param {ref<Array<String>>|undefined} [taskIds=undefined] – An optional array of task IDs to fetch.
  * @param {QueryOptions|undefined} queryOptions – Optional TanStack query options.
  * @returns {UseQueryResult} The TanStack query result.
  */
@@ -19,16 +19,7 @@ const useTasksQuery = (registeredTasksOnly = false, taskIds = undefined, queryOp
     ? [TASKS_QUERY_KEY, taskIds]
     : [TASKS_QUERY_KEY];
 
-  const queryFn = taskIds
-    ? () =>
-        fetchDocsById(
-          taskIds.value.map((taskId) => ({
-            collection: 'tasks',
-            docId: taskId,
-          })),
-          'app',
-        )
-    : () => taskFetcher(registeredTasksOnly, true);
+  const queryFn = taskIds ? () => fetchByTaskId(taskIds) : () => taskFetcher(registeredTasksOnly, true);
 
   return useQuery({
     queryKey,

--- a/src/composables/queries/useTasksQuery.js
+++ b/src/composables/queries/useTasksQuery.js
@@ -19,7 +19,7 @@ const useTasksQuery = (registeredTasksOnly = false, taskIds = undefined, queryOp
     ? [TASKS_QUERY_KEY, taskIds]
     : [TASKS_QUERY_KEY];
 
-  const queryFn = taskIds ? () => fetchByTaskId(taskIds) : () => taskFetcher(registeredTasksOnly, true);
+  const queryFn = !_isEmpty(taskIds) ? () => fetchByTaskId(taskIds) : () => taskFetcher(registeredTasksOnly, true);
 
   return useQuery({
     queryKey,

--- a/src/composables/queries/useTasksQuery.test.js
+++ b/src/composables/queries/useTasksQuery.test.js
@@ -1,11 +1,13 @@
+import { ref } from 'vue';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { withSetup } from '@/test-support/withSetup.js';
 import * as VueQuery from '@tanstack/vue-query';
-import { taskFetcher } from '@/helpers/query/tasks';
+import { taskFetcher, fetchByTaskId } from '@/helpers/query/tasks';
 import useTasksQuery from './useTasksQuery';
 
 vi.mock('@/helpers/query/tasks', () => ({
   taskFetcher: vi.fn().mockImplementation(() => []),
+  fetchByTaskId: vi.fn().mockImplementation(() => []),
 }));
 
 vi.mock('@tanstack/vue-query', async (getModule) => {
@@ -21,53 +23,65 @@ describe('useTasksQuery', () => {
 
   beforeEach(() => {
     queryClient = new VueQuery.QueryClient();
+    // vi.resetAllMocks();
   });
 
   afterEach(() => {
     queryClient?.clear();
   });
 
-  it('should call useQuery with correct parameters', () => {
-    const fetchRegisteredTasks = false;
-    const queryOptions = { enabled: false };
-
+  it('should call useQuery with correct parameters when fetching all tasks', () => {
     vi.spyOn(VueQuery, 'useQuery');
 
-    withSetup(() => useTasksQuery(fetchRegisteredTasks, queryOptions), {
+    withSetup(() => useTasksQuery(), {
       plugins: [[VueQuery.VueQueryPlugin, { queryClient }]],
     });
 
     expect(VueQuery.useQuery).toHaveBeenCalledWith({
       queryKey: ['tasks'],
       queryFn: expect.any(Function),
-      enabled: false,
     });
+
+    expect(taskFetcher).toHaveBeenCalledWith(false, true);
   });
 
-  it('should set the alternate query key if fetching registered tasks only', () => {
+  it('should call useQuery with correct parameters when fetching registered tasks', () => {
     const fetchRegisteredTasks = true;
-    const queryOptions = { enabled: false };
+    const taskIds = null;
+    const queryOptions = { enabled: true };
 
     vi.spyOn(VueQuery, 'useQuery');
 
-    withSetup(() => useTasksQuery(fetchRegisteredTasks, queryOptions), {
+    withSetup(() => useTasksQuery(fetchRegisteredTasks, taskIds, queryOptions), {
       plugins: [[VueQuery.VueQueryPlugin, { queryClient }]],
     });
 
     expect(VueQuery.useQuery).toHaveBeenCalledWith({
       queryKey: ['tasks', 'registered'],
       queryFn: expect.any(Function),
-      enabled: false,
+      enabled: true,
     });
+
+    expect(taskFetcher).toHaveBeenCalledWith(true, true);
   });
 
-  it('should call useTasksQuery with correct parameters', async () => {
+  it('should call useQuery with correct parameters when fetching specific tasks', () => {
     const fetchRegisteredTasks = false;
+    const taskIds = ref(['mock-task-1', 'mock-task-2']);
+    const queryOptions = { enabled: true };
 
-    withSetup(() => useTasksQuery(fetchRegisteredTasks), {
+    vi.spyOn(VueQuery, 'useQuery');
+
+    withSetup(() => useTasksQuery(fetchRegisteredTasks, taskIds, queryOptions), {
       plugins: [[VueQuery.VueQueryPlugin, { queryClient }]],
     });
 
-    expect(taskFetcher).toHaveBeenCalledWith(fetchRegisteredTasks, true);
+    expect(VueQuery.useQuery).toHaveBeenCalledWith({
+      queryKey: ['tasks', taskIds],
+      queryFn: expect.any(Function),
+      enabled: true,
+    });
+
+    expect(fetchByTaskId).toHaveBeenCalledWith(taskIds);
   });
 });

--- a/src/composables/queries/useTasksQuery.test.js
+++ b/src/composables/queries/useTasksQuery.test.js
@@ -23,7 +23,6 @@ describe('useTasksQuery', () => {
 
   beforeEach(() => {
     queryClient = new VueQuery.QueryClient();
-    // vi.resetAllMocks();
   });
 
   afterEach(() => {

--- a/src/composables/queries/useUserAssignmentsQuery.js
+++ b/src/composables/queries/useUserAssignmentsQuery.js
@@ -3,18 +3,19 @@ import { storeToRefs } from 'pinia';
 import { useAuthStore } from '@/store/auth';
 import { getUserAssignments } from '@/helpers/query/assignments';
 import { USER_ASSIGNMENTS_QUERY_KEY } from '@/constants/queryKeys';
+
 /**
  * User assignments query.
  *
  * @param {QueryOptions|undefined} queryOptions – Optional TanStack query options.
  * @returns {UseQueryResult} The TanStack query result.
  */
-const useUserAssignments = (queryOptions = undefined) => {
+const useUserAssignmentsQuery = (queryOptions = undefined) => {
   const authStore = useAuthStore();
   const { roarUid } = storeToRefs(authStore);
 
   return useQuery({
-    queryKey: [USER_ASSIGNMENTS_QUERY_KEY, roarUid.value, userQueryKeyIndex.value],
+    queryKey: [USER_ASSIGNMENTS_QUERY_KEY, roarUid],
     queryFn: () => getUserAssignments(roarUid.value),
     // Refetch on window focus for MEFS assessments as those are opened in a separate tab.
     refetchOnWindowFocus: 'always',
@@ -22,4 +23,4 @@ const useUserAssignments = (queryOptions = undefined) => {
   });
 };
 
-export default useUserAssignments;
+export default useUserAssignmentsQuery;

--- a/src/composables/queries/useUserAssignmentsQuery.js
+++ b/src/composables/queries/useUserAssignmentsQuery.js
@@ -1,3 +1,4 @@
+import { computed } from 'vue';
 import { useQuery } from '@tanstack/vue-query';
 import { storeToRefs } from 'pinia';
 import { useAuthStore } from '@/store/auth';
@@ -14,12 +15,18 @@ const useUserAssignmentsQuery = (queryOptions = undefined) => {
   const authStore = useAuthStore();
   const { roarUid } = storeToRefs(authStore);
 
+  const isQueryEnabled = computed(() => !!roarUid.value && (queryOptions?.enabled ?? true));
+
+  const options = queryOptions ? { ...queryOptions } : {};
+  delete options.enabled;
+
   return useQuery({
     queryKey: [USER_ASSIGNMENTS_QUERY_KEY, roarUid],
     queryFn: () => getUserAssignments(roarUid.value),
     // Refetch on window focus for MEFS assessments as those are opened in a separate tab.
     refetchOnWindowFocus: 'always',
-    ...queryOptions,
+    enabled: isQueryEnabled,
+    ...options,
   });
 };
 

--- a/src/composables/queries/useUserAssignmentsQuery.js
+++ b/src/composables/queries/useUserAssignmentsQuery.js
@@ -1,4 +1,4 @@
-import { computed } from 'vue';
+import { computed, toValue } from 'vue';
 import { useQuery } from '@tanstack/vue-query';
 import { storeToRefs } from 'pinia';
 import { useAuthStore } from '@/store/auth';
@@ -15,13 +15,13 @@ const useUserAssignmentsQuery = (queryOptions = undefined) => {
   const authStore = useAuthStore();
   const { roarUid } = storeToRefs(authStore);
 
-  const isQueryEnabled = computed(() => !!roarUid.value && (queryOptions?.enabled ?? true));
+  const isQueryEnabled = computed(() => !!roarUid.value && (toValue(queryOptions?.enabled) ?? true));
 
   const options = queryOptions ? { ...queryOptions } : {};
   delete options.enabled;
 
   return useQuery({
-    queryKey: [USER_ASSIGNMENTS_QUERY_KEY, roarUid],
+    queryKey: [USER_ASSIGNMENTS_QUERY_KEY],
     queryFn: () => getUserAssignments(roarUid.value),
     // Refetch on window focus for MEFS assessments as those are opened in a separate tab.
     refetchOnWindowFocus: 'always',

--- a/src/composables/queries/useUserAssignmentsQuery.js
+++ b/src/composables/queries/useUserAssignmentsQuery.js
@@ -1,0 +1,25 @@
+import { useQuery } from '@tanstack/vue-query';
+import { storeToRefs } from 'pinia';
+import { useAuthStore } from '@/store/auth';
+import { getUserAssignments } from '@/helpers/query/assignments';
+import { USER_ASSIGNMENTS_QUERY_KEY } from '@/constants/queryKeys';
+/**
+ * User assignments query.
+ *
+ * @param {QueryOptions|undefined} queryOptions – Optional TanStack query options.
+ * @returns {UseQueryResult} The TanStack query result.
+ */
+const useUserAssignments = (queryOptions = undefined) => {
+  const authStore = useAuthStore();
+  const { roarUid } = storeToRefs(authStore);
+
+  return useQuery({
+    queryKey: [USER_ASSIGNMENTS_QUERY_KEY, roarUid.value, userQueryKeyIndex.value],
+    queryFn: () => getUserAssignments(roarUid.value),
+    // Refetch on window focus for MEFS assessments as those are opened in a separate tab.
+    refetchOnWindowFocus: 'always',
+    ...queryOptions,
+  });
+};
+
+export default useUserAssignments;

--- a/src/composables/queries/useUserAssignmentsQuery.test.js
+++ b/src/composables/queries/useUserAssignmentsQuery.test.js
@@ -4,11 +4,11 @@ import { createTestingPinia } from '@pinia/testing';
 import * as VueQuery from '@tanstack/vue-query';
 import { withSetup } from '@/test-support/withSetup.js';
 import { useAuthStore } from '@/store/auth';
-import { fetchSubcollection } from '@/helpers/query/utils';
-import useSurveyResponsesQuery from './useSurveyResponsesQuery';
+import { getUserAssignments } from '@/helpers/query/assignments';
+import useUserAssignmentsQuery from './useUserAssignmentsQuery';
 
-vi.mock('@/helpers/query/utils', () => ({
-  fetchSubcollection: vi.fn().mockImplementation(() => []),
+vi.mock('@/helpers/query/assignments', () => ({
+  getUserAssignments: vi.fn().mockImplementation(() => []),
 }));
 
 vi.mock('@tanstack/vue-query', async (getModule) => {
@@ -19,7 +19,7 @@ vi.mock('@tanstack/vue-query', async (getModule) => {
   };
 });
 
-describe('useSurveyResponsesQuery', () => {
+describe('useUserAssignmentsQuery', () => {
   let piniaInstance;
   let queryClient;
 
@@ -34,39 +34,40 @@ describe('useSurveyResponsesQuery', () => {
 
   it('should call useQuery with correct parameters', () => {
     const authStore = useAuthStore(piniaInstance);
-    authStore.uid = 'mock-uid-1';
+    authStore.roarUid = 'mock-roar-id-1';
 
     vi.spyOn(VueQuery, 'useQuery');
 
-    withSetup(() => useSurveyResponsesQuery(), {
+    withSetup(() => useUserAssignmentsQuery(), {
       plugins: [[VueQuery.VueQueryPlugin, { queryClient }]],
     });
 
     expect(VueQuery.useQuery).toHaveBeenCalledWith({
-      queryKey: ['survey-responses'],
+      queryKey: ['user-assignments'],
       queryFn: expect.any(Function),
       enabled: expect.objectContaining({
         _value: true,
         __v_isRef: true,
         __v_isReadonly: true,
       }),
+      refetchOnWindowFocus: 'always',
     });
   });
 
-  it('should call fetchSubcollection with correct parameters', () => {
+  it('should call getUserAssignments with correct parameters', () => {
     const authStore = useAuthStore(piniaInstance);
-    authStore.uid = 'mock-uid-1';
+    authStore.roarUid = 'mock-roar-id-1';
 
-    withSetup(() => useSurveyResponsesQuery(), {
+    withSetup(() => useUserAssignmentsQuery(), {
       plugins: [[VueQuery.VueQueryPlugin, { queryClient }]],
     });
 
-    expect(fetchSubcollection).toHaveBeenCalledWith('users/mock-uid-1', 'surveyResponses');
+    expect(getUserAssignments).toHaveBeenCalledWith('mock-roar-id-1');
   });
 
   it('should correctly control the enabled state of the query', async () => {
     const authStore = useAuthStore(piniaInstance);
-    authStore.uid = 'mock-uid-1';
+    authStore.roarUid = 'mock-roar-id-1';
 
     const enableQuery = ref(false);
 
@@ -74,25 +75,26 @@ describe('useSurveyResponsesQuery', () => {
       enabled: computed(() => enableQuery.value),
     };
 
-    withSetup(() => useSurveyResponsesQuery(queryOptions), {
+    withSetup(() => useUserAssignmentsQuery(queryOptions), {
       plugins: [[VueQuery.VueQueryPlugin, { queryClient }]],
     });
 
     expect(VueQuery.useQuery).toHaveBeenCalledWith({
-      queryKey: ['survey-responses'],
+      queryKey: ['user-assignments'],
       queryFn: expect.any(Function),
       enabled: expect.objectContaining({
         _value: false,
         __v_isRef: true,
         __v_isReadonly: true,
       }),
+      refetchOnWindowFocus: 'always',
     });
 
-    expect(fetchSubcollection).not.toHaveBeenCalled();
+    expect(getUserAssignments).not.toHaveBeenCalled();
 
     enableQuery.value = true;
     await nextTick();
 
-    expect(fetchSubcollection).toHaveBeenCalled();
+    expect(getUserAssignments).toHaveBeenCalled();
   });
 });

--- a/src/constants/firebase.js
+++ b/src/constants/firebase.js
@@ -18,6 +18,7 @@ export const FIRESTORE_COLLECTIONS = Object.freeze({
   GROUPS: 'groups',
   LEGAL: 'legal',
   SCHOOLS: 'schools',
+  TASKS: 'tasks',
   USER_CLAIMS: 'userClaims',
   USERS: 'users',
 });

--- a/src/constants/firebase.js
+++ b/src/constants/firebase.js
@@ -1,4 +1,12 @@
 /**
+ * Firestore databases
+ */
+export const FIRESTORE_DATABASES = Object.freeze({
+  ADMIN: 'admin',
+  APP: 'app',
+});
+
+/**
  * Firestore database collections
  */
 export const FIRESTORE_COLLECTIONS = Object.freeze({

--- a/src/constants/queryKeys.js
+++ b/src/constants/queryKeys.js
@@ -1,4 +1,5 @@
 export const ADMINISTRATIONS_QUERY_KEY = 'administrations';
+export const ADMINISTRATIONS_LIST_QUERY_KEY = 'administrations-list';
 export const DISTRICTS_QUERY_KEY = 'districts';
 export const DISTRICT_SCHOOLS_QUERY_KEY = 'district-schools';
 export const DSGF_ORGS_QUERY_KEY = 'dsgf-orgs';

--- a/src/constants/queryKeys.js
+++ b/src/constants/queryKeys.js
@@ -10,5 +10,6 @@ export const SCHOOL_CLASSES_QUERY_KEY = 'school-classes';
 export const TASKS_QUERY_KEY = 'tasks';
 export const TASK_VARIANTS_QUERY_KEY = 'task-variants';
 export const USER_DATA_QUERY_KEY = 'user';
-export const USER_STUDENT_DATA_QUERY_KEY = 'user-student';
+export const USER_ASSIGNMENTS_QUERY_KEY = 'user-assignments';
 export const USER_CLAIMS_QUERY_KEY = 'user-claims';
+export const USER_STUDENT_DATA_QUERY_KEY = 'user-student';

--- a/src/constants/queryKeys.js
+++ b/src/constants/queryKeys.js
@@ -8,6 +8,7 @@ export const LEGAL_DOCS_QUERY_KEY = 'legal-docs';
 export const ORG_USERS_QUERY_KEY = 'org-users';
 export const ORGS_TABLE_QUERY_KEY = 'orgs-table';
 export const SCHOOL_CLASSES_QUERY_KEY = 'school-classes';
+export const SURVEY_RESPONSES_QUERY_KEY = 'survey-responses';
 export const TASKS_QUERY_KEY = 'tasks';
 export const TASK_VARIANTS_QUERY_KEY = 'task-variants';
 export const USER_DATA_QUERY_KEY = 'user';

--- a/src/helpers/query/assignments.js
+++ b/src/helpers/query/assignments.js
@@ -1,3 +1,4 @@
+import { toValue, toRaw } from 'vue';
 import _find from 'lodash/find';
 import _flatten from 'lodash/flatten';
 import _get from 'lodash/get';
@@ -9,7 +10,6 @@ import _without from 'lodash/without';
 import _isEmpty from 'lodash/isEmpty';
 import { convertValues, getAxiosInstance, getProjectId, mapFields } from './utils';
 import { pluralizeFirestoreCollection } from '@/helpers';
-import { toRaw } from 'vue';
 
 const userSelectFields = ['name', 'assessmentPid', 'username', 'studentData', 'schools', 'classes'];
 
@@ -1058,6 +1058,13 @@ export const assignmentPageFetcher = async (
   }
 };
 
+/**
+/**
+ * Fetches the assignments that are currently open for a user.
+ *
+ * @param {ref<String>} roarUid - A Vue ref containing the user's ROAR ID.
+ * @returns {Promise<Array>} - A promise that resolves to an array of open assignments for the user.
+ */
 export const getUserAssignments = async (roarUid) => {
   const adminAxiosInstance = getAxiosInstance();
   const assignmentRequest = getAssignmentsRequestBody({
@@ -1065,11 +1072,14 @@ export const getUserAssignments = async (roarUid) => {
     paginate: false,
     isCollectionGroupQuery: false,
   });
-  return await adminAxiosInstance.post(`/users/${roarUid}:runQuery`, assignmentRequest).then(async ({ data }) => {
-    const assignmentData = mapFields(data);
-    const openAssignments = assignmentData.filter((assignment) => new Date(assignment.dateOpened) <= new Date());
-    return openAssignments;
-  });
+  const userId = toValue(roarUid);
+  return await adminAxiosInstance
+    .post(`/users/${toValue(userId)}:runQuery`, assignmentRequest)
+    .then(async ({ data }) => {
+      const assignmentData = mapFields(data);
+      const openAssignments = assignmentData.filter((assignment) => new Date(assignment.dateOpened) <= new Date());
+      return openAssignments;
+    });
 };
 
 export const assignmentFetchAll = async (adminId, orgType, orgId, includeScores = false) => {

--- a/src/helpers/query/tasks.js
+++ b/src/helpers/query/tasks.js
@@ -1,7 +1,9 @@
+import { toValue } from 'vue';
 import _mapValues from 'lodash/mapValues';
 import _uniq from 'lodash/uniq';
 import _without from 'lodash/without';
-import { convertValues, getAxiosInstance, mapFields } from './utils';
+import { convertValues, getAxiosInstance, mapFields, fetchDocsById } from './utils';
+import { FIRESTORE_DATABASES } from '../../constants/firebase';
 
 export const getTasksRequestBody = ({
   registered = true,
@@ -77,6 +79,21 @@ export const taskFetcher = async (registered = true, allData = false, select = [
   });
 
   return axiosInstance.post(':runQuery', requestBody).then(({ data }) => mapFields(data));
+};
+
+/**
+ * Fetch task documents by their IDs.
+ *
+ * @param {Array<String>} taskIds – The array of task IDs to fetch.
+ * @returns {Promise<Array<Object>>} The array of task documents.
+ */
+export const fetchByTaskId = async (taskIds) => {
+  const taskDocs = toValue(taskIds).map((taskId) => ({
+    collection: FIRESTORE_COLLECTIONS.TASKS,
+    docId: taskId,
+  }));
+
+  return fetchDocsById(taskDocs, FIRESTORE_DATABASES.APP);
 };
 
 export const getVariantsRequestBody = ({ registered = false, aggregationQuery, pageLimit, page, paginate = false }) => {

--- a/src/helpers/query/tasks.js
+++ b/src/helpers/query/tasks.js
@@ -3,7 +3,7 @@ import _mapValues from 'lodash/mapValues';
 import _uniq from 'lodash/uniq';
 import _without from 'lodash/without';
 import { convertValues, getAxiosInstance, mapFields, fetchDocsById } from './utils';
-import { FIRESTORE_DATABASES } from '../../constants/firebase';
+import { FIRESTORE_DATABASES, FIRESTORE_COLLECTIONS } from '../../constants/firebase';
 
 export const getTasksRequestBody = ({
   registered = true,

--- a/src/helpers/query/utils.js
+++ b/src/helpers/query/utils.js
@@ -11,6 +11,7 @@ import _without from 'lodash/without';
 import { storeToRefs } from 'pinia';
 import { useAuthStore } from '@/store/auth';
 import { flattenObj } from '@/helpers';
+import { FIRESTORE_DATABASES } from '@/constants/firebase';
 
 export const convertValues = (value) => {
   const passThroughKeys = [
@@ -70,7 +71,7 @@ export const getProjectId = (project = 'admin') => {
   return roarfirekit.value.roarConfig?.[project]?.projectId;
 };
 
-export const getAxiosInstance = (db = 'admin', unauthenticated = false) => {
+export const getAxiosInstance = (db = FIRESTORE_DATABASES.ADMIN, unauthenticated = false) => {
   const authStore = useAuthStore();
   const { roarfirekit } = storeToRefs(authStore);
   const axiosOptions = _get(roarfirekit.value.restConfig, db) ?? {};
@@ -111,7 +112,7 @@ export const fetchDocById = async (
   collection,
   docId,
   select,
-  db = 'admin',
+  db = FIRESTORE_DATABASES.ADMIN,
   unauthenticated = false,
   swallowErrors = false,
 ) => {
@@ -144,7 +145,7 @@ export const fetchDocById = async (
     });
 };
 
-export const fetchDocsById = async (documents, db = 'admin') => {
+export const fetchDocsById = async (documents, db = FIRESTORE_DATABASES.ADMIN) => {
   if (_isEmpty(documents)) {
     console.warn('FetchDocsById: No documents provided!');
     return [];
@@ -168,7 +169,7 @@ export const fetchDocsById = async (documents, db = 'admin') => {
   return Promise.all(promises);
 };
 
-export const batchGetDocs = async (docPaths, select = [], db = 'admin') => {
+export const batchGetDocs = async (docPaths, select = [], db = FIRESTORE_DATABASES.ADMIN) => {
   if (_isEmpty(docPaths)) {
     console.warn('BatchGetDocs: No document paths provided!');
     return [];
@@ -211,7 +212,12 @@ export const matchMode2Op = {
   notEquals: 'NOT_EQUAL',
 };
 
-export const fetchSubcollection = async (collectionPath, subcollectionName, select = [], db = 'admin') => {
+export const fetchSubcollection = async (
+  collectionPath,
+  subcollectionName,
+  select = [],
+  db = FIRESTORE_DATABASES.ADMIN,
+) => {
   const axiosInstance = getAxiosInstance(db);
   // Construct the path to the subcollection
   const subcollectionPath = `/${collectionPath}/${subcollectionName}`;

--- a/src/pages/HomeAdministrator.vue
+++ b/src/pages/HomeAdministrator.vue
@@ -129,7 +129,7 @@ import { orderByDefault } from '@/helpers/query/utils';
 import { getTitle } from '@/helpers/query/administrations';
 import useUserType from '@/composables/useUserType';
 import useUserClaimsQuery from '@/composables/queries/useUserClaimsQuery';
-import useAdministrationsQuery from '@/composables/queries/useAdministrationsQuery';
+import useAdministrationsListQuery from '@/composables/queries/useAdministrationsListQuery';
 import CardAdministration from '@/components/CardAdministration.vue';
 
 const initialized = ref(false);
@@ -196,7 +196,7 @@ const {
   isLoading: isLoadingAdministrations,
   isFetching: isFetchingAdministrations,
   data: administrations,
-} = useAdministrationsQuery(orderBy, fetchTestAdministrations, {
+} = useAdministrationsListQuery(orderBy, fetchTestAdministrations, {
   enabled: initialized,
 });
 

--- a/src/pages/HomeParticipant.vue
+++ b/src/pages/HomeParticipant.vue
@@ -6,8 +6,8 @@
         <span>{{ $t('homeParticipant.loadingAssignments') }}</span>
       </div>
       <div v-else>
-        <h2 v-if="adminInfo?.length == 1" class="p-float-label dropdown-container">
-          {{ adminInfo.at(0).publicName || adminInfo.at(0).name }}
+        <h2 v-if="userAdministrations?.length == 1" class="p-float-label dropdown-container">
+          {{ userAdministrations.at(0).publicName || userAdministrations.at(0).name }}
         </h2>
         <div class="flex flex-row-reverse align-items-end gap-2 justify-content-between">
           <div
@@ -24,13 +24,13 @@
             }}</label>
           </div>
           <div
-            v-if="adminInfo?.length > 0"
+            v-if="userAdministrations?.length > 0"
             class="flex flex-row justify-center align-items-center p-float-label dropdown-container gap-4 w-full"
           >
             <div class="assignment-select-container flex flex-row justify-content-between justify-content-start">
               <div class="flex flex-column align-content-start justify-content-start w-3">
                 <PvDropdown
-                  v-if="adminInfo.every((admin) => admin.publicName)"
+                  v-if="userAdministrations.every((admin) => admin.publicName)"
                   v-model="selectedAdmin"
                   :options="sortedAdminInfo ?? []"
                   option-label="publicName"
@@ -148,18 +148,18 @@ const {
 const {
   isLoading: isLoadingAssignments,
   isFetching: isFetchingAssignments,
-  data: assignmentInfo,
+  data: userAssignments,
 } = useUserAssignmentsQuery({
   enabled: initialized,
 });
 
-const administrationIds = computed(() => (assignmentInfo.value ?? []).map((assignment) => assignment.id));
+const administrationIds = computed(() => (userAssignments?.value ?? []).map((assignment) => assignment.id));
 const administrationQueryEnabled = computed(() => !isLoadingAssignments.value);
 
 const {
   isLoading: isLoadingAdmins,
   isFetching: isFetchingAdmins,
-  data: adminInfo,
+  data: userAdministrations,
 } = useQuery({
   queryKey: ['administrations', uid, administrationIds],
   queryFn: () =>
@@ -178,7 +178,7 @@ const {
 });
 
 const sortedAdminInfo = computed(() => {
-  return [...(adminInfo.value ?? [])].sort((a, b) => a.name.localeCompare(b.name));
+  return [...(userAdministrations.value ?? [])].sort((a, b) => a.name.localeCompare(b.name));
 });
 
 async function checkConsent() {
@@ -325,8 +325,8 @@ const assessments = computed(() => {
   if (!isFetching.value && selectedAdmin.value && (taskInfo.value ?? []).length > 0) {
     const fetchedAssessments = _without(
       selectedAdmin.value.assessments.map((assessment) => {
-        // Get the matching assessment from assignmentInfo
-        const matchingAssignment = _find(assignmentInfo.value, { id: selectedAdmin.value.id });
+        // Get the matching assessment from userAssignments
+        const matchingAssignment = _find(userAssignments.value, { id: selectedAdmin.value.id });
         const matchingAssessments = matchingAssignment?.assessments ?? [];
         const matchingAssessment = _find(matchingAssessments, { taskId: assessment.taskId });
 
@@ -377,7 +377,7 @@ const optionalAssessments = computed(() => {
 const isSequential = computed(() => {
   return (
     _get(
-      _find(adminInfo.value, (admin) => {
+      _find(userAdministrations.value, (admin) => {
         return admin.id === selectedAdmin.value.id;
       }),
       'sequential',
@@ -406,13 +406,13 @@ const studentInfo = computed(() => {
 });
 
 watch(
-  [selectedAdmin, adminInfo],
+  [selectedAdmin, userAdministrations],
   async ([updateSelectedAdmin]) => {
     if (updateSelectedAdmin) {
       await checkConsent();
     }
     const selectedAdminId = selectedAdmin.value?.id;
-    const allAdminIds = (adminInfo.value ?? []).map((admin) => admin.id);
+    const allAdminIds = (userAdministrations.value ?? []).map((admin) => admin.id);
     // If there is no selected admin or if the selected admin is not in the list
     // of all administrations choose the first one after sorting alphabetically by publicName
     if (allAdminIds.length > 0 && (!selectedAdminId || !allAdminIds.includes(selectedAdminId))) {

--- a/src/pages/HomeParticipant.vue
+++ b/src/pages/HomeParticipant.vue
@@ -100,8 +100,8 @@ import { useGameStore } from '@/store/game';
 import { storeToRefs } from 'pinia';
 import { useQuery, useQueryClient } from '@tanstack/vue-query';
 import { fetchDocsById, fetchSubcollection } from '@/helpers/query/utils';
-import { getUserAssignments } from '@/helpers/query/assignments';
 import useUserDataQuery from '@/composables/queries/useUserDataQuery';
+import useUserAssignmentsQuery from '@/composables/queries/useUserAssignmentsQuery';
 import ConsentModal from '@/components/ConsentModal.vue';
 import GameTabs from '@/components/GameTabs.vue';
 import ParticipantSidebar from '@/components/ParticipantSidebar.vue';
@@ -123,15 +123,8 @@ const init = () => {
 const queryClient = useQueryClient();
 
 const authStore = useAuthStore();
-const {
-  roarfirekit,
-  roarUid,
-  uid,
-  consentSpinner,
-  showOptionalAssessments,
-  userQueryKeyIndex,
-  assignmentQueryKeyIndex,
-} = storeToRefs(authStore);
+const { roarfirekit, roarUid, uid, consentSpinner, showOptionalAssessments, userQueryKeyIndex } =
+  storeToRefs(authStore);
 
 unsubscribe = authStore.$subscribe(async (mutation, state) => {
   if (state.roarfirekit.restConfig) init();
@@ -156,14 +149,8 @@ const {
   isLoading: isLoadingAssignments,
   isFetching: isFetchingAssignments,
   data: assignmentInfo,
-} = useQuery({
-  queryKey: ['assignments', uid, assignmentQueryKeyIndex],
-  queryFn: () => getUserAssignments(roarUid.value),
-  keepPreviousData: true,
+} = useUserAssignmentsQuery({
   enabled: initialized,
-  staleTime: 5 * 60 * 1000, // 5 min
-  // For MEFS, since it is opened in a separate tab
-  refetchOnWindowFocus: 'always',
 });
 
 const administrationIds = computed(() => (assignmentInfo.value ?? []).map((assignment) => assignment.id));

--- a/src/pages/HomeParticipant.vue
+++ b/src/pages/HomeParticipant.vue
@@ -104,12 +104,12 @@ import _isEmpty from 'lodash/isEmpty';
 import { useAuthStore } from '@/store/auth';
 import { useGameStore } from '@/store/game';
 import { storeToRefs } from 'pinia';
-import { useQuery, useQueryClient } from '@tanstack/vue-query';
-import { fetchSubcollection } from '@/helpers/query/utils';
+import { useQueryClient } from '@tanstack/vue-query';
 import useUserDataQuery from '@/composables/queries/useUserDataQuery';
 import useUserAssignmentsQuery from '@/composables/queries/useUserAssignmentsQuery';
 import useAdministrationsQuery from '@/composables/queries/useAdministrationsQuery';
 import useTasksQuery from '@/composables/queries/useTasksQuery';
+import useSurveyReponsesQuery from '@/composables/queries/useSurveyResponsesQuery';
 import ConsentModal from '@/components/ConsentModal.vue';
 import GameTabs from '@/components/GameTabs.vue';
 import ParticipantSidebar from '@/components/ParticipantSidebar.vue';
@@ -131,8 +131,7 @@ const init = () => {
 const queryClient = useQueryClient();
 
 const authStore = useAuthStore();
-const { roarfirekit, roarUid, uid, consentSpinner, showOptionalAssessments, userQueryKeyIndex } =
-  storeToRefs(authStore);
+const { roarfirekit, roarUid, consentSpinner, showOptionalAssessments, userQueryKeyIndex } = storeToRefs(authStore);
 
 unsubscribe = authStore.$subscribe(async (mutation, state) => {
   if (state.roarfirekit.restConfig) init();
@@ -187,12 +186,8 @@ const {
   enabled: tasksQueryEnabled,
 });
 
-const { data: surveyResponsesData } = useQuery({
-  queryKey: ['surveyResponses', uid],
-  queryFn: () => fetchSubcollection(`users/${uid.value}`, 'surveyResponses'),
-  keepPreviousData: true,
+const { data: surveyResponsesData } = useSurveyReponsesQuery({
   enabled: initialized.value && import.meta.env.MODE === 'LEVANTE',
-  staleTime: 5 * 60 * 1000,
 });
 
 const isLoading = computed(() => {

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -15,6 +15,7 @@ export default mergeConfig(
       dir: 'src/',
       watch: false,
       setupFiles: ['./vitest.setup.js'],
+      clearMocks: true,
       coverage: {
         enabled: true,
         provider: 'istanbul',


### PR DESCRIPTION
## Proposed changes
This PR migrates the `ParticipantHomepage` page to use new composable TanStack queries and mutations. 

## Types of changes
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactoring (non-breaking change that does not add functionality but makes code cleaner or more efficient)
- [ ] Documentation Update
- [ ] Tests (new or updated tests)
- [ ] Style (changes to code styling)
- [ ] CI (continuous integration changes)
- [ ] Repository Maintenance
- [ ] Other (please describe below)

## Checklist
- [x] I have read the [guidelines for contributing](https://github.com/yeatmanlab/roar-dashboard/blob/main/.github/CONTRIBUTING.md).
- [x] The changes in this PR are as small as they can be. They represent one and only one fix or enhancement.
- [x] Linting checks pass with my changes.
- [x] Any existing unit tests pass with my changes.
- [x] Any existing end-to-end tests pass with my changes.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] If this PR fixes an existing issue, I have added a unit or end-to-end test that will detect if this issue reoccurs.
- [x] I have added JSDoc comments as appropriate.
- [ ] I have added the necessary documentation to the [roar-docs repository](https://github.com/yeatmanlab/roar-docs).
- [x] I have shared this PR on the roar-pr-reviews channel (if I have access)
- [ ] I have linked relevant issues (if any)

## Justification of missing checklist items
n/a


## Further comments
n/a


Ref https://github.com/yeatmanlab/roar/issues/318