### PR TITLE
Fix App Check `debugToken` conditional for Cypress environment

### DIFF
--- a/src/config/firebaseRoar.js
+++ b/src/config/firebaseRoar.js
@@ -9,17 +9,15 @@ const useSandbox = import.meta.env.VITE_FIREBASE_DATA_SOURCE === 'sandbox';
 const isStaging = import.meta.env.VITE_STAGING_BUILD === 'true';
 
 function setDebugToken(config) {
-  // If the NODE_ENV = test, use the debug token from the Cypress config (NODE_ENV is set to test in the Cypress test GitHub action)
-  // Otherwise, use the VITE_APPCHECK_DEBUG_TOKEN environment variable (set as a local environment variable in the .env file and in the GitHub action for preview builds)
-  // If neither are set, create a new debug token which will be inactive until it is set in the Firebase App Check console
-  const debugToken =
-    import.meta.env.NODE_ENV === 'test'
-      ? Cypress.env('appCheckDebugToken')
-      : import.meta.env.VITE_APPCHECK_DEBUG_TOKEN || (self.FIREBASE_APPCHECK_DEBUG_TOKEN = true);
+  // For Cypress tests, use the debug token from the Cypress config. Otherwise, use the VITE_APPCHECK_DEBUG_TOKEN
+  // environment variable (set as a local environment variable in the .env file and in the GitHub action for preview
+  // builds). If neither are set, create a new debug token which will be inactive until it is set in the Firebase App
+  // Check console
+  const debugToken = window?.Cypress
+    ? Cypress.env('appCheckDebugToken')
+    : import.meta.env.VITE_APPCHECK_DEBUG_TOKEN || (self.FIREBASE_APPCHECK_DEBUG_TOKEN = true);
 
-  if (debugToken) {
-    config.debugToken = debugToken;
-  }
+  if (debugToken) config.debugToken = debugToken;
 }
 
 if (isEmulated) {


### PR DESCRIPTION
## Proposed changes
This PR fixes the App Check `debugToken` conditional for Cypress environment by leveraging `window.Cypress` for the environment determination as `NODE_ENV === 'test'` also evaluates to true when running unit tests, causing tests to fail: 

```
 FAIL  src/composables/queries/useSurveyResponsesQuery.test.js [ src/composables/queries/useSurveyResponsesQuery.test.js ]
 FAIL  src/composables/queries/useUserAssignmentsQuery.test.js [ src/composables/queries/useUserAssignmentsQuery.test.js ]
 FAIL  src/composables/queries/useUserDataQuery.test.js [ src/composables/queries/useUserDataQuery.test.js ]
ReferenceError: Cypress is not defined
 ❯ setDebugToken src/config/firebaseRoar.js:17:17
     15|   const debugToken =
     16|     import.meta.env.NODE_ENV === 'test'
     17|       ? Cypress.env('appCheckDebugToken')
       |                 ^
     18|       : import.meta.env.VITE_APPCHECK_DEBUG_TOKEN || (self.FIREBASE_AP…
     19| 
 ❯ src/config/firebaseRoar.js:86:1
 ❯ src/firebaseInit.js:2:31
```
[_Source_](https://github.com/yeatmanlab/roar-dashboard/actions/runs/10801245781/job/29961001478?pr=791)

## Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (non-breaking change that does not add functionality but makes code cleaner or more efficient)
- [ ] Documentation Update
- [ ] Tests (new or updated tests)
- [ ] Style (changes to code styling)
- [ ] CI (continuous integration changes)
- [ ] Repository Maintenance
- [ ] Other (please describe below)

## Checklist
- [x] I have read the [guidelines for contributing](https://github.com/yeatmanlab/roar-dashboard/blob/main/.github/CONTRIBUTING.md).
- [x] The changes in this PR are as small as they can be. They represent one and only one fix or enhancement.
- [x] Linting checks pass with my changes.
- [x] Any existing unit tests pass with my changes.
- [x] Any existing end-to-end tests pass with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] If this PR fixes an existing issue, I have added a unit or end-to-end test that will detect if this issue reoccurs.
- [x] I have added JSDoc comments as appropriate.
- [ ] I have added the necessary documentation to the [roar-docs repository](https://github.com/yeatmanlab/roar-docs).
- [x] I have shared this PR on the roar-pr-reviews channel (if I have access)
- [ ] I have linked relevant issues (if any)

## Justification of missing checklist items
n/a

## Further comments
n/a
