### PR TITLE
Update Letter version to 1.11.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@bdelab/roam-fluency": "1.11.26",
         "@bdelab/roar-firekit": "^8.0.8",
-        "@bdelab/roar-letter": "1.11.5",
+        "@bdelab/roar-letter": "1.11.6",
         "@bdelab/roar-multichoice": "^1.11.3",
         "@bdelab/roar-pa": "2.2.4",
         "@bdelab/roar-sre": "1.15.9",
@@ -1880,9 +1880,9 @@
       }
     },
     "node_modules/@bdelab/roar-letter": {
-      "version": "1.11.5",
-      "resolved": "https://registry.npmjs.org/@bdelab/roar-letter/-/roar-letter-1.11.5.tgz",
-      "integrity": "sha512-8wUZSajJbDfLIOBcv/e+CbhVQvPnvidhVcRf/gA7RhVr0S959ldql1jO5tBKUyzU0jldha2X7zeqbvcb/KtpNA==",
+      "version": "1.11.6",
+      "resolved": "https://registry.npmjs.org/@bdelab/roar-letter/-/roar-letter-1.11.6.tgz",
+      "integrity": "sha512-M1cHlJZz4nUzuc4TKA6hablHlT20OBuyZjgW90dkOPYs1HopfG325/45cErJEPHNdrQOlhFoEwMTdUQXNvUNiA==",
       "dependencies": {
         "@bdelab/jscat": "^4.0.0",
         "@bdelab/roar-firekit": "^4.7.0",
@@ -24779,7 +24779,6 @@
     },
     "node_modules/npm/node_modules/lodash._baseindexof": {
       "version": "3.1.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
@@ -24804,19 +24803,16 @@
     },
     "node_modules/npm/node_modules/lodash._bindcallback": {
       "version": "3.0.1",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/lodash._cacheindexof": {
       "version": "3.0.2",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/lodash._createcache": {
       "version": "3.1.2",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -24825,7 +24821,6 @@
     },
     "node_modules/npm/node_modules/lodash._getnative": {
       "version": "3.9.1",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
@@ -24836,7 +24831,6 @@
     },
     "node_modules/npm/node_modules/lodash.restparam": {
       "version": "3.6.1",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
@@ -39090,9 +39084,9 @@
       }
     },
     "@bdelab/roar-letter": {
-      "version": "1.11.5",
-      "resolved": "https://registry.npmjs.org/@bdelab/roar-letter/-/roar-letter-1.11.5.tgz",
-      "integrity": "sha512-8wUZSajJbDfLIOBcv/e+CbhVQvPnvidhVcRf/gA7RhVr0S959ldql1jO5tBKUyzU0jldha2X7zeqbvcb/KtpNA==",
+      "version": "1.11.6",
+      "resolved": "https://registry.npmjs.org/@bdelab/roar-letter/-/roar-letter-1.11.6.tgz",
+      "integrity": "sha512-M1cHlJZz4nUzuc4TKA6hablHlT20OBuyZjgW90dkOPYs1HopfG325/45cErJEPHNdrQOlhFoEwMTdUQXNvUNiA==",
       "requires": {
         "@bdelab/jscat": "^4.0.0",
         "@bdelab/roar-firekit": "^4.7.0",
@@ -56473,8 +56467,7 @@
         },
         "lodash._baseindexof": {
           "version": "3.1.0",
-          "bundled": true,
-          "extraneous": true
+          "bundled": true
         },
         "lodash._baseuniq": {
           "version": "4.6.0",
@@ -56496,26 +56489,22 @@
         },
         "lodash._bindcallback": {
           "version": "3.0.1",
-          "bundled": true,
-          "extraneous": true
+          "bundled": true
         },
         "lodash._cacheindexof": {
           "version": "3.0.2",
-          "bundled": true,
-          "extraneous": true
+          "bundled": true
         },
         "lodash._createcache": {
           "version": "3.1.2",
           "bundled": true,
-          "extraneous": true,
           "requires": {
             "lodash._getnative": "^3.0.0"
           }
         },
         "lodash._getnative": {
           "version": "3.9.1",
-          "bundled": true,
-          "extraneous": true
+          "bundled": true
         },
         "lodash.clonedeep": {
           "version": "4.5.0",
@@ -56523,8 +56512,7 @@
         },
         "lodash.restparam": {
           "version": "3.6.1",
-          "bundled": true,
-          "extraneous": true
+          "bundled": true
         },
         "lodash.union": {
           "version": "4.6.0",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "dependencies": {
     "@bdelab/roam-fluency": "1.11.26",
     "@bdelab/roar-firekit": "^8.0.8",
-    "@bdelab/roar-letter": "1.11.5",
+    "@bdelab/roar-letter": "1.11.6",
     "@bdelab/roar-multichoice": "^1.11.3",
     "@bdelab/roar-pa": "2.2.4",
     "@bdelab/roar-sre": "1.15.9",


### PR DESCRIPTION
This PR updates the version of `@bdelab/roar-letter` to 1.11.6.