### PR TITLE
Update ROAV-Crowding version to 1.1.14

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@bdelab/roar-swr": "^1.12.1",
         "@bdelab/roar-utils": "^1.2.1",
         "@bdelab/roar-vocab": "^1.8.0",
-        "@bdelab/roav-crowding": "1.1.12",
+        "@bdelab/roav-crowding": "1.1.14",
         "@bdelab/roav-mep": "^1.1.17",
         "@bdelab/roav-ran": "^1.0.21",
         "@levante-framework/core-tasks": "^1.0.0-beta.18",
@@ -6501,9 +6501,9 @@
       }
     },
     "node_modules/@bdelab/roav-crowding": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/@bdelab/roav-crowding/-/roav-crowding-1.1.12.tgz",
-      "integrity": "sha512-Eg2XuOHNnwiciN4LuIDnkrfjKFrJBezDeN+s1DI+ZKU8R5qEksWqhMrkectOrKrHCCVx5UaXlJvnmqEJHJRA6w==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/@bdelab/roav-crowding/-/roav-crowding-1.1.14.tgz",
+      "integrity": "sha512-SP81Ex6aJ/jYabBzrrKHul4d/bsjZo90O0xaxklZhVNeeT79UREsptmiLcFQXVji0MqUNAXr6RpCXIhF53bIGQ==",
       "dependencies": {
         "@bdelab/jscat": "^4.0.0",
         "@bdelab/roar-firekit": "^4.7.0",
@@ -24779,7 +24779,6 @@
     },
     "node_modules/npm/node_modules/lodash._baseindexof": {
       "version": "3.1.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
@@ -24804,19 +24803,16 @@
     },
     "node_modules/npm/node_modules/lodash._bindcallback": {
       "version": "3.0.1",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/lodash._cacheindexof": {
       "version": "3.0.2",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/lodash._createcache": {
       "version": "3.1.2",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -24825,7 +24821,6 @@
     },
     "node_modules/npm/node_modules/lodash._getnative": {
       "version": "3.9.1",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
@@ -24836,7 +24831,6 @@
     },
     "node_modules/npm/node_modules/lodash.restparam": {
       "version": "3.6.1",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
@@ -42975,9 +42969,9 @@
       }
     },
     "@bdelab/roav-crowding": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/@bdelab/roav-crowding/-/roav-crowding-1.1.12.tgz",
-      "integrity": "sha512-Eg2XuOHNnwiciN4LuIDnkrfjKFrJBezDeN+s1DI+ZKU8R5qEksWqhMrkectOrKrHCCVx5UaXlJvnmqEJHJRA6w==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/@bdelab/roav-crowding/-/roav-crowding-1.1.14.tgz",
+      "integrity": "sha512-SP81Ex6aJ/jYabBzrrKHul4d/bsjZo90O0xaxklZhVNeeT79UREsptmiLcFQXVji0MqUNAXr6RpCXIhF53bIGQ==",
       "requires": {
         "@bdelab/jscat": "^4.0.0",
         "@bdelab/roar-firekit": "^4.7.0",
@@ -56473,8 +56467,7 @@
         },
         "lodash._baseindexof": {
           "version": "3.1.0",
-          "bundled": true,
-          "extraneous": true
+          "bundled": true
         },
         "lodash._baseuniq": {
           "version": "4.6.0",
@@ -56496,26 +56489,22 @@
         },
         "lodash._bindcallback": {
           "version": "3.0.1",
-          "bundled": true,
-          "extraneous": true
+          "bundled": true
         },
         "lodash._cacheindexof": {
           "version": "3.0.2",
-          "bundled": true,
-          "extraneous": true
+          "bundled": true
         },
         "lodash._createcache": {
           "version": "3.1.2",
           "bundled": true,
-          "extraneous": true,
           "requires": {
             "lodash._getnative": "^3.0.0"
           }
         },
         "lodash._getnative": {
           "version": "3.9.1",
-          "bundled": true,
-          "extraneous": true
+          "bundled": true
         },
         "lodash.clonedeep": {
           "version": "4.5.0",
@@ -56523,8 +56512,7 @@
         },
         "lodash.restparam": {
           "version": "3.6.1",
-          "bundled": true,
-          "extraneous": true
+          "bundled": true
         },
         "lodash.union": {
           "version": "4.6.0",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@bdelab/roar-swr": "^1.12.1",
     "@bdelab/roar-utils": "^1.2.1",
     "@bdelab/roar-vocab": "^1.8.0",
-    "@bdelab/roav-crowding": "1.1.12",
+    "@bdelab/roav-crowding": "1.1.14",
     "@bdelab/roav-mep": "^1.1.17",
     "@bdelab/roav-ran": "^1.0.21",
     "@levante-framework/core-tasks": "^1.0.0-beta.18",


### PR DESCRIPTION
This PR updates the version of `@bdelab/roav-crowding` to 1.1.14.