### PR TITLE
Update ROAV-Ran version to 1.0.28

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "@bdelab/roar-vocab": "^1.8.0",
         "@bdelab/roav-crowding": "1.1.12",
         "@bdelab/roav-mep": "^1.1.17",
-        "@bdelab/roav-ran": "^1.0.21",
+        "@bdelab/roav-ran": "1.0.28",
         "@levante-framework/core-tasks": "^1.0.0-beta.18",
         "@sentry/browser": "^8.0.0",
         "@sentry/integrations": "^7.114.0",
@@ -6710,9 +6710,9 @@
       }
     },
     "node_modules/@bdelab/roav-ran": {
-      "version": "1.0.21",
-      "resolved": "https://registry.npmjs.org/@bdelab/roav-ran/-/roav-ran-1.0.21.tgz",
-      "integrity": "sha512-aT8pUBgWXdDutE6xccaz2LRvNaDQ8VbAHrBsqwljysbOplyxIhFhzmsmvfAD1RTPRG3saUMlexTHiPHRZymVFQ==",
+      "version": "1.0.28",
+      "resolved": "https://registry.npmjs.org/@bdelab/roav-ran/-/roav-ran-1.0.28.tgz",
+      "integrity": "sha512-RDq8TRnm/77G8uD92t+QO0nlWGsvNbXqJRTooP3gQk/9a8RYg1veilb9hK3kxdc5XRW03HbTbwh8IZ6Nmk50/Q==",
       "dependencies": {
         "@bdelab/jscat": "^1.0.5",
         "@bdelab/roar-firekit": "^4.7.0",
@@ -6722,9 +6722,13 @@
         "@jspsych/plugin-audio-keyboard-response": "^1.1.0",
         "@jspsych/plugin-call-function": "^1.1.2",
         "@jspsych/plugin-fullscreen": "^1.1.0",
+        "@mediapipe/face_mesh": "^0.4.1633559619",
+        "@rollup/plugin-url": "^8.0.2",
+        "@rollup/plugin-wasm": "^6.2.2",
         "@sentry/browser": "^7.111.0",
         "@sentry/integrations": "^7.111.0",
         "@sentry/wasm": "^7.111.0",
+        "@surma/rollup-plugin-off-main-thread": "^2.2.3",
         "@xenova/transformers": "^1.3.2",
         "dotenv": "^16.4.5",
         "fscreen": "^1.2.0",
@@ -6733,11 +6737,18 @@
         "i18next-browser-languagedetector": "^7.0.1",
         "jspsych": "^7.2.1",
         "lodash": "^4.17.21",
+        "ml-regression-polynomial": "^3.0.0",
+        "ndarray": "^1.0.19",
+        "ndarray-ops": "^1.2.2",
         "node-fetch": "^2.6.6",
+        "onnxjs": "^0.1.8",
+        "onnxruntime-web": "^1.17.1",
         "papaparse": "^5.4.1",
         "regenerator-runtime": "^0.13.9",
         "roarr": "^7.21.1",
-        "store2": "^2.13.2"
+        "store2": "^2.13.2",
+        "webpack": "^5.70.0",
+        "webpack-dev-server": "^4.7.4"
       }
     },
     "node_modules/@bdelab/roav-ran/node_modules/@bdelab/jscat": {
@@ -24779,7 +24790,6 @@
     },
     "node_modules/npm/node_modules/lodash._baseindexof": {
       "version": "3.1.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
@@ -24804,19 +24814,16 @@
     },
     "node_modules/npm/node_modules/lodash._bindcallback": {
       "version": "3.0.1",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/lodash._cacheindexof": {
       "version": "3.0.2",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/lodash._createcache": {
       "version": "3.1.2",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -24825,7 +24832,6 @@
     },
     "node_modules/npm/node_modules/lodash._getnative": {
       "version": "3.9.1",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
@@ -24836,7 +24842,6 @@
     },
     "node_modules/npm/node_modules/lodash.restparam": {
       "version": "3.6.1",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
@@ -43167,9 +43172,9 @@
       }
     },
     "@bdelab/roav-ran": {
-      "version": "1.0.21",
-      "resolved": "https://registry.npmjs.org/@bdelab/roav-ran/-/roav-ran-1.0.21.tgz",
-      "integrity": "sha512-aT8pUBgWXdDutE6xccaz2LRvNaDQ8VbAHrBsqwljysbOplyxIhFhzmsmvfAD1RTPRG3saUMlexTHiPHRZymVFQ==",
+      "version": "1.0.28",
+      "resolved": "https://registry.npmjs.org/@bdelab/roav-ran/-/roav-ran-1.0.28.tgz",
+      "integrity": "sha512-RDq8TRnm/77G8uD92t+QO0nlWGsvNbXqJRTooP3gQk/9a8RYg1veilb9hK3kxdc5XRW03HbTbwh8IZ6Nmk50/Q==",
       "requires": {
         "@bdelab/jscat": "^1.0.5",
         "@bdelab/roar-firekit": "^4.7.0",
@@ -43179,9 +43184,13 @@
         "@jspsych/plugin-audio-keyboard-response": "^1.1.0",
         "@jspsych/plugin-call-function": "^1.1.2",
         "@jspsych/plugin-fullscreen": "^1.1.0",
+        "@mediapipe/face_mesh": "^0.4.1633559619",
+        "@rollup/plugin-url": "^8.0.2",
+        "@rollup/plugin-wasm": "^6.2.2",
         "@sentry/browser": "^7.111.0",
         "@sentry/integrations": "^7.111.0",
         "@sentry/wasm": "^7.111.0",
+        "@surma/rollup-plugin-off-main-thread": "^2.2.3",
         "@xenova/transformers": "^1.3.2",
         "dotenv": "^16.4.5",
         "fscreen": "^1.2.0",
@@ -43190,11 +43199,18 @@
         "i18next-browser-languagedetector": "^7.0.1",
         "jspsych": "^7.2.1",
         "lodash": "^4.17.21",
+        "ml-regression-polynomial": "^3.0.0",
+        "ndarray": "^1.0.19",
+        "ndarray-ops": "^1.2.2",
         "node-fetch": "^2.6.6",
+        "onnxjs": "^0.1.8",
+        "onnxruntime-web": "^1.17.1",
         "papaparse": "^5.4.1",
         "regenerator-runtime": "^0.13.9",
         "roarr": "^7.21.1",
-        "store2": "^2.13.2"
+        "store2": "^2.13.2",
+        "webpack": "^5.70.0",
+        "webpack-dev-server": "^4.7.4"
       },
       "dependencies": {
         "@bdelab/jscat": {
@@ -56473,8 +56489,7 @@
         },
         "lodash._baseindexof": {
           "version": "3.1.0",
-          "bundled": true,
-          "extraneous": true
+          "bundled": true
         },
         "lodash._baseuniq": {
           "version": "4.6.0",
@@ -56496,26 +56511,22 @@
         },
         "lodash._bindcallback": {
           "version": "3.0.1",
-          "bundled": true,
-          "extraneous": true
+          "bundled": true
         },
         "lodash._cacheindexof": {
           "version": "3.0.2",
-          "bundled": true,
-          "extraneous": true
+          "bundled": true
         },
         "lodash._createcache": {
           "version": "3.1.2",
           "bundled": true,
-          "extraneous": true,
           "requires": {
             "lodash._getnative": "^3.0.0"
           }
         },
         "lodash._getnative": {
           "version": "3.9.1",
-          "bundled": true,
-          "extraneous": true
+          "bundled": true
         },
         "lodash.clonedeep": {
           "version": "4.5.0",
@@ -56523,8 +56534,7 @@
         },
         "lodash.restparam": {
           "version": "3.6.1",
-          "bundled": true,
-          "extraneous": true
+          "bundled": true
         },
         "lodash.union": {
           "version": "4.6.0",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@bdelab/roar-vocab": "^1.8.0",
     "@bdelab/roav-crowding": "1.1.12",
     "@bdelab/roav-mep": "^1.1.17",
-    "@bdelab/roav-ran": "^1.0.21",
+    "@bdelab/roav-ran": "1.0.28",
     "@levante-framework/core-tasks": "^1.0.0-beta.18",
     "@sentry/browser": "^8.0.0",
     "@sentry/integrations": "^7.114.0",


### PR DESCRIPTION
This PR updates the version of `@bdelab/roav-ran` to 1.0.28.