### PR TITLE
Update SWR version to 1.1.20

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@bdelab/roar-utils": "^1.2.1",
         "@bdelab/roar-vocab": "^1.8.0",
         "@bdelab/roav-crowding": "1.1.12",
-        "@bdelab/roav-mep": "^1.1.17",
+        "@bdelab/roav-mep": "1.1.20",
         "@bdelab/roav-ran": "^1.0.21",
         "@levante-framework/core-tasks": "^1.0.0-beta.18",
         "@sentry/browser": "^8.0.0",
@@ -6648,9 +6648,9 @@
       }
     },
     "node_modules/@bdelab/roav-mep": {
-      "version": "1.1.17",
-      "resolved": "https://registry.npmjs.org/@bdelab/roav-mep/-/roav-mep-1.1.17.tgz",
-      "integrity": "sha512-p/G1JvQ5Ppna26o5nJ0X2mPTYkl9qi/YUVbDYqKcvPTrxZnoWwlZoK+fgQ/zorBi9EIrg+A9u1/vUAdJL7y6qQ==",
+      "version": "1.1.20",
+      "resolved": "https://registry.npmjs.org/@bdelab/roav-mep/-/roav-mep-1.1.20.tgz",
+      "integrity": "sha512-Rr0B5TcvAfqL/WySzMKjcI90GP16WHR69DueIg+EnBFCFuoV8NzUH+igrpnXRdYYX7OQR7V3fz9ILN6+7vdERQ==",
       "dependencies": {
         "@bdelab/jscat": "^4.0.0",
         "@bdelab/roar-firekit": "^4.7.0",
@@ -24779,7 +24779,6 @@
     },
     "node_modules/npm/node_modules/lodash._baseindexof": {
       "version": "3.1.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
@@ -24804,19 +24803,16 @@
     },
     "node_modules/npm/node_modules/lodash._bindcallback": {
       "version": "3.0.1",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/lodash._cacheindexof": {
       "version": "3.0.2",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/lodash._createcache": {
       "version": "3.1.2",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -24825,7 +24821,6 @@
     },
     "node_modules/npm/node_modules/lodash._getnative": {
       "version": "3.9.1",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
@@ -24836,7 +24831,6 @@
     },
     "node_modules/npm/node_modules/lodash.restparam": {
       "version": "3.6.1",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
@@ -43103,9 +43097,9 @@
       }
     },
     "@bdelab/roav-mep": {
-      "version": "1.1.17",
-      "resolved": "https://registry.npmjs.org/@bdelab/roav-mep/-/roav-mep-1.1.17.tgz",
-      "integrity": "sha512-p/G1JvQ5Ppna26o5nJ0X2mPTYkl9qi/YUVbDYqKcvPTrxZnoWwlZoK+fgQ/zorBi9EIrg+A9u1/vUAdJL7y6qQ==",
+      "version": "1.1.20",
+      "resolved": "https://registry.npmjs.org/@bdelab/roav-mep/-/roav-mep-1.1.20.tgz",
+      "integrity": "sha512-Rr0B5TcvAfqL/WySzMKjcI90GP16WHR69DueIg+EnBFCFuoV8NzUH+igrpnXRdYYX7OQR7V3fz9ILN6+7vdERQ==",
       "requires": {
         "@bdelab/jscat": "^4.0.0",
         "@bdelab/roar-firekit": "^4.7.0",
@@ -56473,8 +56467,7 @@
         },
         "lodash._baseindexof": {
           "version": "3.1.0",
-          "bundled": true,
-          "extraneous": true
+          "bundled": true
         },
         "lodash._baseuniq": {
           "version": "4.6.0",
@@ -56496,26 +56489,22 @@
         },
         "lodash._bindcallback": {
           "version": "3.0.1",
-          "bundled": true,
-          "extraneous": true
+          "bundled": true
         },
         "lodash._cacheindexof": {
           "version": "3.0.2",
-          "bundled": true,
-          "extraneous": true
+          "bundled": true
         },
         "lodash._createcache": {
           "version": "3.1.2",
           "bundled": true,
-          "extraneous": true,
           "requires": {
             "lodash._getnative": "^3.0.0"
           }
         },
         "lodash._getnative": {
           "version": "3.9.1",
-          "bundled": true,
-          "extraneous": true
+          "bundled": true
         },
         "lodash.clonedeep": {
           "version": "4.5.0",
@@ -56523,8 +56512,7 @@
         },
         "lodash.restparam": {
           "version": "3.6.1",
-          "bundled": true,
-          "extraneous": true
+          "bundled": true
         },
         "lodash.union": {
           "version": "4.6.0",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@bdelab/roar-utils": "^1.2.1",
     "@bdelab/roar-vocab": "^1.8.0",
     "@bdelab/roav-crowding": "1.1.12",
-    "@bdelab/roav-mep": "^1.1.17",
+    "@bdelab/roav-mep": "1.1.20",
     "@bdelab/roav-ran": "^1.0.21",
     "@levante-framework/core-tasks": "^1.0.0-beta.18",
     "@sentry/browser": "^8.0.0",


### PR DESCRIPTION
This PR updates the version of `@bdelab/roar-swr` to 1.1.20.