### PR TITLE
Temporarily disable score and progress filtering E2E tests

### DIFF
--- a/cypress/e2e/partner-admin/default-tests/testProgressReportFiltering.spec.cy.js
+++ b/cypress/e2e/partner-admin/default-tests/testProgressReportFiltering.spec.cy.js
@@ -121,26 +121,28 @@ describe('The partner admin can view progress reports for a given administration
   });
 });
 
-describe('The partner admin can view progress reports for a given administration and filter by progress status', () => {
-  it('Selects an administration, views its score report, then accesses the column filter to filter by progress status', () => {
-    checkUrl();
-    cy.getAdministrationCard(roarTestAdministrationName, 'descending');
-    clickProgressButton(roarTestAdministrationId);
-    setFilterByProgressCategory('ROAR - Word', 'completed');
-    checkTableColumn(['Username'], 'CypressTestStudent0');
-  });
-});
+// @NOTE: Temporarily disabled as instructed by the ROAR maintainers team.
+// describe('The partner admin can view progress reports for a given administration and filter by progress status', () => {
+//   it('Selects an administration, views its score report, then accesses the column filter to filter by progress status', () => {
+//     checkUrl();
+//     cy.getAdministrationCard(roarTestAdministrationName, 'descending');
+//     clickProgressButton(roarTestAdministrationId);
+//     setFilterByProgressCategory('ROAR - Word', 'completed');
+//     checkTableColumn(['Username'], 'CypressTestStudent0');
+//   });
+// });
 
-describe('The partner admin can view progress reports for a given administration and filter by grade and progress status', () => {
-  it('Selects an administration, views its score report, then accesses the column filter to filter by grade and support level', () => {
-    checkUrl();
-    cy.getAdministrationCard(roarTestAdministrationName, 'descending');
-    clickProgressButton(roarTestAdministrationId);
-    setFilterByGrade('1');
-    setFilterByProgressCategory('ROAR - Word', 'completed');
-    checkTableColumn(['Username'], 'CypressTestStudent0');
-  });
-});
+// @NOTE: Temporarily disabled as instructed by the ROAR maintainers team.
+// describe('The partner admin can view progress reports for a given administration and filter by grade and progress status', () => {
+//   it('Selects an administration, views its score report, then accesses the column filter to filter by grade and support level', () => {
+//     checkUrl();
+//     cy.getAdministrationCard(roarTestAdministrationName, 'descending');
+//     clickProgressButton(roarTestAdministrationId);
+//     setFilterByGrade('1');
+//     setFilterByProgressCategory('ROAR - Word', 'completed');
+//     checkTableColumn(['Username'], 'CypressTestStudent0');
+//   });
+// });
 
 describe('The partner admin can view progress reports for a given administration and a not applicable filter returns an empty message', () => {
   it('Selects an administration, views its score report, then accesses the column filter to filter by a non-returnable filter', () => {

--- a/cypress/e2e/partner-admin/default-tests/testScoreReportFiltering.cy.js
+++ b/cypress/e2e/partner-admin/default-tests/testScoreReportFiltering.cy.js
@@ -96,37 +96,40 @@ describe('The partner admin can view score reports for a given administration an
   });
 });
 
-describe('The partner admin can view score reports for a given administration and filter by support level', () => {
-  it('Selects an administration, views its score report, then accesses the column filter to filter by support level', () => {
-    checkUrl();
-    cy.getAdministrationCard(roarTestAdministrationName, 'descending');
-    clickScoreButton(roarTestAdministrationId);
-    setFilterByScoreCategory('ROAR - Word', 'Pink');
-    checkTableColumn(['Username'], 'CypressTestStudent0');
-  });
-});
+// @NOTE: Temporarily disabled as instructed by the ROAR maintainers team.
+// describe('The partner admin can view score reports for a given administration and filter by support level', () => {
+//   it('Selects an administration, views its score report, then accesses the column filter to filter by support level', () => {
+//     checkUrl();
+//     cy.getAdministrationCard(roarTestAdministrationName, 'descending');
+//     clickScoreButton(roarTestAdministrationId);
+//     setFilterByScoreCategory('ROAR - Word', 'Pink');
+//     checkTableColumn(['Username'], 'CypressTestStudent0');
+//   });
+// });
 
-describe('The partner admin can view score reports for a given administration filter by school, grade, and progress status: completed', () => {
-  it('Selects an administration, views its score report, then accesses the column filter to filter by school, grade, and completed', () => {
-    checkUrl();
-    cy.getAdministrationCard(roarTestAdministrationName, 'descending');
-    clickScoreButton(roarTestAdministrationId);
-    setFilterByGrade('1');
-    setFilterBySchool('Cypress Test School');
-    setFilterByProgressCategory('ROAR - Morphology', 'completed');
-    checkTableColumn(['Username'], 'CypressTestStudent0');
-  });
-});
+// @NOTE: Temporarily disabled as instructed by the ROAR maintainers team.
+// describe('The partner admin can view score reports for a given administration filter by school, grade, and progress status: completed', () => {
+//   it('Selects an administration, views its score report, then accesses the column filter to filter by school, grade, and completed', () => {
+//     checkUrl();
+//     cy.getAdministrationCard(roarTestAdministrationName, 'descending');
+//     clickScoreButton(roarTestAdministrationId);
+//     setFilterByGrade('1');
+//     setFilterBySchool('Cypress Test School');
+//     setFilterByProgressCategory('ROAR - Morphology', 'completed');
+//     checkTableColumn(['Username'], 'CypressTestStudent0');
+//   });
+// });
 
-describe('The partner admin can view score reports for a given administration and filter by Assessed', () => {
-  it('Selects an administration, views its score report, then accesses the column filter to filter by assessed', () => {
-    checkUrl();
-    cy.getAdministrationCard(roarTestAdministrationName, 'descending');
-    clickScoreButton(roarTestAdministrationId);
-    setFilterByScoreCategory('ROAR - Morphology', 'Assessed');
-    checkTableColumn(['Username'], 'CypressTestStudent0');
-  });
-});
+// @NOTE: Temporarily disabled as instructed by the ROAR maintainers team.
+// describe('The partner admin can view score reports for a given administration and filter by Assessed', () => {
+//   it('Selects an administration, views its score report, then accesses the column filter to filter by assessed', () => {
+//     checkUrl();
+//     cy.getAdministrationCard(roarTestAdministrationName, 'descending');
+//     clickScoreButton(roarTestAdministrationId);
+//     setFilterByScoreCategory('ROAR - Morphology', 'Assessed');
+//     checkTableColumn(['Username'], 'CypressTestStudent0');
+//   });
+// });
 
 describe('The partner admin can view score reports for a given administration and a not applicable filter returns an empty message', () => {
   it('Selects an administration, views its score report, then accesses the column filter to filter by a non-returnable filter', () => {


### PR DESCRIPTION
## Proposed changes
As instructed via Slack by @Emily-ejag, this PR temporarily disables the failing `testScoreFiltering` and `testProgressReportFiltering` tests.

## Types of changes
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (non-breaking change that does not add functionality but makes code cleaner or more efficient)
- [ ] Documentation Update
- [x] Tests (new or updated tests)
- [ ] Style (changes to code styling)
- [ ] CI (continuous integration changes)
- [ ] Repository Maintenance
- [ ] Other (please describe below)

## Checklist

- [x] I have read the [guidelines for contributing](https://github.com/yeatmanlab/roar-dashboard/blob/main/.github/CONTRIBUTING.md).
- [x] The changes in this PR are as small as they can be. They represent one and only one fix or enhancement.
- [x] Linting checks pass with my changes.
- [x] Any existing unit tests pass with my changes.
- [ ] Any existing end-to-end tests pass with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] If this PR fixes an existing issue, I have added a unit or end-to-end test that will detect if this issue reoccurs.
- [x] I have added JSDoc comments as appropriate.
- [ ] I have added the necessary documentation to the [roar-docs repository](https://github.com/yeatmanlab/roar-docs).
- [x] I have shared this PR on the roar-pr-reviews channel (if I have access)
- [ ] I have linked relevant issues (if any)

## Justification of missing checklist items
n/a


## Further comments
n/a