### PR TITLE
Update Letter version to 1.11.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@bdelab/roam-fluency": "1.11.26",
         "@bdelab/roar-firekit": "^8.0.8",
-        "@bdelab/roar-letter": "1.11.5",
+        "@bdelab/roar-letter": "1.11.8",
         "@bdelab/roar-multichoice": "^1.11.3",
         "@bdelab/roar-pa": "2.2.4",
         "@bdelab/roar-sre": "1.15.9",
@@ -1880,9 +1880,9 @@
       }
     },
     "node_modules/@bdelab/roar-letter": {
-      "version": "1.11.5",
-      "resolved": "https://registry.npmjs.org/@bdelab/roar-letter/-/roar-letter-1.11.5.tgz",
-      "integrity": "sha512-8wUZSajJbDfLIOBcv/e+CbhVQvPnvidhVcRf/gA7RhVr0S959ldql1jO5tBKUyzU0jldha2X7zeqbvcb/KtpNA==",
+      "version": "1.11.8",
+      "resolved": "https://registry.npmjs.org/@bdelab/roar-letter/-/roar-letter-1.11.8.tgz",
+      "integrity": "sha512-y0VJ6mIYf0KkDZ1tvt9aGWFSokF9dhuJv74vf9yiewIFQxJHft/LIWfjscvW/Hpe9YUwJuHjJ0Liq129jbA1Qg==",
       "dependencies": {
         "@bdelab/jscat": "^4.0.0",
         "@bdelab/roar-firekit": "^4.7.0",
@@ -39095,9 +39095,9 @@
       }
     },
     "@bdelab/roar-letter": {
-      "version": "1.11.5",
-      "resolved": "https://registry.npmjs.org/@bdelab/roar-letter/-/roar-letter-1.11.5.tgz",
-      "integrity": "sha512-8wUZSajJbDfLIOBcv/e+CbhVQvPnvidhVcRf/gA7RhVr0S959ldql1jO5tBKUyzU0jldha2X7zeqbvcb/KtpNA==",
+      "version": "1.11.8",
+      "resolved": "https://registry.npmjs.org/@bdelab/roar-letter/-/roar-letter-1.11.8.tgz",
+      "integrity": "sha512-y0VJ6mIYf0KkDZ1tvt9aGWFSokF9dhuJv74vf9yiewIFQxJHft/LIWfjscvW/Hpe9YUwJuHjJ0Liq129jbA1Qg==",
       "requires": {
         "@bdelab/jscat": "^4.0.0",
         "@bdelab/roar-firekit": "^4.7.0",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "dependencies": {
     "@bdelab/roam-fluency": "1.11.26",
     "@bdelab/roar-firekit": "^8.0.8",
-    "@bdelab/roar-letter": "1.11.5",
+    "@bdelab/roar-letter": "1.11.8",
     "@bdelab/roar-multichoice": "^1.11.3",
     "@bdelab/roar-pa": "2.2.4",
     "@bdelab/roar-sre": "1.15.9",


### PR DESCRIPTION
This PR updates the version of `@bdelab/roar-letter` to 1.11.8.