### PR TITLE
Update SWR version to 1.12.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@bdelab/roar-multichoice": "^1.11.3",
         "@bdelab/roar-pa": "2.2.4",
         "@bdelab/roar-sre": "1.15.9",
-        "@bdelab/roar-swr": "^1.12.1",
+        "@bdelab/roar-swr": "1.12.6",
         "@bdelab/roar-utils": "^1.2.1",
         "@bdelab/roar-vocab": "^1.8.0",
         "@bdelab/roav-crowding": "1.1.16",
@@ -4706,11 +4706,11 @@
       }
     },
     "node_modules/@bdelab/roar-swr": {
-      "version": "1.12.5",
-      "resolved": "https://registry.npmjs.org/@bdelab/roar-swr/-/roar-swr-1.12.5.tgz",
-      "integrity": "sha512-0mdQXNm1CIXQ1qXlP7iYVEMDRBftUXjzQjDqU29eM43Xh1e6E9/b9amcdf9WTMsDAxZ6rtAaeJbu07iywgF1pA==",
+      "version": "1.12.6",
+      "resolved": "https://registry.npmjs.org/@bdelab/roar-swr/-/roar-swr-1.12.6.tgz",
+      "integrity": "sha512-HN87FYtNyRg0nyvp3n/vmVFhtMQP5iA9G5/u7J18LkmH4g5SmC6qifTDY+GK2gzuYJ5o4QH/q+7MhkSnMuKqFw==",
       "dependencies": {
-        "@bdelab/jscat": "^4.0.0",
+        "@bdelab/jscat": "4.0.0",
         "@bdelab/roar-firekit": "^4.7.0",
         "@bdelab/roar-utils": "^1.0.18",
         "@jspsych-contrib/plugin-audio-multi-response": "^1.0.0",
@@ -41388,11 +41388,11 @@
       }
     },
     "@bdelab/roar-swr": {
-      "version": "1.12.5",
-      "resolved": "https://registry.npmjs.org/@bdelab/roar-swr/-/roar-swr-1.12.5.tgz",
-      "integrity": "sha512-0mdQXNm1CIXQ1qXlP7iYVEMDRBftUXjzQjDqU29eM43Xh1e6E9/b9amcdf9WTMsDAxZ6rtAaeJbu07iywgF1pA==",
+      "version": "1.12.6",
+      "resolved": "https://registry.npmjs.org/@bdelab/roar-swr/-/roar-swr-1.12.6.tgz",
+      "integrity": "sha512-HN87FYtNyRg0nyvp3n/vmVFhtMQP5iA9G5/u7J18LkmH4g5SmC6qifTDY+GK2gzuYJ5o4QH/q+7MhkSnMuKqFw==",
       "requires": {
-        "@bdelab/jscat": "^4.0.0",
+        "@bdelab/jscat": "4.0.0",
         "@bdelab/roar-firekit": "^4.7.0",
         "@bdelab/roar-utils": "^1.0.18",
         "@jspsych-contrib/plugin-audio-multi-response": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@bdelab/roar-multichoice": "^1.11.3",
     "@bdelab/roar-pa": "2.2.4",
     "@bdelab/roar-sre": "1.15.9",
-    "@bdelab/roar-swr": "^1.12.1",
+    "@bdelab/roar-swr": "1.12.6",
     "@bdelab/roar-utils": "^1.2.1",
     "@bdelab/roar-vocab": "^1.8.0",
     "@bdelab/roav-crowding": "1.1.16",


### PR DESCRIPTION
This PR updates the version of `@bdelab/roar-swr` to 1.12.6.