### PR TITLE
Update ROAV-Crowding version to 1.1.20

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@bdelab/roar-swr": "^1.12.1",
         "@bdelab/roar-utils": "^1.2.1",
         "@bdelab/roar-vocab": "^1.8.0",
-        "@bdelab/roav-crowding": "1.1.16",
+        "@bdelab/roav-crowding": "1.1.20",
         "@bdelab/roav-mep": "^1.1.21",
         "@bdelab/roav-ran": "^1.0.30",
         "@levante-framework/core-tasks": "1.0.0-beta.16",
@@ -6500,9 +6500,10 @@
       }
     },
     "node_modules/@bdelab/roav-crowding": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/@bdelab/roav-crowding/-/roav-crowding-1.1.16.tgz",
-      "integrity": "sha512-xNaiz8Vwu9HoMgzU4Kd2fTgjZdVMa/2EAjZiIER/gTZrWNTKuJffqnAu9GL92nwqrVVYi5Qr1THhgOWzwcS6HQ==",
+      "version": "1.1.20",
+      "resolved": "https://registry.npmjs.org/@bdelab/roav-crowding/-/roav-crowding-1.1.20.tgz",
+      "integrity": "sha512-vyORmBXZBxZcOly6T0ysBedRAwjfAu14VtNks/VM/QY5iea+d89J6ITxQdvtp/QbUaH5KTuWftioIB/D0j13Mg==",
+      "license": "Stanford Academic Software License for ROAR",
       "dependencies": {
         "@bdelab/jscat": "^4.0.0",
         "@bdelab/roar-firekit": "^4.7.0",
@@ -42898,9 +42899,9 @@
       }
     },
     "@bdelab/roav-crowding": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/@bdelab/roav-crowding/-/roav-crowding-1.1.16.tgz",
-      "integrity": "sha512-xNaiz8Vwu9HoMgzU4Kd2fTgjZdVMa/2EAjZiIER/gTZrWNTKuJffqnAu9GL92nwqrVVYi5Qr1THhgOWzwcS6HQ==",
+      "version": "1.1.20",
+      "resolved": "https://registry.npmjs.org/@bdelab/roav-crowding/-/roav-crowding-1.1.20.tgz",
+      "integrity": "sha512-vyORmBXZBxZcOly6T0ysBedRAwjfAu14VtNks/VM/QY5iea+d89J6ITxQdvtp/QbUaH5KTuWftioIB/D0j13Mg==",
       "requires": {
         "@bdelab/jscat": "^4.0.0",
         "@bdelab/roar-firekit": "^4.7.0",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@bdelab/roar-swr": "^1.12.1",
     "@bdelab/roar-utils": "^1.2.1",
     "@bdelab/roar-vocab": "^1.8.0",
-    "@bdelab/roav-crowding": "1.1.16",
+    "@bdelab/roav-crowding": "1.1.20",
     "@bdelab/roav-mep": "^1.1.21",
     "@bdelab/roav-ran": "^1.0.30",
     "@levante-framework/core-tasks": "1.0.0-beta.16",


### PR DESCRIPTION
This PR updates the version of `@bdelab/roav-crowding` to 1.1.20.