### PR TITLE
Update roam-apps version to 1.0.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "roar-dashboard",
       "version": "3.0.2",
       "dependencies": {
+        "@bdelab/roam-apps": "1.0.2",
         "@bdelab/roam-fluency": "1.11.26",
         "@bdelab/roar-firekit": "9.1.0",
         "@bdelab/roar-letter": "1.11.8",
@@ -1698,6 +1699,195 @@
       "version": "14.18.63",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.63.tgz",
       "integrity": "sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ=="
+    },
+    "node_modules/@bdelab/roam-apps": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bdelab/roam-apps/-/roam-apps-1.0.2.tgz",
+      "integrity": "sha512-vp+Vj+5SRWW/8PaqsRZhwB7SvnRJXL2IkhJ8EIsO7JqRmca1FTpTeBJZa6VIbOtTPkZNWIFD2Di6N4tlVtgvNg==",
+      "license": "Stanford Academic Software License for ROAR",
+      "dependencies": {
+        "@bdelab/jscat": "^4.0.0",
+        "@bdelab/roar-firekit": "^9.1.0",
+        "@bdelab/roar-utils": "^1.2.2",
+        "@jspsych-contrib/plugin-audio-multi-response": "^1.0.0",
+        "@jspsych-contrib/plugin-html-multi-response": "^1.0.2",
+        "@jspsych-contrib/plugin-html-swipe-response": "^1.0.0",
+        "@jspsych/plugin-audio-button-response": "^1.1.2",
+        "@jspsych/plugin-audio-keyboard-response": "^1.1.0",
+        "@jspsych/plugin-call-function": "^1.1.2",
+        "@jspsych/plugin-fullscreen": "^1.1.0",
+        "@jspsych/plugin-html-button-response": "^1.1.0",
+        "@jspsych/plugin-html-keyboard-response": "^1.1.0",
+        "@jspsych/plugin-html-slider-response": "^1.1.3",
+        "@jspsych/plugin-preload": "^1.1.0",
+        "@jspsych/plugin-survey-html-form": "^1.0.0",
+        "@jspsych/plugin-survey-multi-select": "^1.1.0",
+        "@jspsych/plugin-survey-text": "^1.1.0",
+        "@sentry/browser": "^7.101.1",
+        "@sentry/integrations": "^7.101.1",
+        "@sentry/rollup-plugin": "^2.14.1",
+        "@sentry/wasm": "^7.101.1",
+        "@sentry/webpack-plugin": "^2.14.1",
+        "csv-loader": "^3.0.5",
+        "detect-it": "^4.0.1",
+        "file-loader": "^6.2.0",
+        "fkill-cli": "^8.0.0",
+        "fscreen": "^1.2.0",
+        "i18next": "^22.4.15",
+        "i18next-browser-languagedetector": "^7.0.1",
+        "jspsych": "^7.2.1",
+        "katex": "^0.16.9",
+        "lerp": "^1.0.3",
+        "lodash": "^4.17.21",
+        "mime-types": "^2.1.35",
+        "path-browserify": "^1.0.1",
+        "process": "^0.11.10",
+        "regenerator-runtime": "^0.13.9",
+        "roarr": "^7.14.0",
+        "store2": "^2.13.2",
+        "webpack": "^5.70.0"
+      }
+    },
+    "node_modules/@bdelab/roam-apps/node_modules/@sentry-internal/feedback": {
+      "version": "7.119.2",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/feedback/-/feedback-7.119.2.tgz",
+      "integrity": "sha512-bnR1yJWVBZfXGx675nMXE8hCXsxluCBfIFy9GQT8PTN/urxpoS9cGz+5F7MA7Xe3Q06/7TT0Mz3fcDvjkqTu3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "7.119.2",
+        "@sentry/types": "7.119.2",
+        "@sentry/utils": "7.119.2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@bdelab/roam-apps/node_modules/@sentry-internal/replay-canvas": {
+      "version": "7.119.2",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/replay-canvas/-/replay-canvas-7.119.2.tgz",
+      "integrity": "sha512-Lqo8IFyeKkdOrOGRqm9jCEqeBl8kINe5+c2VqULpkO/I6ql6ISwPSYnmG6yL8cCVIaT1893CLog/pS4FxCv8/Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "7.119.2",
+        "@sentry/replay": "7.119.2",
+        "@sentry/types": "7.119.2",
+        "@sentry/utils": "7.119.2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@bdelab/roam-apps/node_modules/@sentry-internal/tracing": {
+      "version": "7.119.2",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/tracing/-/tracing-7.119.2.tgz",
+      "integrity": "sha512-V2W+STWrafyGJhQv3ulMFXYDwWHiU6wHQAQBShsHVACiFaDrJ2kPRet38FKv4dMLlLlP2xN+ss2e5zv3tYlTiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "7.119.2",
+        "@sentry/types": "7.119.2",
+        "@sentry/utils": "7.119.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@bdelab/roam-apps/node_modules/@sentry/browser": {
+      "version": "7.119.2",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-7.119.2.tgz",
+      "integrity": "sha512-Wb2RzCsJBTNCmS9KPmbVyV5GGzFXjFdUThAN9xlnN5GgemMBwdQjGu/tRYr8yJAVsRb0EOFH8IuJBNKKNnO49g==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry-internal/feedback": "7.119.2",
+        "@sentry-internal/replay-canvas": "7.119.2",
+        "@sentry-internal/tracing": "7.119.2",
+        "@sentry/core": "7.119.2",
+        "@sentry/integrations": "7.119.2",
+        "@sentry/replay": "7.119.2",
+        "@sentry/types": "7.119.2",
+        "@sentry/utils": "7.119.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@bdelab/roam-apps/node_modules/@sentry/core": {
+      "version": "7.119.2",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.119.2.tgz",
+      "integrity": "sha512-hQr3d2yWq/2lMvoyBPOwXw1IHqTrCjOsU1vYKhAa6w9vGbJZFGhKGGE2KEi/92c3gqGn+gW/PC7cV6waCTDuVA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/types": "7.119.2",
+        "@sentry/utils": "7.119.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@bdelab/roam-apps/node_modules/@sentry/integrations": {
+      "version": "7.119.2",
+      "resolved": "https://registry.npmjs.org/@sentry/integrations/-/integrations-7.119.2.tgz",
+      "integrity": "sha512-dCuXKvbUE3gXVVa696SYMjlhSP6CxpMH/gl4Jk26naEB8Xjsn98z/hqEoXLg6Nab73rjR9c/9AdKqBbwVMHyrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "7.119.2",
+        "@sentry/types": "7.119.2",
+        "@sentry/utils": "7.119.2",
+        "localforage": "^1.8.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@bdelab/roam-apps/node_modules/@sentry/replay": {
+      "version": "7.119.2",
+      "resolved": "https://registry.npmjs.org/@sentry/replay/-/replay-7.119.2.tgz",
+      "integrity": "sha512-nHDsBt0mlJXTWAHjzQdCzDbhV2fv8B62PPB5mu5SpI+G5h+ir3r5lR0lZZrMT8eurVowb/HnLXAs+XYVug3blg==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry-internal/tracing": "7.119.2",
+        "@sentry/core": "7.119.2",
+        "@sentry/types": "7.119.2",
+        "@sentry/utils": "7.119.2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@bdelab/roam-apps/node_modules/@sentry/types": {
+      "version": "7.119.2",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.119.2.tgz",
+      "integrity": "sha512-ydq1tWsdG7QW+yFaTp0gFaowMLNVikIqM70wxWNK+u98QzKnVY/3XTixxNLsUtnAB4Y+isAzFhrc6Vb5GFdFeg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@bdelab/roam-apps/node_modules/@sentry/utils": {
+      "version": "7.119.2",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.119.2.tgz",
+      "integrity": "sha512-TLdUCvcNgzKP0r9YD7tgCL1PEUp42TObISridsPJ5rhpVGQJvpr+Six0zIkfDUxerLYWZoK8QMm9KgFlPLNQzA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/types": "7.119.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@bdelab/roam-apps/node_modules/@sentry/wasm": {
+      "version": "7.119.2",
+      "resolved": "https://registry.npmjs.org/@sentry/wasm/-/wasm-7.119.2.tgz",
+      "integrity": "sha512-SGrrGeU6gkKp+k+Tb1yBzNKW+xj4OdiT8Mql68fSeSqQxDktk48m4/nkTAdhkZ/sYmGkO1wcmq2S/4axcGtJWw==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/browser": "7.119.2",
+        "@sentry/core": "7.119.2",
+        "@sentry/types": "7.119.2",
+        "@sentry/utils": "7.119.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/@bdelab/roam-fluency": {
       "version": "1.11.26",
@@ -38885,6 +39075,156 @@
           "version": "14.18.63",
           "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.63.tgz",
           "integrity": "sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ=="
+        }
+      }
+    },
+    "@bdelab/roam-apps": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bdelab/roam-apps/-/roam-apps-1.0.2.tgz",
+      "integrity": "sha512-vp+Vj+5SRWW/8PaqsRZhwB7SvnRJXL2IkhJ8EIsO7JqRmca1FTpTeBJZa6VIbOtTPkZNWIFD2Di6N4tlVtgvNg==",
+      "requires": {
+        "@bdelab/jscat": "^4.0.0",
+        "@bdelab/roar-firekit": "^9.1.0",
+        "@bdelab/roar-utils": "^1.2.2",
+        "@jspsych-contrib/plugin-audio-multi-response": "^1.0.0",
+        "@jspsych-contrib/plugin-html-multi-response": "^1.0.2",
+        "@jspsych-contrib/plugin-html-swipe-response": "^1.0.0",
+        "@jspsych/plugin-audio-button-response": "^1.1.2",
+        "@jspsych/plugin-audio-keyboard-response": "^1.1.0",
+        "@jspsych/plugin-call-function": "^1.1.2",
+        "@jspsych/plugin-fullscreen": "^1.1.0",
+        "@jspsych/plugin-html-button-response": "^1.1.0",
+        "@jspsych/plugin-html-keyboard-response": "^1.1.0",
+        "@jspsych/plugin-html-slider-response": "^1.1.3",
+        "@jspsych/plugin-preload": "^1.1.0",
+        "@jspsych/plugin-survey-html-form": "^1.0.0",
+        "@jspsych/plugin-survey-multi-select": "^1.1.0",
+        "@jspsych/plugin-survey-text": "^1.1.0",
+        "@sentry/browser": "^7.101.1",
+        "@sentry/integrations": "^7.101.1",
+        "@sentry/rollup-plugin": "^2.14.1",
+        "@sentry/wasm": "^7.101.1",
+        "@sentry/webpack-plugin": "^2.14.1",
+        "csv-loader": "^3.0.5",
+        "detect-it": "^4.0.1",
+        "file-loader": "^6.2.0",
+        "fkill-cli": "^8.0.0",
+        "fscreen": "^1.2.0",
+        "i18next": "^22.4.15",
+        "i18next-browser-languagedetector": "^7.0.1",
+        "jspsych": "^7.2.1",
+        "katex": "^0.16.9",
+        "lerp": "^1.0.3",
+        "lodash": "^4.17.21",
+        "mime-types": "^2.1.35",
+        "path-browserify": "^1.0.1",
+        "process": "^0.11.10",
+        "regenerator-runtime": "^0.13.9",
+        "roarr": "^7.14.0",
+        "store2": "^2.13.2",
+        "webpack": "^5.70.0"
+      },
+      "dependencies": {
+        "@sentry-internal/feedback": {
+          "version": "7.119.2",
+          "resolved": "https://registry.npmjs.org/@sentry-internal/feedback/-/feedback-7.119.2.tgz",
+          "integrity": "sha512-bnR1yJWVBZfXGx675nMXE8hCXsxluCBfIFy9GQT8PTN/urxpoS9cGz+5F7MA7Xe3Q06/7TT0Mz3fcDvjkqTu3Q==",
+          "requires": {
+            "@sentry/core": "7.119.2",
+            "@sentry/types": "7.119.2",
+            "@sentry/utils": "7.119.2"
+          }
+        },
+        "@sentry-internal/replay-canvas": {
+          "version": "7.119.2",
+          "resolved": "https://registry.npmjs.org/@sentry-internal/replay-canvas/-/replay-canvas-7.119.2.tgz",
+          "integrity": "sha512-Lqo8IFyeKkdOrOGRqm9jCEqeBl8kINe5+c2VqULpkO/I6ql6ISwPSYnmG6yL8cCVIaT1893CLog/pS4FxCv8/Q==",
+          "requires": {
+            "@sentry/core": "7.119.2",
+            "@sentry/replay": "7.119.2",
+            "@sentry/types": "7.119.2",
+            "@sentry/utils": "7.119.2"
+          }
+        },
+        "@sentry-internal/tracing": {
+          "version": "7.119.2",
+          "resolved": "https://registry.npmjs.org/@sentry-internal/tracing/-/tracing-7.119.2.tgz",
+          "integrity": "sha512-V2W+STWrafyGJhQv3ulMFXYDwWHiU6wHQAQBShsHVACiFaDrJ2kPRet38FKv4dMLlLlP2xN+ss2e5zv3tYlTiQ==",
+          "requires": {
+            "@sentry/core": "7.119.2",
+            "@sentry/types": "7.119.2",
+            "@sentry/utils": "7.119.2"
+          }
+        },
+        "@sentry/browser": {
+          "version": "7.119.2",
+          "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-7.119.2.tgz",
+          "integrity": "sha512-Wb2RzCsJBTNCmS9KPmbVyV5GGzFXjFdUThAN9xlnN5GgemMBwdQjGu/tRYr8yJAVsRb0EOFH8IuJBNKKNnO49g==",
+          "requires": {
+            "@sentry-internal/feedback": "7.119.2",
+            "@sentry-internal/replay-canvas": "7.119.2",
+            "@sentry-internal/tracing": "7.119.2",
+            "@sentry/core": "7.119.2",
+            "@sentry/integrations": "7.119.2",
+            "@sentry/replay": "7.119.2",
+            "@sentry/types": "7.119.2",
+            "@sentry/utils": "7.119.2"
+          }
+        },
+        "@sentry/core": {
+          "version": "7.119.2",
+          "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.119.2.tgz",
+          "integrity": "sha512-hQr3d2yWq/2lMvoyBPOwXw1IHqTrCjOsU1vYKhAa6w9vGbJZFGhKGGE2KEi/92c3gqGn+gW/PC7cV6waCTDuVA==",
+          "requires": {
+            "@sentry/types": "7.119.2",
+            "@sentry/utils": "7.119.2"
+          }
+        },
+        "@sentry/integrations": {
+          "version": "7.119.2",
+          "resolved": "https://registry.npmjs.org/@sentry/integrations/-/integrations-7.119.2.tgz",
+          "integrity": "sha512-dCuXKvbUE3gXVVa696SYMjlhSP6CxpMH/gl4Jk26naEB8Xjsn98z/hqEoXLg6Nab73rjR9c/9AdKqBbwVMHyrQ==",
+          "requires": {
+            "@sentry/core": "7.119.2",
+            "@sentry/types": "7.119.2",
+            "@sentry/utils": "7.119.2",
+            "localforage": "^1.8.1"
+          }
+        },
+        "@sentry/replay": {
+          "version": "7.119.2",
+          "resolved": "https://registry.npmjs.org/@sentry/replay/-/replay-7.119.2.tgz",
+          "integrity": "sha512-nHDsBt0mlJXTWAHjzQdCzDbhV2fv8B62PPB5mu5SpI+G5h+ir3r5lR0lZZrMT8eurVowb/HnLXAs+XYVug3blg==",
+          "requires": {
+            "@sentry-internal/tracing": "7.119.2",
+            "@sentry/core": "7.119.2",
+            "@sentry/types": "7.119.2",
+            "@sentry/utils": "7.119.2"
+          }
+        },
+        "@sentry/types": {
+          "version": "7.119.2",
+          "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.119.2.tgz",
+          "integrity": "sha512-ydq1tWsdG7QW+yFaTp0gFaowMLNVikIqM70wxWNK+u98QzKnVY/3XTixxNLsUtnAB4Y+isAzFhrc6Vb5GFdFeg=="
+        },
+        "@sentry/utils": {
+          "version": "7.119.2",
+          "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.119.2.tgz",
+          "integrity": "sha512-TLdUCvcNgzKP0r9YD7tgCL1PEUp42TObISridsPJ5rhpVGQJvpr+Six0zIkfDUxerLYWZoK8QMm9KgFlPLNQzA==",
+          "requires": {
+            "@sentry/types": "7.119.2"
+          }
+        },
+        "@sentry/wasm": {
+          "version": "7.119.2",
+          "resolved": "https://registry.npmjs.org/@sentry/wasm/-/wasm-7.119.2.tgz",
+          "integrity": "sha512-SGrrGeU6gkKp+k+Tb1yBzNKW+xj4OdiT8Mql68fSeSqQxDktk48m4/nkTAdhkZ/sYmGkO1wcmq2S/4axcGtJWw==",
+          "requires": {
+            "@sentry/browser": "7.119.2",
+            "@sentry/core": "7.119.2",
+            "@sentry/types": "7.119.2",
+            "@sentry/utils": "7.119.2"
+          }
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -86,7 +86,8 @@
     "vue-router": "^4.1.6",
     "vue3-text-clamp": "^0.1.2",
     "workbox-precaching": "^7.1.0",
-    "zipson": "^0.2.12"
+    "zipson": "^0.2.12",
+    "@bdelab/roam-apps": "1.0.2"
   },
   "devDependencies": {
     "@pinia/testing": "^0.1.5",


### PR DESCRIPTION
This PR updates the version of `@bdelab/roam-apps` to 1.0.2.