### PR TITLE
Update Multichoice version to 1.11.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,9 @@
       "version": "3.0.2",
       "dependencies": {
         "@bdelab/roam-apps": "^1.0.0",
-        "@bdelab/roar-firekit": "^9.1.0",
+        "@bdelab/roar-firekit": "9.1.0",
         "@bdelab/roar-letter": "1.11.8",
-        "@bdelab/roar-multichoice": "^1.11.3",
+        "@bdelab/roar-multichoice": "1.11.4",
         "@bdelab/roar-pa": "2.2.4",
         "@bdelab/roar-sre": "1.15.9",
         "@bdelab/roar-swr": "^1.12.1",
@@ -2791,9 +2791,9 @@
       }
     },
     "node_modules/@bdelab/roar-multichoice": {
-      "version": "1.11.3",
-      "resolved": "https://registry.npmjs.org/@bdelab/roar-multichoice/-/roar-multichoice-1.11.3.tgz",
-      "integrity": "sha512-ebWVSLVdR1l+80eAs2DRSsCTdQEjUSJ7fdXFl1EIGNlSMLWvi5LYfcbwAbEhqSbhZKnBTmsvsA4/XJlhF8FSKA==",
+      "version": "1.11.4",
+      "resolved": "https://registry.npmjs.org/@bdelab/roar-multichoice/-/roar-multichoice-1.11.4.tgz",
+      "integrity": "sha512-aLwljB7Khg0OHGgyGFvlIQCZPU+7aoDGgWaf/xC3fpbm0bijwUzx+R5V8XgY8aDKEMm/RsJV4qMFPTGd3BvYEw==",
       "dependencies": {
         "@bdelab/jscat": "^4.0.0",
         "@bdelab/roar-firekit": "^4.7.0",
@@ -39859,9 +39859,9 @@
       }
     },
     "@bdelab/roar-multichoice": {
-      "version": "1.11.3",
-      "resolved": "https://registry.npmjs.org/@bdelab/roar-multichoice/-/roar-multichoice-1.11.3.tgz",
-      "integrity": "sha512-ebWVSLVdR1l+80eAs2DRSsCTdQEjUSJ7fdXFl1EIGNlSMLWvi5LYfcbwAbEhqSbhZKnBTmsvsA4/XJlhF8FSKA==",
+      "version": "1.11.4",
+      "resolved": "https://registry.npmjs.org/@bdelab/roar-multichoice/-/roar-multichoice-1.11.4.tgz",
+      "integrity": "sha512-aLwljB7Khg0OHGgyGFvlIQCZPU+7aoDGgWaf/xC3fpbm0bijwUzx+R5V8XgY8aDKEMm/RsJV4qMFPTGd3BvYEw==",
       "requires": {
         "@bdelab/jscat": "^4.0.0",
         "@bdelab/roar-firekit": "^4.7.0",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@bdelab/roam-apps": "^1.0.0",
     "@bdelab/roar-firekit": "9.1.0",
     "@bdelab/roar-letter": "1.11.8",
-    "@bdelab/roar-multichoice": "^1.11.3",
+    "@bdelab/roar-multichoice": "1.11.4",
     "@bdelab/roar-pa": "2.2.4",
     "@bdelab/roar-sre": "1.15.9",
     "@bdelab/roar-swr": "^1.12.1",


### PR DESCRIPTION
This PR updates the version of `@bdelab/roar-multichoice` to 1.11.4.