### PR TITLE
Update MEP version to 1.1.27

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@bdelab/roar-utils": "^1.2.1",
         "@bdelab/roar-vocab": "^1.8.0",
         "@bdelab/roav-crowding": "1.1.16",
-        "@bdelab/roav-mep": "^1.1.21",
+        "@bdelab/roav-mep": "1.1.27",
         "@bdelab/roav-ran": "^1.0.30",
         "@levante-framework/core-tasks": "1.0.0-beta.16",
         "@sentry/browser": "^8.0.0",
@@ -6677,9 +6677,9 @@
       }
     },
     "node_modules/@bdelab/roav-mep": {
-      "version": "1.1.22",
-      "resolved": "https://registry.npmjs.org/@bdelab/roav-mep/-/roav-mep-1.1.22.tgz",
-      "integrity": "sha512-igr+XtQ1Mdn01kKyrUGexLkakHMdz58HTRzC5ZzujDm2C0agzjKG3OOEQdy+ICmvtDL0v8xzlauNSgelSj93PA==",
+      "version": "1.1.27",
+      "resolved": "https://registry.npmjs.org/@bdelab/roav-mep/-/roav-mep-1.1.27.tgz",
+      "integrity": "sha512-zG+vxGBbI3VR93opHJgOHwDPMxeb6W/rC98MHP9a/u9aFQF7eocKajwytoPxtYTgZunf+4zndkMdlk7q1bAi5g==",
       "dependencies": {
         "@bdelab/jscat": "^4.0.0",
         "@bdelab/roar-firekit": "^4.7.0",
@@ -43125,9 +43125,9 @@
       }
     },
     "@bdelab/roav-mep": {
-      "version": "1.1.22",
-      "resolved": "https://registry.npmjs.org/@bdelab/roav-mep/-/roav-mep-1.1.22.tgz",
-      "integrity": "sha512-igr+XtQ1Mdn01kKyrUGexLkakHMdz58HTRzC5ZzujDm2C0agzjKG3OOEQdy+ICmvtDL0v8xzlauNSgelSj93PA==",
+      "version": "1.1.27",
+      "resolved": "https://registry.npmjs.org/@bdelab/roav-mep/-/roav-mep-1.1.27.tgz",
+      "integrity": "sha512-zG+vxGBbI3VR93opHJgOHwDPMxeb6W/rC98MHP9a/u9aFQF7eocKajwytoPxtYTgZunf+4zndkMdlk7q1bAi5g==",
       "requires": {
         "@bdelab/jscat": "^4.0.0",
         "@bdelab/roar-firekit": "^4.7.0",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@bdelab/roar-utils": "^1.2.1",
     "@bdelab/roar-vocab": "^1.8.0",
     "@bdelab/roav-crowding": "1.1.16",
-    "@bdelab/roav-mep": "^1.1.21",
+    "@bdelab/roav-mep": "1.1.27",
     "@bdelab/roav-ran": "^1.0.30",
     "@levante-framework/core-tasks": "1.0.0-beta.16",
     "@sentry/browser": "^8.0.0",


### PR DESCRIPTION
This PR updates the version of `@bdelab/roav-mep` to 1.1.27.