### PR TITLE
Update ROAV-Crowding version to 1.1.23

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@bdelab/roar-swr": "^1.12.1",
         "@bdelab/roar-utils": "^1.2.1",
         "@bdelab/roar-vocab": "^1.8.0",
-        "@bdelab/roav-crowding": "1.1.16",
+        "@bdelab/roav-crowding": "1.1.23",
         "@bdelab/roav-mep": "^1.1.21",
         "@bdelab/roav-ran": "^1.0.30",
         "@levante-framework/core-tasks": "1.0.0-beta.16",
@@ -6530,9 +6530,9 @@
       }
     },
     "node_modules/@bdelab/roav-crowding": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/@bdelab/roav-crowding/-/roav-crowding-1.1.16.tgz",
-      "integrity": "sha512-xNaiz8Vwu9HoMgzU4Kd2fTgjZdVMa/2EAjZiIER/gTZrWNTKuJffqnAu9GL92nwqrVVYi5Qr1THhgOWzwcS6HQ==",
+      "version": "1.1.23",
+      "resolved": "https://registry.npmjs.org/@bdelab/roav-crowding/-/roav-crowding-1.1.23.tgz",
+      "integrity": "sha512-W1uaMGCVXWQrssmESS5K3gqP8+uFNY3lmy7+1C3iZ+mIRgvnHVSWlhnlOPM+92XK3jjQEAPpueesFoEIY6AoDw==",
       "dependencies": {
         "@bdelab/jscat": "^4.0.0",
         "@bdelab/roar-firekit": "^4.7.0",
@@ -24853,7 +24853,6 @@
     },
     "node_modules/npm/node_modules/lodash._baseindexof": {
       "version": "3.1.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
@@ -24878,19 +24877,16 @@
     },
     "node_modules/npm/node_modules/lodash._bindcallback": {
       "version": "3.0.1",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/lodash._cacheindexof": {
       "version": "3.0.2",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/lodash._createcache": {
       "version": "3.1.2",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -24899,7 +24895,6 @@
     },
     "node_modules/npm/node_modules/lodash._getnative": {
       "version": "3.9.1",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
@@ -24910,7 +24905,6 @@
     },
     "node_modules/npm/node_modules/lodash.restparam": {
       "version": "3.6.1",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
@@ -43003,9 +42997,9 @@
       }
     },
     "@bdelab/roav-crowding": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/@bdelab/roav-crowding/-/roav-crowding-1.1.16.tgz",
-      "integrity": "sha512-xNaiz8Vwu9HoMgzU4Kd2fTgjZdVMa/2EAjZiIER/gTZrWNTKuJffqnAu9GL92nwqrVVYi5Qr1THhgOWzwcS6HQ==",
+      "version": "1.1.23",
+      "resolved": "https://registry.npmjs.org/@bdelab/roav-crowding/-/roav-crowding-1.1.23.tgz",
+      "integrity": "sha512-W1uaMGCVXWQrssmESS5K3gqP8+uFNY3lmy7+1C3iZ+mIRgvnHVSWlhnlOPM+92XK3jjQEAPpueesFoEIY6AoDw==",
       "requires": {
         "@bdelab/jscat": "^4.0.0",
         "@bdelab/roar-firekit": "^4.7.0",
@@ -56542,8 +56536,7 @@
         },
         "lodash._baseindexof": {
           "version": "3.1.0",
-          "bundled": true,
-          "extraneous": true
+          "bundled": true
         },
         "lodash._baseuniq": {
           "version": "4.6.0",
@@ -56565,26 +56558,22 @@
         },
         "lodash._bindcallback": {
           "version": "3.0.1",
-          "bundled": true,
-          "extraneous": true
+          "bundled": true
         },
         "lodash._cacheindexof": {
           "version": "3.0.2",
-          "bundled": true,
-          "extraneous": true
+          "bundled": true
         },
         "lodash._createcache": {
           "version": "3.1.2",
           "bundled": true,
-          "extraneous": true,
           "requires": {
             "lodash._getnative": "^3.0.0"
           }
         },
         "lodash._getnative": {
           "version": "3.9.1",
-          "bundled": true,
-          "extraneous": true
+          "bundled": true
         },
         "lodash.clonedeep": {
           "version": "4.5.0",
@@ -56592,8 +56581,7 @@
         },
         "lodash.restparam": {
           "version": "3.6.1",
-          "bundled": true,
-          "extraneous": true
+          "bundled": true
         },
         "lodash.union": {
           "version": "4.6.0",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@bdelab/roar-swr": "^1.12.1",
     "@bdelab/roar-utils": "^1.2.1",
     "@bdelab/roar-vocab": "^1.8.0",
-    "@bdelab/roav-crowding": "1.1.16",
+    "@bdelab/roav-crowding": "1.1.23",
     "@bdelab/roav-mep": "^1.1.21",
     "@bdelab/roav-ran": "^1.0.30",
     "@levante-framework/core-tasks": "1.0.0-beta.16",


### PR DESCRIPTION
This PR updates the version of `@bdelab/roav-crowding` to 1.1.23.