### PR TITLE
Update Multichoice version to 1.11.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@bdelab/roam-apps": "^1.0.0",
         "@bdelab/roar-firekit": "9.1.0",
         "@bdelab/roar-letter": "1.11.8",
-        "@bdelab/roar-multichoice": "^1.11.5",
+        "@bdelab/roar-multichoice": "1.11.6",
         "@bdelab/roar-pa": "2.2.4",
         "@bdelab/roar-sre": "1.15.9",
         "@bdelab/roar-swr": "^1.12.1",
@@ -2791,11 +2791,11 @@
       }
     },
     "node_modules/@bdelab/roar-multichoice": {
-      "version": "1.11.5",
-      "resolved": "https://registry.npmjs.org/@bdelab/roar-multichoice/-/roar-multichoice-1.11.5.tgz",
-      "integrity": "sha512-5ScfQSzkoGdn7FEYsZvA1UgrFbAmRgQwZGbZbS0xRs0jvK8NcciaOuvntd2SpQvf+1s26TGO9Bh17lyYOh9JnQ==",
+      "version": "1.11.6",
+      "resolved": "https://registry.npmjs.org/@bdelab/roar-multichoice/-/roar-multichoice-1.11.6.tgz",
+      "integrity": "sha512-yaYW2nEmJgPGsh8MBvZvWsjaVdkrD7lJvSAp4DxusSrqn50AUno2sWiYY+msrlIdZR67X4MI9WPcvokJNizPtA==",
       "dependencies": {
-        "@bdelab/jscat": "^4.0.0",
+        "@bdelab/jscat": "4.0.0",
         "@bdelab/roar-firekit": "^4.7.0",
         "@bdelab/roar-utils": "^1.0.18",
         "@jspsych-contrib/plugin-audio-multi-response": "^1.0.0",
@@ -39859,11 +39859,11 @@
       }
     },
     "@bdelab/roar-multichoice": {
-      "version": "1.11.5",
-      "resolved": "https://registry.npmjs.org/@bdelab/roar-multichoice/-/roar-multichoice-1.11.5.tgz",
-      "integrity": "sha512-5ScfQSzkoGdn7FEYsZvA1UgrFbAmRgQwZGbZbS0xRs0jvK8NcciaOuvntd2SpQvf+1s26TGO9Bh17lyYOh9JnQ==",
+      "version": "1.11.6",
+      "resolved": "https://registry.npmjs.org/@bdelab/roar-multichoice/-/roar-multichoice-1.11.6.tgz",
+      "integrity": "sha512-yaYW2nEmJgPGsh8MBvZvWsjaVdkrD7lJvSAp4DxusSrqn50AUno2sWiYY+msrlIdZR67X4MI9WPcvokJNizPtA==",
       "requires": {
-        "@bdelab/jscat": "^4.0.0",
+        "@bdelab/jscat": "4.0.0",
         "@bdelab/roar-firekit": "^4.7.0",
         "@bdelab/roar-utils": "^1.0.18",
         "@jspsych-contrib/plugin-audio-multi-response": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@bdelab/roam-apps": "^1.0.0",
     "@bdelab/roar-firekit": "9.1.0",
     "@bdelab/roar-letter": "1.11.8",
-    "@bdelab/roar-multichoice": "^1.11.5",
+    "@bdelab/roar-multichoice": "1.11.6",
     "@bdelab/roar-pa": "2.2.4",
     "@bdelab/roar-sre": "1.15.9",
     "@bdelab/roar-swr": "^1.12.1",


### PR DESCRIPTION
This PR updates the version of `@bdelab/roar-multichoice` to 1.11.6.