### PR TITLE
Update Letter version to 1.11.9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@bdelab/roam-apps": "^1.0.0",
         "@bdelab/roar-firekit": "9.1.0",
-        "@bdelab/roar-letter": "1.11.8",
+        "@bdelab/roar-letter": "1.11.9",
         "@bdelab/roar-multichoice": "^1.11.5",
         "@bdelab/roar-pa": "2.2.4",
         "@bdelab/roar-sre": "1.15.9",
@@ -1908,12 +1908,11 @@
       }
     },
     "node_modules/@bdelab/roar-letter": {
-      "version": "1.11.8",
-      "resolved": "https://registry.npmjs.org/@bdelab/roar-letter/-/roar-letter-1.11.8.tgz",
-      "integrity": "sha512-y0VJ6mIYf0KkDZ1tvt9aGWFSokF9dhuJv74vf9yiewIFQxJHft/LIWfjscvW/Hpe9YUwJuHjJ0Liq129jbA1Qg==",
-      "license": "Stanford Academic Software License for ROAR",
+      "version": "1.11.9",
+      "resolved": "https://registry.npmjs.org/@bdelab/roar-letter/-/roar-letter-1.11.9.tgz",
+      "integrity": "sha512-imkmbpVHGvZSR79vOjFSp3lGSx6qc015xz0lql2gsh9agYjD6Q7upE3RE6IMgYVGpOsl6tLGtIvPhFsv8/zuTg==",
       "dependencies": {
-        "@bdelab/jscat": "^4.0.0",
+        "@bdelab/jscat": "4.0.0",
         "@bdelab/roar-firekit": "^4.7.0",
         "@bdelab/roar-utils": "^1.0.18",
         "@jspsych-contrib/plugin-audio-multi-response": "^1.0.0",
@@ -39112,11 +39111,11 @@
       }
     },
     "@bdelab/roar-letter": {
-      "version": "1.11.8",
-      "resolved": "https://registry.npmjs.org/@bdelab/roar-letter/-/roar-letter-1.11.8.tgz",
-      "integrity": "sha512-y0VJ6mIYf0KkDZ1tvt9aGWFSokF9dhuJv74vf9yiewIFQxJHft/LIWfjscvW/Hpe9YUwJuHjJ0Liq129jbA1Qg==",
+      "version": "1.11.9",
+      "resolved": "https://registry.npmjs.org/@bdelab/roar-letter/-/roar-letter-1.11.9.tgz",
+      "integrity": "sha512-imkmbpVHGvZSR79vOjFSp3lGSx6qc015xz0lql2gsh9agYjD6Q7upE3RE6IMgYVGpOsl6tLGtIvPhFsv8/zuTg==",
       "requires": {
-        "@bdelab/jscat": "^4.0.0",
+        "@bdelab/jscat": "4.0.0",
         "@bdelab/roar-firekit": "^4.7.0",
         "@bdelab/roar-utils": "^1.0.18",
         "@jspsych-contrib/plugin-audio-multi-response": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "dependencies": {
     "@bdelab/roam-apps": "^1.0.0",
     "@bdelab/roar-firekit": "9.1.0",
-    "@bdelab/roar-letter": "1.11.8",
+    "@bdelab/roar-letter": "1.11.9",
     "@bdelab/roar-multichoice": "^1.11.5",
     "@bdelab/roar-pa": "2.2.4",
     "@bdelab/roar-sre": "1.15.9",


### PR DESCRIPTION
This PR updates the version of `@bdelab/roar-letter` to 1.11.9.