### PR TITLE
Update ROAV-Crowding version to 1.1.24

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@bdelab/roar-swr": "1.12.7",
         "@bdelab/roar-utils": "^1.2.1",
         "@bdelab/roar-vocab": "1.8.0",
-        "@bdelab/roav-crowding": "1.1.23",
+        "@bdelab/roav-crowding": "1.1.24",
         "@bdelab/roav-mep": "1.1.28",
         "@bdelab/roav-ran": "1.0.30",
         "@levante-framework/core-tasks": "1.0.0-beta.16",
@@ -6509,9 +6509,9 @@
       }
     },
     "node_modules/@bdelab/roav-crowding": {
-      "version": "1.1.23",
-      "resolved": "https://registry.npmjs.org/@bdelab/roav-crowding/-/roav-crowding-1.1.23.tgz",
-      "integrity": "sha512-W1uaMGCVXWQrssmESS5K3gqP8+uFNY3lmy7+1C3iZ+mIRgvnHVSWlhnlOPM+92XK3jjQEAPpueesFoEIY6AoDw==",
+      "version": "1.1.24",
+      "resolved": "https://registry.npmjs.org/@bdelab/roav-crowding/-/roav-crowding-1.1.24.tgz",
+      "integrity": "sha512-lCrWFCikIHuYGnF7dRnQksvdhLo+eoc4+DrfdZYVpI2Tg3oScJ23Zj+4Qwbktc2Lp/ATPt99rdCQCCK+e3gNKQ==",
       "dependencies": {
         "@bdelab/jscat": "^4.0.0",
         "@bdelab/roar-firekit": "^4.7.0",
@@ -24937,7 +24937,6 @@
     },
     "node_modules/npm/node_modules/lodash._baseindexof": {
       "version": "3.1.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
@@ -24962,19 +24961,16 @@
     },
     "node_modules/npm/node_modules/lodash._bindcallback": {
       "version": "3.0.1",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/lodash._cacheindexof": {
       "version": "3.0.2",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/lodash._createcache": {
       "version": "3.1.2",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -24983,7 +24979,6 @@
     },
     "node_modules/npm/node_modules/lodash._getnative": {
       "version": "3.9.1",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
@@ -24994,7 +24989,6 @@
     },
     "node_modules/npm/node_modules/lodash.restparam": {
       "version": "3.6.1",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
@@ -43004,9 +42998,9 @@
       }
     },
     "@bdelab/roav-crowding": {
-      "version": "1.1.23",
-      "resolved": "https://registry.npmjs.org/@bdelab/roav-crowding/-/roav-crowding-1.1.23.tgz",
-      "integrity": "sha512-W1uaMGCVXWQrssmESS5K3gqP8+uFNY3lmy7+1C3iZ+mIRgvnHVSWlhnlOPM+92XK3jjQEAPpueesFoEIY6AoDw==",
+      "version": "1.1.24",
+      "resolved": "https://registry.npmjs.org/@bdelab/roav-crowding/-/roav-crowding-1.1.24.tgz",
+      "integrity": "sha512-lCrWFCikIHuYGnF7dRnQksvdhLo+eoc4+DrfdZYVpI2Tg3oScJ23Zj+4Qwbktc2Lp/ATPt99rdCQCCK+e3gNKQ==",
       "requires": {
         "@bdelab/jscat": "^4.0.0",
         "@bdelab/roar-firekit": "^4.7.0",
@@ -56631,8 +56625,7 @@
         },
         "lodash._baseindexof": {
           "version": "3.1.0",
-          "bundled": true,
-          "extraneous": true
+          "bundled": true
         },
         "lodash._baseuniq": {
           "version": "4.6.0",
@@ -56654,26 +56647,22 @@
         },
         "lodash._bindcallback": {
           "version": "3.0.1",
-          "bundled": true,
-          "extraneous": true
+          "bundled": true
         },
         "lodash._cacheindexof": {
           "version": "3.0.2",
-          "bundled": true,
-          "extraneous": true
+          "bundled": true
         },
         "lodash._createcache": {
           "version": "3.1.2",
           "bundled": true,
-          "extraneous": true,
           "requires": {
             "lodash._getnative": "^3.0.0"
           }
         },
         "lodash._getnative": {
           "version": "3.9.1",
-          "bundled": true,
-          "extraneous": true
+          "bundled": true
         },
         "lodash.clonedeep": {
           "version": "4.5.0",
@@ -56681,8 +56670,7 @@
         },
         "lodash.restparam": {
           "version": "3.6.1",
-          "bundled": true,
-          "extraneous": true
+          "bundled": true
         },
         "lodash.union": {
           "version": "4.6.0",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@bdelab/roar-swr": "1.12.7",
     "@bdelab/roar-utils": "^1.2.1",
     "@bdelab/roar-vocab": "1.8.0",
-    "@bdelab/roav-crowding": "1.1.23",
+    "@bdelab/roav-crowding": "1.1.24",
     "@bdelab/roav-mep": "1.1.28",
     "@bdelab/roav-ran": "1.0.30",
     "@levante-framework/core-tasks": "1.0.0-beta.16",


### PR DESCRIPTION
This PR updates the version of `@bdelab/roav-crowding` to 1.1.24.