### PR TITLE
Update MEP version to 1.1.31

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@bdelab/roar-utils": "^1.2.1",
         "@bdelab/roar-vocab": "1.8.0",
         "@bdelab/roav-crowding": "1.1.23",
-        "@bdelab/roav-mep": "1.1.28",
+        "@bdelab/roav-mep": "1.1.31",
         "@bdelab/roav-ran": "1.0.30",
         "@levante-framework/core-tasks": "1.0.0-beta.16",
         "@sentry/browser": "^8.0.0",
@@ -6656,9 +6656,9 @@
       }
     },
     "node_modules/@bdelab/roav-mep": {
-      "version": "1.1.28",
-      "resolved": "https://registry.npmjs.org/@bdelab/roav-mep/-/roav-mep-1.1.28.tgz",
-      "integrity": "sha512-bGl6UTxpxoPcPfbNBEvWmHqxZYPcWuLrlupWX9TG7j54mVNQYDiuLlVTD2+O06MtY6L2s4HXUKC6iMyrVDHv8Q==",
+      "version": "1.1.31",
+      "resolved": "https://registry.npmjs.org/@bdelab/roav-mep/-/roav-mep-1.1.31.tgz",
+      "integrity": "sha512-qrOv6gvPl0rSW8yMyr2vQ4cfepCqiDktuLyEirBGCUetiEFqWJaEsineFwjpAQR4JUhA9sbH38KGLREBeTcAUw==",
       "dependencies": {
         "@bdelab/jscat": "^4.0.0",
         "@bdelab/roar-firekit": "^4.7.0",
@@ -24937,7 +24937,6 @@
     },
     "node_modules/npm/node_modules/lodash._baseindexof": {
       "version": "3.1.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
@@ -24962,19 +24961,16 @@
     },
     "node_modules/npm/node_modules/lodash._bindcallback": {
       "version": "3.0.1",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/lodash._cacheindexof": {
       "version": "3.0.2",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/lodash._createcache": {
       "version": "3.1.2",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -24983,7 +24979,6 @@
     },
     "node_modules/npm/node_modules/lodash._getnative": {
       "version": "3.9.1",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
@@ -24994,7 +24989,6 @@
     },
     "node_modules/npm/node_modules/lodash.restparam": {
       "version": "3.6.1",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
@@ -43132,9 +43126,9 @@
       }
     },
     "@bdelab/roav-mep": {
-      "version": "1.1.28",
-      "resolved": "https://registry.npmjs.org/@bdelab/roav-mep/-/roav-mep-1.1.28.tgz",
-      "integrity": "sha512-bGl6UTxpxoPcPfbNBEvWmHqxZYPcWuLrlupWX9TG7j54mVNQYDiuLlVTD2+O06MtY6L2s4HXUKC6iMyrVDHv8Q==",
+      "version": "1.1.31",
+      "resolved": "https://registry.npmjs.org/@bdelab/roav-mep/-/roav-mep-1.1.31.tgz",
+      "integrity": "sha512-qrOv6gvPl0rSW8yMyr2vQ4cfepCqiDktuLyEirBGCUetiEFqWJaEsineFwjpAQR4JUhA9sbH38KGLREBeTcAUw==",
       "requires": {
         "@bdelab/jscat": "^4.0.0",
         "@bdelab/roar-firekit": "^4.7.0",
@@ -56631,8 +56625,7 @@
         },
         "lodash._baseindexof": {
           "version": "3.1.0",
-          "bundled": true,
-          "extraneous": true
+          "bundled": true
         },
         "lodash._baseuniq": {
           "version": "4.6.0",
@@ -56654,26 +56647,22 @@
         },
         "lodash._bindcallback": {
           "version": "3.0.1",
-          "bundled": true,
-          "extraneous": true
+          "bundled": true
         },
         "lodash._cacheindexof": {
           "version": "3.0.2",
-          "bundled": true,
-          "extraneous": true
+          "bundled": true
         },
         "lodash._createcache": {
           "version": "3.1.2",
           "bundled": true,
-          "extraneous": true,
           "requires": {
             "lodash._getnative": "^3.0.0"
           }
         },
         "lodash._getnative": {
           "version": "3.9.1",
-          "bundled": true,
-          "extraneous": true
+          "bundled": true
         },
         "lodash.clonedeep": {
           "version": "4.5.0",
@@ -56681,8 +56670,7 @@
         },
         "lodash.restparam": {
           "version": "3.6.1",
-          "bundled": true,
-          "extraneous": true
+          "bundled": true
         },
         "lodash.union": {
           "version": "4.6.0",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@bdelab/roar-utils": "^1.2.1",
     "@bdelab/roar-vocab": "1.8.0",
     "@bdelab/roav-crowding": "1.1.23",
-    "@bdelab/roav-mep": "1.1.28",
+    "@bdelab/roav-mep": "1.1.31",
     "@bdelab/roav-ran": "1.0.30",
     "@levante-framework/core-tasks": "1.0.0-beta.16",
     "@sentry/browser": "^8.0.0",


### PR DESCRIPTION
This PR updates the version of `@bdelab/roav-mep` to 1.1.31.