### PR TITLE
Update SRE version to 1.15.18

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@bdelab/roar-letter": "1.11.9",
         "@bdelab/roar-multichoice": "1.11.6",
         "@bdelab/roar-pa": "2.2.4",
-        "@bdelab/roar-sre": "1.15.15",
+        "@bdelab/roar-sre": "1.15.18",
         "@bdelab/roar-swr": "1.12.7",
         "@bdelab/roar-utils": "^1.2.1",
         "@bdelab/roar-vocab": "1.8.0",
@@ -3839,10 +3839,9 @@
       }
     },
     "node_modules/@bdelab/roar-sre": {
-      "version": "1.15.15",
-      "resolved": "https://registry.npmjs.org/@bdelab/roar-sre/-/roar-sre-1.15.15.tgz",
-      "integrity": "sha512-/A41PNBC4sb4B6a6NdV717odjAXLX24c+KOWdB78MNXlEch/zfau2i/ZHN172H0wJfR9YSB53/NieA2flZaiPQ==",
-      "license": "STANFORD ACADEMIC SOFTWARE LICENSE FOR ROAR™",
+      "version": "1.15.18",
+      "resolved": "https://registry.npmjs.org/@bdelab/roar-sre/-/roar-sre-1.15.18.tgz",
+      "integrity": "sha512-NsUnJDuGWFTpL5Q2zJ8I48Tb8r/XuB/fuXG3PU6HEwr546X/rkcApA1NeS52pXXF0nLplKEUjfW2JY7j1XyiBg==",
       "dependencies": {
         "@babel/core": "^7.19.3",
         "@babel/preset-env": "^7.19.4",
@@ -40747,9 +40746,9 @@
       }
     },
     "@bdelab/roar-sre": {
-      "version": "1.15.15",
-      "resolved": "https://registry.npmjs.org/@bdelab/roar-sre/-/roar-sre-1.15.15.tgz",
-      "integrity": "sha512-/A41PNBC4sb4B6a6NdV717odjAXLX24c+KOWdB78MNXlEch/zfau2i/ZHN172H0wJfR9YSB53/NieA2flZaiPQ==",
+      "version": "1.15.18",
+      "resolved": "https://registry.npmjs.org/@bdelab/roar-sre/-/roar-sre-1.15.18.tgz",
+      "integrity": "sha512-NsUnJDuGWFTpL5Q2zJ8I48Tb8r/XuB/fuXG3PU6HEwr546X/rkcApA1NeS52pXXF0nLplKEUjfW2JY7j1XyiBg==",
       "requires": {
         "@babel/core": "^7.19.3",
         "@babel/preset-env": "^7.19.4",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@bdelab/roar-letter": "1.11.9",
     "@bdelab/roar-multichoice": "1.11.6",
     "@bdelab/roar-pa": "2.2.4",
-    "@bdelab/roar-sre": "1.15.15",
+    "@bdelab/roar-sre": "1.15.18",
     "@bdelab/roar-swr": "1.12.7",
     "@bdelab/roar-utils": "^1.2.1",
     "@bdelab/roar-vocab": "1.8.0",


### PR DESCRIPTION
This PR updates the version of `@bdelab/roar-sre` to 1.15.18.