### PR TITLE
Update Multichoice version to 1.11.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@bdelab/roam-apps": "1.0.0",
         "@bdelab/roar-firekit": "9.1.0",
         "@bdelab/roar-letter": "1.11.9",
-        "@bdelab/roar-multichoice": "1.11.6",
+        "@bdelab/roar-multichoice": "1.11.7",
         "@bdelab/roar-pa": "2.2.4",
         "@bdelab/roar-sre": "1.15.15",
         "@bdelab/roar-swr": "1.12.7",
@@ -2791,10 +2791,9 @@
       }
     },
     "node_modules/@bdelab/roar-multichoice": {
-      "version": "1.11.6",
-      "resolved": "https://registry.npmjs.org/@bdelab/roar-multichoice/-/roar-multichoice-1.11.6.tgz",
-      "integrity": "sha512-yaYW2nEmJgPGsh8MBvZvWsjaVdkrD7lJvSAp4DxusSrqn50AUno2sWiYY+msrlIdZR67X4MI9WPcvokJNizPtA==",
-      "license": "Stanford Academic Software License for ROAR",
+      "version": "1.11.7",
+      "resolved": "https://registry.npmjs.org/@bdelab/roar-multichoice/-/roar-multichoice-1.11.7.tgz",
+      "integrity": "sha512-jKtulqJD6g2gv42NvRundxaP8z3v8LclvdsffWRylvRTKf63DXo248CtE555nx4qnXeFOPD7tmSK8ivxA9VjzA==",
       "dependencies": {
         "@bdelab/jscat": "4.0.0",
         "@bdelab/roar-firekit": "^4.7.0",
@@ -39868,9 +39867,9 @@
       }
     },
     "@bdelab/roar-multichoice": {
-      "version": "1.11.6",
-      "resolved": "https://registry.npmjs.org/@bdelab/roar-multichoice/-/roar-multichoice-1.11.6.tgz",
-      "integrity": "sha512-yaYW2nEmJgPGsh8MBvZvWsjaVdkrD7lJvSAp4DxusSrqn50AUno2sWiYY+msrlIdZR67X4MI9WPcvokJNizPtA==",
+      "version": "1.11.7",
+      "resolved": "https://registry.npmjs.org/@bdelab/roar-multichoice/-/roar-multichoice-1.11.7.tgz",
+      "integrity": "sha512-jKtulqJD6g2gv42NvRundxaP8z3v8LclvdsffWRylvRTKf63DXo248CtE555nx4qnXeFOPD7tmSK8ivxA9VjzA==",
       "requires": {
         "@bdelab/jscat": "4.0.0",
         "@bdelab/roar-firekit": "^4.7.0",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@bdelab/roam-apps": "1.0.0",
     "@bdelab/roar-firekit": "9.1.0",
     "@bdelab/roar-letter": "1.11.9",
-    "@bdelab/roar-multichoice": "1.11.6",
+    "@bdelab/roar-multichoice": "1.11.7",
     "@bdelab/roar-pa": "2.2.4",
     "@bdelab/roar-sre": "1.15.15",
     "@bdelab/roar-swr": "1.12.7",


### PR DESCRIPTION
This PR updates the version of `@bdelab/roar-multichoice` to 1.11.7.