### PR TITLE
Update ROAV-Crowding version to 1.1.26

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@bdelab/roar-swr": "1.12.7",
         "@bdelab/roar-utils": "^1.2.1",
         "@bdelab/roar-vocab": "1.8.0",
-        "@bdelab/roav-crowding": "1.1.23",
+        "@bdelab/roav-crowding": "1.1.26",
         "@bdelab/roav-mep": "1.1.28",
         "@bdelab/roav-ran": "1.0.30",
         "@levante-framework/core-tasks": "1.0.0-beta.25",
@@ -6509,9 +6509,9 @@
       }
     },
     "node_modules/@bdelab/roav-crowding": {
-      "version": "1.1.23",
-      "resolved": "https://registry.npmjs.org/@bdelab/roav-crowding/-/roav-crowding-1.1.23.tgz",
-      "integrity": "sha512-W1uaMGCVXWQrssmESS5K3gqP8+uFNY3lmy7+1C3iZ+mIRgvnHVSWlhnlOPM+92XK3jjQEAPpueesFoEIY6AoDw==",
+      "version": "1.1.26",
+      "resolved": "https://registry.npmjs.org/@bdelab/roav-crowding/-/roav-crowding-1.1.26.tgz",
+      "integrity": "sha512-VTQZbfSIzjCqE0wmrHmAz4dyotQilFdolEbL07Hq4omBshq0z8eclid7mbnfhdJ31jZdHAp1yC7epBigtsbvdg==",
       "dependencies": {
         "@bdelab/jscat": "^4.0.0",
         "@bdelab/roar-firekit": "^4.7.0",
@@ -42923,9 +42923,9 @@
       }
     },
     "@bdelab/roav-crowding": {
-      "version": "1.1.23",
-      "resolved": "https://registry.npmjs.org/@bdelab/roav-crowding/-/roav-crowding-1.1.23.tgz",
-      "integrity": "sha512-W1uaMGCVXWQrssmESS5K3gqP8+uFNY3lmy7+1C3iZ+mIRgvnHVSWlhnlOPM+92XK3jjQEAPpueesFoEIY6AoDw==",
+      "version": "1.1.26",
+      "resolved": "https://registry.npmjs.org/@bdelab/roav-crowding/-/roav-crowding-1.1.26.tgz",
+      "integrity": "sha512-VTQZbfSIzjCqE0wmrHmAz4dyotQilFdolEbL07Hq4omBshq0z8eclid7mbnfhdJ31jZdHAp1yC7epBigtsbvdg==",
       "requires": {
         "@bdelab/jscat": "^4.0.0",
         "@bdelab/roar-firekit": "^4.7.0",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@bdelab/roar-swr": "1.12.7",
     "@bdelab/roar-utils": "^1.2.1",
     "@bdelab/roar-vocab": "1.8.0",
-    "@bdelab/roav-crowding": "1.1.23",
+    "@bdelab/roav-crowding": "1.1.26",
     "@bdelab/roav-mep": "1.1.28",
     "@bdelab/roav-ran": "1.0.30",
     "@levante-framework/core-tasks": "1.0.0-beta.25",


### PR DESCRIPTION
This PR updates the version of `@bdelab/roav-crowding` to 1.1.26.