### PR TITLE
Update ROAV-Crowding version to 1.1.27

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@bdelab/roar-swr": "1.12.11",
         "@bdelab/roar-utils": "^1.2.1",
         "@bdelab/roar-vocab": "1.8.0",
-        "@bdelab/roav-crowding": "1.1.23",
+        "@bdelab/roav-crowding": "1.1.27",
         "@bdelab/roav-mep": "1.1.28",
         "@bdelab/roav-ran": "1.0.30",
         "@levante-framework/core-tasks": "1.0.0-beta.25",
@@ -6485,9 +6485,9 @@
       }
     },
     "node_modules/@bdelab/roav-crowding": {
-      "version": "1.1.23",
-      "resolved": "https://registry.npmjs.org/@bdelab/roav-crowding/-/roav-crowding-1.1.23.tgz",
-      "integrity": "sha512-W1uaMGCVXWQrssmESS5K3gqP8+uFNY3lmy7+1C3iZ+mIRgvnHVSWlhnlOPM+92XK3jjQEAPpueesFoEIY6AoDw==",
+      "version": "1.1.27",
+      "resolved": "https://registry.npmjs.org/@bdelab/roav-crowding/-/roav-crowding-1.1.27.tgz",
+      "integrity": "sha512-3hqG7F877v1FfZhL9wrVvvs7czjugU4lDcfLt2q0oGWHUd05fsgy1Mqrzyv/iCIpMO4cicGdXTPARP0Yd7YqXQ==",
       "dependencies": {
         "@bdelab/jscat": "^4.0.0",
         "@bdelab/roar-firekit": "^4.7.0",
@@ -24864,7 +24864,6 @@
     },
     "node_modules/npm/node_modules/lodash._baseindexof": {
       "version": "3.1.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
@@ -24889,19 +24888,16 @@
     },
     "node_modules/npm/node_modules/lodash._bindcallback": {
       "version": "3.0.1",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/lodash._cacheindexof": {
       "version": "3.0.2",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/lodash._createcache": {
       "version": "3.1.2",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -24910,7 +24906,6 @@
     },
     "node_modules/npm/node_modules/lodash._getnative": {
       "version": "3.9.1",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
@@ -24921,7 +24916,6 @@
     },
     "node_modules/npm/node_modules/lodash.restparam": {
       "version": "3.6.1",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
@@ -42828,9 +42822,9 @@
       }
     },
     "@bdelab/roav-crowding": {
-      "version": "1.1.23",
-      "resolved": "https://registry.npmjs.org/@bdelab/roav-crowding/-/roav-crowding-1.1.23.tgz",
-      "integrity": "sha512-W1uaMGCVXWQrssmESS5K3gqP8+uFNY3lmy7+1C3iZ+mIRgvnHVSWlhnlOPM+92XK3jjQEAPpueesFoEIY6AoDw==",
+      "version": "1.1.27",
+      "resolved": "https://registry.npmjs.org/@bdelab/roav-crowding/-/roav-crowding-1.1.27.tgz",
+      "integrity": "sha512-3hqG7F877v1FfZhL9wrVvvs7czjugU4lDcfLt2q0oGWHUd05fsgy1Mqrzyv/iCIpMO4cicGdXTPARP0Yd7YqXQ==",
       "requires": {
         "@bdelab/jscat": "^4.0.0",
         "@bdelab/roar-firekit": "^4.7.0",
@@ -56401,8 +56395,7 @@
         },
         "lodash._baseindexof": {
           "version": "3.1.0",
-          "bundled": true,
-          "extraneous": true
+          "bundled": true
         },
         "lodash._baseuniq": {
           "version": "4.6.0",
@@ -56424,26 +56417,22 @@
         },
         "lodash._bindcallback": {
           "version": "3.0.1",
-          "bundled": true,
-          "extraneous": true
+          "bundled": true
         },
         "lodash._cacheindexof": {
           "version": "3.0.2",
-          "bundled": true,
-          "extraneous": true
+          "bundled": true
         },
         "lodash._createcache": {
           "version": "3.1.2",
           "bundled": true,
-          "extraneous": true,
           "requires": {
             "lodash._getnative": "^3.0.0"
           }
         },
         "lodash._getnative": {
           "version": "3.9.1",
-          "bundled": true,
-          "extraneous": true
+          "bundled": true
         },
         "lodash.clonedeep": {
           "version": "4.5.0",
@@ -56451,8 +56440,7 @@
         },
         "lodash.restparam": {
           "version": "3.6.1",
-          "bundled": true,
-          "extraneous": true
+          "bundled": true
         },
         "lodash.union": {
           "version": "4.6.0",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@bdelab/roar-swr": "1.12.11",
     "@bdelab/roar-utils": "^1.2.1",
     "@bdelab/roar-vocab": "1.8.0",
-    "@bdelab/roav-crowding": "1.1.23",
+    "@bdelab/roav-crowding": "1.1.27",
     "@bdelab/roav-mep": "1.1.28",
     "@bdelab/roav-ran": "1.0.30",
     "@levante-framework/core-tasks": "1.0.0-beta.25",


### PR DESCRIPTION
This PR updates the version of `@bdelab/roav-crowding` to 1.1.27.