### PR TITLE
Update ROAV-Ran version to 1.0.31

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "@bdelab/roar-vocab": "1.8.0",
         "@bdelab/roav-crowding": "1.1.23",
         "@bdelab/roav-mep": "1.1.28",
-        "@bdelab/roav-ran": "1.0.30",
+        "@bdelab/roav-ran": "1.0.31",
         "@levante-framework/core-tasks": "1.0.0-beta.25",
         "@sentry/browser": "^8.0.0",
         "@sentry/integrations": "^7.114.0",
@@ -6694,9 +6694,10 @@
       }
     },
     "node_modules/@bdelab/roav-ran": {
-      "version": "1.0.30",
-      "resolved": "https://registry.npmjs.org/@bdelab/roav-ran/-/roav-ran-1.0.30.tgz",
-      "integrity": "sha512-iltS7eUkKXW2pOKGODAVxtT3n5A7WxDY/QnKYiLDjODh9oHKkZcszsPGvc13OgslOmaYao9uxrshGcfHLzCEgQ==",
+      "version": "1.0.31",
+      "resolved": "https://registry.npmjs.org/@bdelab/roav-ran/-/roav-ran-1.0.31.tgz",
+      "integrity": "sha512-omtCDcD3zEEe16312RC/PsAeI1ttIqxGdU/ipRrjfcKrDP9QLkJptf/zPLBeA7oJCsA1BPHbfn6vs0J1rNEygg==",
+      "license": "Stanford Academic Software License for ROAR",
       "dependencies": {
         "@bdelab/jscat": "^1.0.5",
         "@bdelab/roar-firekit": "^4.7.0",
@@ -24864,7 +24865,6 @@
     },
     "node_modules/npm/node_modules/lodash._baseindexof": {
       "version": "3.1.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
@@ -24889,19 +24889,16 @@
     },
     "node_modules/npm/node_modules/lodash._bindcallback": {
       "version": "3.0.1",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/lodash._cacheindexof": {
       "version": "3.0.2",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/lodash._createcache": {
       "version": "3.1.2",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -24910,7 +24907,6 @@
     },
     "node_modules/npm/node_modules/lodash._getnative": {
       "version": "3.9.1",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
@@ -24921,7 +24917,6 @@
     },
     "node_modules/npm/node_modules/lodash.restparam": {
       "version": "3.6.1",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
@@ -43020,9 +43015,9 @@
       }
     },
     "@bdelab/roav-ran": {
-      "version": "1.0.30",
-      "resolved": "https://registry.npmjs.org/@bdelab/roav-ran/-/roav-ran-1.0.30.tgz",
-      "integrity": "sha512-iltS7eUkKXW2pOKGODAVxtT3n5A7WxDY/QnKYiLDjODh9oHKkZcszsPGvc13OgslOmaYao9uxrshGcfHLzCEgQ==",
+      "version": "1.0.31",
+      "resolved": "https://registry.npmjs.org/@bdelab/roav-ran/-/roav-ran-1.0.31.tgz",
+      "integrity": "sha512-omtCDcD3zEEe16312RC/PsAeI1ttIqxGdU/ipRrjfcKrDP9QLkJptf/zPLBeA7oJCsA1BPHbfn6vs0J1rNEygg==",
       "requires": {
         "@bdelab/jscat": "^1.0.5",
         "@bdelab/roar-firekit": "^4.7.0",
@@ -56401,8 +56396,7 @@
         },
         "lodash._baseindexof": {
           "version": "3.1.0",
-          "bundled": true,
-          "extraneous": true
+          "bundled": true
         },
         "lodash._baseuniq": {
           "version": "4.6.0",
@@ -56424,26 +56418,22 @@
         },
         "lodash._bindcallback": {
           "version": "3.0.1",
-          "bundled": true,
-          "extraneous": true
+          "bundled": true
         },
         "lodash._cacheindexof": {
           "version": "3.0.2",
-          "bundled": true,
-          "extraneous": true
+          "bundled": true
         },
         "lodash._createcache": {
           "version": "3.1.2",
           "bundled": true,
-          "extraneous": true,
           "requires": {
             "lodash._getnative": "^3.0.0"
           }
         },
         "lodash._getnative": {
           "version": "3.9.1",
-          "bundled": true,
-          "extraneous": true
+          "bundled": true
         },
         "lodash.clonedeep": {
           "version": "4.5.0",
@@ -56451,8 +56441,7 @@
         },
         "lodash.restparam": {
           "version": "3.6.1",
-          "bundled": true,
-          "extraneous": true
+          "bundled": true
         },
         "lodash.union": {
           "version": "4.6.0",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@bdelab/roar-vocab": "1.8.0",
     "@bdelab/roav-crowding": "1.1.23",
     "@bdelab/roav-mep": "1.1.28",
-    "@bdelab/roav-ran": "1.0.30",
+    "@bdelab/roav-ran": "1.0.31",
     "@levante-framework/core-tasks": "1.0.0-beta.25",
     "@sentry/browser": "^8.0.0",
     "@sentry/integrations": "^7.114.0",


### PR DESCRIPTION
This PR updates the version of `@bdelab/roav-ran` to 1.0.31.