### PR TITLE
Update ROAV-Crowding version to 1.1.33

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@bdelab/roar-swr": "1.12.13",
         "@bdelab/roar-utils": "^1.2.1",
         "@bdelab/roar-vocab": "1.8.0",
-        "@bdelab/roav-crowding": "1.1.31",
+        "@bdelab/roav-crowding": "1.1.33",
         "@bdelab/roav-mep": "1.1.35",
         "@bdelab/roav-ran": "1.0.31",
         "@levante-framework/core-tasks": "1.0.0-beta.27",
@@ -6405,9 +6405,9 @@
       }
     },
     "node_modules/@bdelab/roav-crowding": {
-      "version": "1.1.31",
-      "resolved": "https://registry.npmjs.org/@bdelab/roav-crowding/-/roav-crowding-1.1.31.tgz",
-      "integrity": "sha512-6psoL+OLBXdxn6B9wUJd8l1uY8sliP9GntV3FDByW9qm3hF2KudzJYEEcfZFkuboBlmNW7aWgNNFuGfX4yvxIg==",
+      "version": "1.1.33",
+      "resolved": "https://registry.npmjs.org/@bdelab/roav-crowding/-/roav-crowding-1.1.33.tgz",
+      "integrity": "sha512-1xaA7a0f7zwcY4/8q0GP+TPhY2XzgoXtWdBHFzSnGUz7eTM60+C8svujCN78PPYxbmXOakeTZ768HELvWNsQdQ==",
       "license": "Stanford Academic Software License for ROAR",
       "dependencies": {
         "@bdelab/jscat": "^4.0.0",
@@ -42657,9 +42657,9 @@
       }
     },
     "@bdelab/roav-crowding": {
-      "version": "1.1.31",
-      "resolved": "https://registry.npmjs.org/@bdelab/roav-crowding/-/roav-crowding-1.1.31.tgz",
-      "integrity": "sha512-6psoL+OLBXdxn6B9wUJd8l1uY8sliP9GntV3FDByW9qm3hF2KudzJYEEcfZFkuboBlmNW7aWgNNFuGfX4yvxIg==",
+      "version": "1.1.33",
+      "resolved": "https://registry.npmjs.org/@bdelab/roav-crowding/-/roav-crowding-1.1.33.tgz",
+      "integrity": "sha512-1xaA7a0f7zwcY4/8q0GP+TPhY2XzgoXtWdBHFzSnGUz7eTM60+C8svujCN78PPYxbmXOakeTZ768HELvWNsQdQ==",
       "requires": {
         "@bdelab/jscat": "^4.0.0",
         "@bdelab/roar-firekit": "^4.7.0",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@bdelab/roar-swr": "1.12.13",
     "@bdelab/roar-utils": "^1.2.1",
     "@bdelab/roar-vocab": "1.8.0",
-    "@bdelab/roav-crowding": "1.1.31",
+    "@bdelab/roav-crowding": "1.1.33",
     "@bdelab/roav-mep": "1.1.35",
     "@bdelab/roav-ran": "1.0.31",
     "@primevue/core": "^4.2.4",


### PR DESCRIPTION
This PR updates the version of `@bdelab/roav-crowding` to 1.1.33.