### PR TITLE
Update MEP version to 1.1.36

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@bdelab/roar-utils": "^1.2.1",
         "@bdelab/roar-vocab": "1.8.0",
         "@bdelab/roav-crowding": "1.1.31",
-        "@bdelab/roav-mep": "1.1.35",
+        "@bdelab/roav-mep": "1.1.36",
         "@bdelab/roav-ran": "1.0.31",
         "@levante-framework/core-tasks": "1.0.0-beta.27",
         "@primevue/core": "^4.2.4",
@@ -6539,9 +6539,9 @@
       }
     },
     "node_modules/@bdelab/roav-mep": {
-      "version": "1.1.35",
-      "resolved": "https://registry.npmjs.org/@bdelab/roav-mep/-/roav-mep-1.1.35.tgz",
-      "integrity": "sha512-azL8x6YTaXvMnmNPdoa8vycu5CEhS3l55Qb/tMCW2Ci5qTjeH4beqmVZwAzT4e3pDeJjwUieCccUakydsPtkkQ==",
+      "version": "1.1.36",
+      "resolved": "https://registry.npmjs.org/@bdelab/roav-mep/-/roav-mep-1.1.36.tgz",
+      "integrity": "sha512-caiTJYmKu87GpLy6rfd8hxXP+tNx8gE2q1GeYbHE1DqdljI2g6WXs7JyYa/ltnPjXqTHjJi9hXVjuL39y2jGPA==",
       "license": "Stanford Academic Software License for ROAR",
       "dependencies": {
         "@bdelab/jscat": "^4.0.0",
@@ -42772,9 +42772,9 @@
       }
     },
     "@bdelab/roav-mep": {
-      "version": "1.1.35",
-      "resolved": "https://registry.npmjs.org/@bdelab/roav-mep/-/roav-mep-1.1.35.tgz",
-      "integrity": "sha512-azL8x6YTaXvMnmNPdoa8vycu5CEhS3l55Qb/tMCW2Ci5qTjeH4beqmVZwAzT4e3pDeJjwUieCccUakydsPtkkQ==",
+      "version": "1.1.36",
+      "resolved": "https://registry.npmjs.org/@bdelab/roav-mep/-/roav-mep-1.1.36.tgz",
+      "integrity": "sha512-caiTJYmKu87GpLy6rfd8hxXP+tNx8gE2q1GeYbHE1DqdljI2g6WXs7JyYa/ltnPjXqTHjJi9hXVjuL39y2jGPA==",
       "requires": {
         "@bdelab/jscat": "^4.0.0",
         "@bdelab/roar-firekit": "^4.7.0",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@bdelab/roar-utils": "^1.2.1",
     "@bdelab/roar-vocab": "1.8.0",
     "@bdelab/roav-crowding": "1.1.31",
-    "@bdelab/roav-mep": "1.1.35",
+    "@bdelab/roav-mep": "1.1.36",
     "@bdelab/roav-ran": "1.0.31",
     "@primevue/core": "^4.2.4",
     "@primevue/themes": "^4.2.4",


### PR DESCRIPTION
This PR updates the version of `@bdelab/roav-mep` to 1.1.36.