### PR TITLE
Update ROAV-Ran version to 1.0.32

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "@bdelab/roar-vocab": "1.8.0",
         "@bdelab/roav-crowding": "1.1.31",
         "@bdelab/roav-mep": "1.1.35",
-        "@bdelab/roav-ran": "1.0.31",
+        "@bdelab/roav-ran": "1.0.32",
         "@levante-framework/core-tasks": "1.0.0-beta.27",
         "@primevue/core": "^4.2.4",
         "@primevue/themes": "^4.2.4",
@@ -6602,9 +6602,9 @@
       }
     },
     "node_modules/@bdelab/roav-ran": {
-      "version": "1.0.31",
-      "resolved": "https://registry.npmjs.org/@bdelab/roav-ran/-/roav-ran-1.0.31.tgz",
-      "integrity": "sha512-omtCDcD3zEEe16312RC/PsAeI1ttIqxGdU/ipRrjfcKrDP9QLkJptf/zPLBeA7oJCsA1BPHbfn6vs0J1rNEygg==",
+      "version": "1.0.32",
+      "resolved": "https://registry.npmjs.org/@bdelab/roav-ran/-/roav-ran-1.0.32.tgz",
+      "integrity": "sha512-YG61HpoqcSKIROP/gqk3D9s1ci33QrnzxyTbNQZCt66PaNHa6JrJF755FAUka8Y6NTpJZ8NbY/uu+3JsmY0kwA==",
       "license": "Stanford Academic Software License for ROAR",
       "dependencies": {
         "@bdelab/jscat": "^1.0.5",
@@ -42836,9 +42836,9 @@
       }
     },
     "@bdelab/roav-ran": {
-      "version": "1.0.31",
-      "resolved": "https://registry.npmjs.org/@bdelab/roav-ran/-/roav-ran-1.0.31.tgz",
-      "integrity": "sha512-omtCDcD3zEEe16312RC/PsAeI1ttIqxGdU/ipRrjfcKrDP9QLkJptf/zPLBeA7oJCsA1BPHbfn6vs0J1rNEygg==",
+      "version": "1.0.32",
+      "resolved": "https://registry.npmjs.org/@bdelab/roav-ran/-/roav-ran-1.0.32.tgz",
+      "integrity": "sha512-YG61HpoqcSKIROP/gqk3D9s1ci33QrnzxyTbNQZCt66PaNHa6JrJF755FAUka8Y6NTpJZ8NbY/uu+3JsmY0kwA==",
       "requires": {
         "@bdelab/jscat": "^1.0.5",
         "@bdelab/roar-firekit": "^4.7.0",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@bdelab/roar-vocab": "1.8.0",
     "@bdelab/roav-crowding": "1.1.31",
     "@bdelab/roav-mep": "1.1.35",
-    "@bdelab/roav-ran": "1.0.31",
+    "@bdelab/roav-ran": "1.0.32",
     "@primevue/core": "^4.2.4",
     "@primevue/themes": "^4.2.4",
     "@levante-framework/core-tasks": "1.0.0-beta.27",


### PR DESCRIPTION
This PR updates the version of `@bdelab/roav-ran` to 1.0.32.