### PR TITLE
Update ROAV-Crowding version to 1.1.35

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@bdelab/roar-swr": "1.12.13",
         "@bdelab/roar-utils": "^1.2.1",
         "@bdelab/roar-vocab": "1.8.0",
-        "@bdelab/roav-crowding": "1.1.34",
+        "@bdelab/roav-crowding": "1.1.35",
         "@bdelab/roav-mep": "1.1.37",
         "@bdelab/roav-ran": "1.0.33",
         "@levante-framework/core-tasks": "1.0.0-beta.30",
@@ -6406,9 +6406,9 @@
       }
     },
     "node_modules/@bdelab/roav-crowding": {
-      "version": "1.1.34",
-      "resolved": "https://registry.npmjs.org/@bdelab/roav-crowding/-/roav-crowding-1.1.34.tgz",
-      "integrity": "sha512-WzUmuP0oNd9zyaGs5uDNjhdSDkJuAmAArtpy5hfXsHq27YE64M+xPT+TLbmGN8nJbgETDAbCme1BQpmW5HPREg==",
+      "version": "1.1.35",
+      "resolved": "https://registry.npmjs.org/@bdelab/roav-crowding/-/roav-crowding-1.1.35.tgz",
+      "integrity": "sha512-a+ClIVPABGWZWqXqfbH7480hi6yWcrHgQxirRmXs2a66hWgSDn9o1B9SaV8NwfmXXGh6v2TguWrpT//o9E9lcg==",
       "license": "Stanford Academic Software License for ROAR",
       "dependencies": {
         "@bdelab/jscat": "^4.0.0",
@@ -42658,9 +42658,9 @@
       }
     },
     "@bdelab/roav-crowding": {
-      "version": "1.1.34",
-      "resolved": "https://registry.npmjs.org/@bdelab/roav-crowding/-/roav-crowding-1.1.34.tgz",
-      "integrity": "sha512-WzUmuP0oNd9zyaGs5uDNjhdSDkJuAmAArtpy5hfXsHq27YE64M+xPT+TLbmGN8nJbgETDAbCme1BQpmW5HPREg==",
+      "version": "1.1.35",
+      "resolved": "https://registry.npmjs.org/@bdelab/roav-crowding/-/roav-crowding-1.1.35.tgz",
+      "integrity": "sha512-a+ClIVPABGWZWqXqfbH7480hi6yWcrHgQxirRmXs2a66hWgSDn9o1B9SaV8NwfmXXGh6v2TguWrpT//o9E9lcg==",
       "requires": {
         "@bdelab/jscat": "^4.0.0",
         "@bdelab/roar-firekit": "^4.7.0",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@bdelab/roar-swr": "1.12.13",
     "@bdelab/roar-utils": "^1.2.1",
     "@bdelab/roar-vocab": "1.8.0",
-    "@bdelab/roav-crowding": "1.1.34",
+    "@bdelab/roav-crowding": "1.1.35",
     "@bdelab/roav-mep": "1.1.37",
     "@bdelab/roav-ran": "1.0.33",
     "@levante-framework/core-tasks": "1.0.0-beta.30",


### PR DESCRIPTION
This PR updates the version of `@bdelab/roav-crowding` to 1.1.35.