### PR TITLE
Update Letter version to 2.0.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@bdelab/roam-apps": "1.0.9",
         "@bdelab/roar-firekit": "9.1.0",
-        "@bdelab/roar-letter": "1.11.9",
+        "@bdelab/roar-letter": "2.0.4",
         "@bdelab/roar-multichoice": "1.11.7",
         "@bdelab/roar-pa": "2.2.4",
         "@bdelab/roar-sre": "1.15.18",
@@ -1913,9 +1913,9 @@
       }
     },
     "node_modules/@bdelab/roar-letter": {
-      "version": "1.11.9",
-      "resolved": "https://registry.npmjs.org/@bdelab/roar-letter/-/roar-letter-1.11.9.tgz",
-      "integrity": "sha512-imkmbpVHGvZSR79vOjFSp3lGSx6qc015xz0lql2gsh9agYjD6Q7upE3RE6IMgYVGpOsl6tLGtIvPhFsv8/zuTg==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@bdelab/roar-letter/-/roar-letter-2.0.4.tgz",
+      "integrity": "sha512-NDw9i5W1ej+mJUnL5fEYvwL/dbEm1SGXKKbbQ7QFOFJF9OqZX8aUaywl3mWfVNHq0sHutO3CzupfSmStZg8yXA==",
       "license": "Stanford Academic Software License for ROAR",
       "dependencies": {
         "@bdelab/jscat": "4.0.0",
@@ -39017,9 +39017,9 @@
       }
     },
     "@bdelab/roar-letter": {
-      "version": "1.11.9",
-      "resolved": "https://registry.npmjs.org/@bdelab/roar-letter/-/roar-letter-1.11.9.tgz",
-      "integrity": "sha512-imkmbpVHGvZSR79vOjFSp3lGSx6qc015xz0lql2gsh9agYjD6Q7upE3RE6IMgYVGpOsl6tLGtIvPhFsv8/zuTg==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@bdelab/roar-letter/-/roar-letter-2.0.4.tgz",
+      "integrity": "sha512-NDw9i5W1ej+mJUnL5fEYvwL/dbEm1SGXKKbbQ7QFOFJF9OqZX8aUaywl3mWfVNHq0sHutO3CzupfSmStZg8yXA==",
       "requires": {
         "@bdelab/jscat": "4.0.0",
         "@bdelab/roar-firekit": "^4.7.0",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "dependencies": {
     "@bdelab/roam-apps": "1.0.9",
     "@bdelab/roar-firekit": "9.1.0",
-    "@bdelab/roar-letter": "1.11.9",
+    "@bdelab/roar-letter": "2.0.4",
     "@bdelab/roar-multichoice": "1.11.7",
     "@bdelab/roar-pa": "2.2.4",
     "@bdelab/roar-sre": "1.15.18",


### PR DESCRIPTION
This PR updates the version of `@bdelab/roar-letter` to 2.0.4.