### PR TITLE
External ROAR tasks open in a new tab and display message

### DIFF
--- a/src/components/GameTabs.vue
+++ b/src/components/GameTabs.vue
@@ -285,13 +285,19 @@ async function routeExternalTask(game) {
   // Mark the assessment as complete immediately if external roar task and clicked the button
   if (game.taskData.external) {
     await authStore.completeAssessment(selectedAdmin.value.id, game.taskId);
+    if (game.taskId === 'qualtrics-experience') {
+      // this was a request for this specific task
+      window.open(`${game.taskData.taskURL}/?participantID=${props?.userData?.username}`, '_blank').focus();
+    }
     window.open(game.taskData.taskURL, '_blank').focus();
   } else if (game.taskData.name.toLowerCase() === 'mefs') {
+    // this is a levante external task
     const ageInMonths = getAgeData(props.userData.birthMonth, props.userData.birthYear).ageMonths;
     url += `participantID=${props.userData.id}&participantAgeInMonths=${ageInMonths}&lng=${locale.value}`;
     window.open(url, '_blank').focus();
     await authStore.completeAssessment(selectedAdmin.value.id, game.taskId);
   } else {
+    // This is for no external tasks
     url += `&participant=${props.userData.assessmentPid}${
       (props?.userData?.schools?.current ?? []).length
         ? '&schoolId=' + props.userData.schools.current.join('“%2C”')

--- a/src/components/GameTabs.vue
+++ b/src/components/GameTabs.vue
@@ -49,7 +49,7 @@
               >{{ getTaskName(game.taskId, game.taskData.name) }}</span
             >
           </template>
-          <div class="roar-tabview-game pointer flex flex-row p-5 surface-100 w-full">
+          <div class="roar-tabview-game flex flex-row p-5 surface-100 w-full">
             <div class="roar-game-content flex flex-column" style="width: 70%" @click="routeExternalTask(game)">
               <div class="roar-game-title font-bold">{{ getTaskName(game.taskId, game.taskData.name) }}</div>
               <div class="roar-game-description mr-2">
@@ -63,13 +63,20 @@
                     :value="metaIndex + ': ' + items"
                   />
                 </div>
-                <div class="roar-game-footer p-3 h-full mr-5" :class="{ 'hover:surface-200': !game.completedOn }">
+                <div
+                  class="roar-game-footer p-3 h-full mr-5"
+                  :class="{ 'hover:surface-200 pointer': !game.completedOn || game.taskData.external }"
+                >
                   <div class="flex align-items-center justify-content-center font-bold mt-2 h-full responsive-text">
                     <router-link
                       v-if="
-                        !allGamesComplete && !game.completedOn && !game.taskData?.taskURL && !game.taskData?.variantURL
+                        (!allGamesComplete &&
+                          !game.completedOn &&
+                          !game.taskData?.taskURL &&
+                          !game.taskData?.variantURL) ||
+                        game.taskData.external
                       "
-                      :to="{ path: getRoutePath(game.taskId) }"
+                      :to="game.taskData.external ? '' : { path: getRoutePath(game.taskId) }"
                       class="no-underline text-900 text-center"
                     >
                       <div class="flex align-items-center justify-content-center h-full w-full">
@@ -88,13 +95,21 @@
                           </svg>
                         </i>
                       </div>
-                      <span v-if="!allGamesComplete && !game.completedOn">{{ $t('gameTabs.clickToStart') }}</span>
-                      <span v-else>{{ taskCompletedMessage }} </span>
+                      <span v-if="game.taskData.external && game.completedOn">{{
+                        $t('gameTabs.externalTaskMessage')
+                      }}</span>
+                      <span
+                        v-else-if="
+                          (!allGamesComplete && !game.completedOn) || (game.taskData.external && !game.completedOn)
+                        "
+                        >{{ $t('gameTabs.clickToStart') }}</span
+                      >
+                      <span v-else style="cursor: default">{{ taskCompletedMessage }}</span>
                     </router-link>
                     <div v-else>
                       <div class="flex align-items-center justify-content-center text-green-500">
                         <i v-if="game.completedOn" class="pi pi-check-circle mr-3" />
-                        <span>{{ taskCompletedMessage }} </span>
+                        <span style="cursor: default">{{ taskCompletedMessage }} </span>
                       </div>
                     </div>
                   </div>
@@ -267,7 +282,11 @@ async function routeExternalTask(game) {
     return;
   }
 
-  if (game.taskData.name.toLowerCase() === 'mefs') {
+  // Mark the assessment as complete immediately if external roar task and clicked the button
+  if (game.taskData.external) {
+    await authStore.completeAssessment(selectedAdmin.value.id, game.taskId);
+    window.open(game.taskData.taskURL, '_blank').focus();
+  } else if (game.taskData.name.toLowerCase() === 'mefs') {
     const ageInMonths = getAgeData(props.userData.birthMonth, props.userData.birthYear).ageMonths;
     url += `participantID=${props.userData.id}&participantAgeInMonths=${ageInMonths}&lng=${locale.value}`;
     window.open(url, '_blank').focus();

--- a/src/translations/en/en-componentTranslations.json
+++ b/src/translations/en/en-componentTranslations.json
@@ -45,6 +45,7 @@
   },
   "gameTabs": {
     "clickToStart": "Click to start",
+    "externalTaskMessage": "This task was opened in a new tab \n Click here to open again",
     "taskCompleted": "Task Completed!",
     "LEVANTE TRANSLATIONS--------------------------": "",
     "heartsAndFlowersDescription": "Choose the correct side for the hearts and flowers.",

--- a/src/translations/en/us/en-us-componentTranslations.json
+++ b/src/translations/en/us/en-us-componentTranslations.json
@@ -45,6 +45,7 @@
   },
   "gameTabs": {
     "clickToStart": "Click to start",
+    "externalTaskMessage": "This task was opened in a new tab \n Click here to open again",
     "taskCompleted": "Task Completed!",
     "LEVANTE TRANSLATIONS--------------------------": "",
     "heartsAndFlowersDescription": "Choose the correct side for the hearts and flowers.",

--- a/src/translations/es/co/es-co-componentTranslations.json
+++ b/src/translations/es/co/es-co-componentTranslations.json
@@ -46,6 +46,7 @@
   },
   "gameTabs": {
     "clickToStart": "Haz clic para empezar",
+    "externalTaskMessage": "La tarea se abrió en otra pestaña \n Haga clic aquí para abrir de nuevo",
     "taskCompleted": "¡Tarea completa!"
   },
   "navBar": {

--- a/src/translations/es/es-componentTranslations.json
+++ b/src/translations/es/es-componentTranslations.json
@@ -46,6 +46,7 @@
   },
   "gameTabs": {
     "clickToStart": "Haz clic para empezar",
+    "externalTaskMessage": "La tarea se abrió en otra pestaña \n Haga clic aquí para abrir de nuevo",
     "taskCompleted": "¡Tarea completada!",
     "LEVANTE TRANSLATIONS--------------------------": "",
     "heartsAndFlowersDescription": "Haz coincidir el lado correcto con los corazones y las flores.",


### PR DESCRIPTION
## Proposed changes

Ensure that external tasks requiring a record of a username open in a new tab instead of the same one. Additionally, display a message indicating that the task has been opened in a new tab and provide an option to click again.

THIS WAS REQUIRED -- ONLY the qualtrics-experience ROAR external task passes the participantID in the URL

<!--
Describe your changes here. Why are they necessary?

If it fixes a bug or resolves a feature request, be sure to link to that issue.

If appropriate, include images of the expected behavior or user experience.
You can drag and drop images into this text box.
-->

## Types of changes

What types of changes does this pull request introduce?

<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (non-breaking change that does not add functionality but makes code cleaner or more efficient)
- [ ] Documentation Update
- [ ] Tests (new or updated tests)
- [ ] Style (changes to code styling)
- [ ] CI (continuous integration changes)
- [ ] Repository Maintenance
- [ ] Other (please describe below)

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask.  We're here
to help! This is simply a reminder of what we are going to look for before
merging your code.
-->

- [x] I have read the [guidelines for contributing](https://github.com/yeatmanlab/roar-dashboard/blob/main/.github/CONTRIBUTING.md).
- [x] The changes in this PR are as small as they can be. They represent one and only one fix or enhancement.
- [x] Linting checks pass with my changes.
- [x] Any existing unit tests pass with my changes.
- [ ] Any existing end-to-end tests pass with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] If this PR fixes an existing issue, I have added a unit or end-to-end test that will detect if this issue reoccurs.
- [ ] I have added JSDoc comments as appropriate.
- [ ] I have added the necessary documentation to the [roar-docs repository](https://github.com/yeatmanlab/roar-docs).
- [x] I have shared this PR on the roar-pr-reviews channel (if I have access)
- [x] I have linked relevant issues (if any)

## Justification of missing checklist items

<!--
If you feel that a checklist item above is not applicable to this PR, please
provide your justification here. Otherwise, delete this section.
-->

This is important for the Microsoft study and future studies

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
