### PR TITLE
Update roam-apps version to 1.0.15

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "roar-dashboard",
       "version": "3.6.0",
       "dependencies": {
-        "@bdelab/roam-apps": "1.0.14",
+        "@bdelab/roam-apps": "1.0.15",
         "@bdelab/roar-firekit": "^9.3.0",
         "@bdelab/roar-letter": "2.0.4",
         "@bdelab/roar-multichoice": "1.11.7",
@@ -1705,12 +1705,12 @@
       "integrity": "sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ=="
     },
     "node_modules/@bdelab/roam-apps": {
-      "version": "1.0.14",
-      "resolved": "https://registry.npmjs.org/@bdelab/roam-apps/-/roam-apps-1.0.14.tgz",
-      "integrity": "sha512-FfgVduumC6s4MYWhbcc+GzWGnYQft7t1lrDTy7ncifQ+tf2weVvQIgw1qb8vRADmLZmAH9N2ca3HiViQqvGHog==",
+      "version": "1.0.15",
+      "resolved": "https://registry.npmjs.org/@bdelab/roam-apps/-/roam-apps-1.0.15.tgz",
+      "integrity": "sha512-odGF+zw2y6jH5dAhYiUv0XHbCRHPE8+nF+lEJqCyf/bFtVSrlH8zi5xDXlbLfSyRYgZrJxa99EBBbew7cf5tsA==",
       "license": "Stanford Academic Software License for ROAR",
       "dependencies": {
-        "@bdelab/jscat": "^5.0.0",
+        "@bdelab/jscat": "5.0.0",
         "@bdelab/roar-firekit": "^9.1.0",
         "@bdelab/roar-utils": "^1.2.2",
         "@jspsych-contrib/plugin-audio-multi-response": "^1.0.0",
@@ -39051,11 +39051,11 @@
       }
     },
     "@bdelab/roam-apps": {
-      "version": "1.0.14",
-      "resolved": "https://registry.npmjs.org/@bdelab/roam-apps/-/roam-apps-1.0.14.tgz",
-      "integrity": "sha512-FfgVduumC6s4MYWhbcc+GzWGnYQft7t1lrDTy7ncifQ+tf2weVvQIgw1qb8vRADmLZmAH9N2ca3HiViQqvGHog==",
+      "version": "1.0.15",
+      "resolved": "https://registry.npmjs.org/@bdelab/roam-apps/-/roam-apps-1.0.15.tgz",
+      "integrity": "sha512-odGF+zw2y6jH5dAhYiUv0XHbCRHPE8+nF+lEJqCyf/bFtVSrlH8zi5xDXlbLfSyRYgZrJxa99EBBbew7cf5tsA==",
       "requires": {
-        "@bdelab/jscat": "^5.0.0",
+        "@bdelab/jscat": "5.0.0",
         "@bdelab/roar-firekit": "^9.1.0",
         "@bdelab/roar-utils": "^1.2.2",
         "@jspsych-contrib/plugin-audio-multi-response": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "version": "npm run format && git add -A"
   },
   "dependencies": {
-    "@bdelab/roam-apps": "1.0.14",
+    "@bdelab/roam-apps": "1.0.15",
     "@bdelab/roar-firekit": "^9.3.0",
     "@bdelab/roar-letter": "2.0.4",
     "@bdelab/roar-multichoice": "1.11.7",


### PR DESCRIPTION
This PR updates the version of `@bdelab/roam-apps` to 1.0.15.