### PR TITLE
Update roam-apps version to 1.0.16

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "roar-dashboard",
       "version": "3.6.0",
       "dependencies": {
-        "@bdelab/roam-apps": "1.0.14",
+        "@bdelab/roam-apps": "1.0.16",
         "@bdelab/roar-firekit": "^9.4.0",
         "@bdelab/roar-letter": "2.0.4",
         "@bdelab/roar-multichoice": "1.11.7",
@@ -1705,12 +1705,12 @@
       "integrity": "sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ=="
     },
     "node_modules/@bdelab/roam-apps": {
-      "version": "1.0.14",
-      "resolved": "https://registry.npmjs.org/@bdelab/roam-apps/-/roam-apps-1.0.14.tgz",
-      "integrity": "sha512-FfgVduumC6s4MYWhbcc+GzWGnYQft7t1lrDTy7ncifQ+tf2weVvQIgw1qb8vRADmLZmAH9N2ca3HiViQqvGHog==",
+      "version": "1.0.16",
+      "resolved": "https://registry.npmjs.org/@bdelab/roam-apps/-/roam-apps-1.0.16.tgz",
+      "integrity": "sha512-SvTbEB6a/tkWBPzCj9liGIpA1UMoEBKce/ab8ddVjJquZbzTPVxFg6fVUrE8d4aVbkwTdxtU4iuhL0bf6tgr+g==",
       "license": "Stanford Academic Software License for ROAR",
       "dependencies": {
-        "@bdelab/jscat": "^5.0.0",
+        "@bdelab/jscat": "5.0.0",
         "@bdelab/roar-firekit": "^9.1.0",
         "@bdelab/roar-utils": "^1.2.2",
         "@jspsych-contrib/plugin-audio-multi-response": "^1.0.0",
@@ -24981,7 +24981,6 @@
     },
     "node_modules/npm/node_modules/lodash._baseindexof": {
       "version": "3.1.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
@@ -25006,19 +25005,16 @@
     },
     "node_modules/npm/node_modules/lodash._bindcallback": {
       "version": "3.0.1",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/lodash._cacheindexof": {
       "version": "3.0.2",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/lodash._createcache": {
       "version": "3.1.2",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -25027,7 +25023,6 @@
     },
     "node_modules/npm/node_modules/lodash._getnative": {
       "version": "3.9.1",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
@@ -25038,7 +25033,6 @@
     },
     "node_modules/npm/node_modules/lodash.restparam": {
       "version": "3.6.1",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
@@ -39057,11 +39051,11 @@
       }
     },
     "@bdelab/roam-apps": {
-      "version": "1.0.14",
-      "resolved": "https://registry.npmjs.org/@bdelab/roam-apps/-/roam-apps-1.0.14.tgz",
-      "integrity": "sha512-FfgVduumC6s4MYWhbcc+GzWGnYQft7t1lrDTy7ncifQ+tf2weVvQIgw1qb8vRADmLZmAH9N2ca3HiViQqvGHog==",
+      "version": "1.0.16",
+      "resolved": "https://registry.npmjs.org/@bdelab/roam-apps/-/roam-apps-1.0.16.tgz",
+      "integrity": "sha512-SvTbEB6a/tkWBPzCj9liGIpA1UMoEBKce/ab8ddVjJquZbzTPVxFg6fVUrE8d4aVbkwTdxtU4iuhL0bf6tgr+g==",
       "requires": {
-        "@bdelab/jscat": "^5.0.0",
+        "@bdelab/jscat": "5.0.0",
         "@bdelab/roar-firekit": "^9.1.0",
         "@bdelab/roar-utils": "^1.2.2",
         "@jspsych-contrib/plugin-audio-multi-response": "^1.0.0",
@@ -56521,8 +56515,7 @@
         },
         "lodash._baseindexof": {
           "version": "3.1.0",
-          "bundled": true,
-          "extraneous": true
+          "bundled": true
         },
         "lodash._baseuniq": {
           "version": "4.6.0",
@@ -56544,26 +56537,22 @@
         },
         "lodash._bindcallback": {
           "version": "3.0.1",
-          "bundled": true,
-          "extraneous": true
+          "bundled": true
         },
         "lodash._cacheindexof": {
           "version": "3.0.2",
-          "bundled": true,
-          "extraneous": true
+          "bundled": true
         },
         "lodash._createcache": {
           "version": "3.1.2",
           "bundled": true,
-          "extraneous": true,
           "requires": {
             "lodash._getnative": "^3.0.0"
           }
         },
         "lodash._getnative": {
           "version": "3.9.1",
-          "bundled": true,
-          "extraneous": true
+          "bundled": true
         },
         "lodash.clonedeep": {
           "version": "4.5.0",
@@ -56571,8 +56560,7 @@
         },
         "lodash.restparam": {
           "version": "3.6.1",
-          "bundled": true,
-          "extraneous": true
+          "bundled": true
         },
         "lodash.union": {
           "version": "4.6.0",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "version": "npm run format && git add -A"
   },
   "dependencies": {
-    "@bdelab/roam-apps": "1.0.14",
+    "@bdelab/roam-apps": "1.0.16",
     "@bdelab/roar-firekit": "^9.4.0",
     "@bdelab/roar-letter": "2.0.4",
     "@bdelab/roar-multichoice": "1.11.7",


### PR DESCRIPTION
This PR updates the version of `@bdelab/roam-apps` to 1.0.16.