### PR TITLE
Add missing private key for legacy staging deployments

### DIFF
--- a/.github/workflows/deploy-legacy-staging.yml
+++ b/.github/workflows/deploy-legacy-staging.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     env:
-      DOTENV_PRIVATE_KEY_STAGING: ${{ secrets.DOTENV_PRIVATE_KEY_STAGING }}
+      DOTENV_PRIVATE_KEY_STAGING: ${{ secrets.DOTENV_PRIVATE_KEY_PRODUCTION }}
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/deploy-legacy-staging.yml
+++ b/.github/workflows/deploy-legacy-staging.yml
@@ -20,6 +20,9 @@ jobs:
     name: Deploy Firebase app
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    env:
+      DOTENV_PRIVATE_KEY_STAGING: ${{ secrets.DOTENV_PRIVATE_KEY_STAGING }}
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
## Proposed changes
This PR adds the missing `DOTENV_PRIVATE_KEY` env variables to decrypt `dotenvx` environment configuration injected during the build process of the legacy staging site.

## Types of changes
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (non-breaking change that does not add functionality but makes code cleaner or more efficient)
- [ ] Documentation Update
- [ ] Tests (new or updated tests)
- [ ] Style (changes to code styling)
- [x] CI (continuous integration changes)
- [ ] Repository Maintenance
- [ ] Other (please describe below)

## Checklist
n/a

## Justification of missing checklist items
n/a

## Further comments
n/a