### PR TITLE
Use fieldOverrides instead of composite indexes for assignments readOrgs

### DIFF
--- a/cypress/support/helper-functions/roam-apps/roamHelpers.js
+++ b/cypress/support/helper-functions/roam-apps/roamHelpers.js
@@ -17,6 +17,8 @@ function waitTimeout() {
   cy.wait(0.1 * Cypress.env('timeout'));
 }
 
+const timeout = Cypress.env('timeout');
+
 function playARFIntro() {
   waitTimeout();
 

--- a/cypress/support/helper-functions/roar-letter/letterHelpers.js
+++ b/cypress/support/helper-functions/roar-letter/letterHelpers.js
@@ -14,6 +14,8 @@ function clickButton(selector) {
   });
 }
 
+const timeout = Cypress.env('timeout');
+
 function checkGameTab(language) {
   cy.get('.p-tablist-tab-list', { timeout: timeout }).contains(languageOptions[language].gameTab).should('exist');
 }

--- a/cypress/support/helper-functions/roar-multichoice/multichoiceHelpers.js
+++ b/cypress/support/helper-functions/roar-multichoice/multichoiceHelpers.js
@@ -14,6 +14,8 @@ function clickButton(selector) {
   });
 }
 
+const timeout = Cypress.env('timeout');
+
 function checkGameTab(language, task) {
   cy.get('.p-tablist-tab-list', { timeout: timeout }).contains(languageOptions[language][task].gameTab).should('exist');
 }

--- a/cypress/support/helper-functions/roar-pa/paHelpers.js
+++ b/cypress/support/helper-functions/roar-pa/paHelpers.js
@@ -12,6 +12,8 @@ function handleFullScreenError() {
   });
 }
 
+const timeout = Cypress.env('timeout');
+
 function checkGameTab(language) {
   cy.get('.p-tablist-tab-list', { timeout: timeout }).contains(languageOptions[language].gameTab).should('exist');
 }

--- a/cypress/support/helper-functions/roar-sre/sreHelpers.js
+++ b/cypress/support/helper-functions/roar-sre/sreHelpers.js
@@ -6,6 +6,8 @@ const CLEVER_PASSWORD = Cypress.env('CLEVER_PASSWORD');
 const PARTICIPANT_USERNAME = Cypress.env('PARTICIPANT_USERNAME');
 const PARTICIPANT_PASSWORD = Cypress.env('PARTICIPANT_PASSWORD');
 
+const timeout = Cypress.env('timeout');
+
 export const playSRE = ({
   administration = Cypress.env('testRoarAppsAdministration'),
   language = 'en',

--- a/cypress/support/helper-functions/roar-swr/swrHelpers.js
+++ b/cypress/support/helper-functions/roar-swr/swrHelpers.js
@@ -8,6 +8,8 @@ const CLEVER_PASSWORD = Cypress.env('CLEVER_PASSWORD');
 const PARTICIPANT_USERNAME = Cypress.env('PARTICIPANT_USERNAME');
 const PARTICIPANT_PASSWORD = Cypress.env('PARTICIPANT_PASSWORD');
 
+const timeout = Cypress.env('timeout');
+
 export const playSWR = ({
   administration = Cypress.env('testRoarAppsAdministration'),
   language = 'en',

--- a/cypress/support/helper-functions/roar-syntax/syntaxHelpers.js
+++ b/cypress/support/helper-functions/roar-syntax/syntaxHelpers.js
@@ -14,6 +14,8 @@ function clickButton(selector) {
   });
 }
 
+const timeout = Cypress.env('timeout');
+
 function checkGameTab(language, task) {
   cy.get('.p-tablist-tab-list', { timeout: timeout }).contains(languageOptions[language][task].gameTab).should('exist');
 }

--- a/cypress/support/helper-functions/roar-vocab/vocabHelpers.js
+++ b/cypress/support/helper-functions/roar-vocab/vocabHelpers.js
@@ -6,6 +6,8 @@ const CLEVER_PASSWORD = Cypress.env('CLEVER_PASSWORD');
 const PARTICIPANT_USERNAME = Cypress.env('PARTICIPANT_USERNAME');
 const PARTICIPANT_PASSWORD = Cypress.env('PARTICIPANT_PASSWORD');
 
+const timeout = Cypress.env('timeout');
+
 function checkGameTab(language) {
   cy.get('.p-tablist-tab-list', { timeout: timeout }).contains(languageOptions[language].gameTab).should('exist');
 }

--- a/firebase/admin/firestore.indexes.json
+++ b/firebase/admin/firestore.indexes.json
@@ -3195,56 +3195,6 @@
       ]
     },
     {
-      "collectionGroup": "assignments",
-      "queryScope": "COLLECTION_GROUP",
-      "fields": [
-        {
-          "fieldPath": "readOrgs.districts",
-          "arrayConfig": "CONTAINS"
-        }
-      ]
-    },
-    {
-      "collectionGroup": "assignments",
-      "queryScope": "COLLECTION_GROUP",
-      "fields": [
-        {
-          "fieldPath": "readOrgs.schools",
-          "arrayConfig": "CONTAINS"
-        }
-      ]
-    },
-    {
-      "collectionGroup": "assignments",
-      "queryScope": "COLLECTION_GROUP",
-      "fields": [
-        {
-          "fieldPath": "readOrgs.classrooms",
-          "arrayConfig": "CONTAINS"
-        }
-      ]
-    },
-    {
-      "collectionGroup": "assignments",
-      "queryScope": "COLLECTION_GROUP",
-      "fields": [
-        {
-          "fieldPath": "readOrgs.groups",
-          "arrayConfig": "CONTAINS"
-        }
-      ]
-    },
-    {
-      "collectionGroup": "assignments",
-      "queryScope": "COLLECTION_GROUP",
-      "fields": [
-        {
-          "fieldPath": "readOrgs.families",
-          "arrayConfig": "CONTAINS"
-        }
-      ]
-    },
-    {
       "collectionGroup": "classes",
       "queryScope": "COLLECTION",
       "fields": [
@@ -5145,6 +5095,61 @@
       "fieldPath": "readOrgs",
       "ttl": false,
       "indexes": []
+    },
+    {
+      "collectionGroup": "assignments",
+      "fieldPath": "readOrgs.classes",
+      "ttl": false,
+      "indexes": [
+        {
+          "arrayConfig": "CONTAINS",
+          "queryScope": "COLLECTION_GROUP"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "assignments",
+      "fieldPath": "readOrgs.districts",
+      "ttl": false,
+      "indexes": [
+        {
+          "arrayConfig": "CONTAINS",
+          "queryScope": "COLLECTION_GROUP"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "assignments",
+      "fieldPath": "readOrgs.families",
+      "ttl": false,
+      "indexes": [
+        {
+          "arrayConfig": "CONTAINS",
+          "queryScope": "COLLECTION_GROUP"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "assignments",
+      "fieldPath": "readOrgs.groups",
+      "ttl": false,
+      "indexes": [
+        {
+          "arrayConfig": "CONTAINS",
+          "queryScope": "COLLECTION_GROUP"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "assignments",
+      "fieldPath": "readOrgs.schools",
+      "ttl": false,
+      "indexes": [
+        {
+          "arrayConfig": "CONTAINS",
+          "queryScope": "COLLECTION_GROUP"
+        }
+      ]
     },
     {
       "collectionGroup": "readOrgs",


### PR DESCRIPTION
## Proposed changes

I noticed that the firestore index actions ([here](https://github.com/yeatmanlab/roar-dashboard/actions/runs/14229868872/job/39878277887)) were failing from @lucasxsong's recent PR #1090. This is because the new indexes were for `array-contains` queries on various `readOrgs` fields in the `assignments` collection. Instead of having separate composite indexes, we need to use single field indexes by moving these configurations to the `fieldOverrides` section of the file.

## Types of changes

What types of changes does this pull request introduce?

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (non-breaking change that does not add functionality but makes code cleaner or more efficient)
- [ ] Documentation Update
- [ ] Tests (new or updated tests)
- [ ] Style (changes to code styling)
- [ ] CI (continuous integration changes)
- [ ] Repository Maintenance
- [ ] Other (please describe below)

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask.  We're here
to help! This is simply a reminder of what we are going to look for before
merging your code.
-->

- [x] I have read the [guidelines for contributing](https://github.com/yeatmanlab/roar-dashboard/blob/main/.github/CONTRIBUTING.md).
- [x] The changes in this PR are as small as they can be. They represent one and only one fix or enhancement.
- [x] Linting checks pass with my changes.
- [x] Any existing unit tests pass with my changes.
- [x] Any existing end-to-end tests pass with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] If this PR fixes an existing issue, I have added a unit or end-to-end test that will detect if this issue reoccurs.
- [x] I have added JSDoc comments as appropriate.
- [x] I have added the necessary documentation to the [roar-docs repository](https://github.com/yeatmanlab/roar-docs).
- [x] I have shared this PR on the roar-pr-reviews channel (if I have access)
- [ ] I have linked relevant issues (if any)