### PR TITLE
Update Read Aloud version to 1.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@bdelab/roar-letter": "2.0.4",
         "@bdelab/roar-multichoice": "1.11.7",
         "@bdelab/roar-pa": "2.2.4",
-        "@bdelab/roar-readaloud": "1.1.33",
+        "@bdelab/roar-readaloud": "1.2.0",
         "@bdelab/roar-sre": "1.16.0",
         "@bdelab/roar-swr": "1.13.0",
         "@bdelab/roar-utils": "^1.2.1",
@@ -4640,9 +4640,9 @@
       }
     },
     "node_modules/@bdelab/roar-readaloud": {
-      "version": "1.1.33",
-      "resolved": "https://registry.npmjs.org/@bdelab/roar-readaloud/-/roar-readaloud-1.1.33.tgz",
-      "integrity": "sha512-PNdfzMiiqShNkPV6Bbgq3JWsvy4LVZANOUskWICmQ0d41O5+iTkMyvPxD88CVL4H/Qp7x7arBacSDU3+wU5/eA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@bdelab/roar-readaloud/-/roar-readaloud-1.2.0.tgz",
+      "integrity": "sha512-6jdRTJvOZVzDPSOXYXv6s9THiicwF3obQXNYqO88R7WA6yLUSICBnwkla4Dl7mB3ZgWaRMb40VpeH3A4G3wZvg==",
       "license": "Stanford Academic Software License for ROAR",
       "dependencies": {
         "@bdelab/jscat": "^4.0.0",
@@ -42189,9 +42189,9 @@
       }
     },
     "@bdelab/roar-readaloud": {
-      "version": "1.1.33",
-      "resolved": "https://registry.npmjs.org/@bdelab/roar-readaloud/-/roar-readaloud-1.1.33.tgz",
-      "integrity": "sha512-PNdfzMiiqShNkPV6Bbgq3JWsvy4LVZANOUskWICmQ0d41O5+iTkMyvPxD88CVL4H/Qp7x7arBacSDU3+wU5/eA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@bdelab/roar-readaloud/-/roar-readaloud-1.2.0.tgz",
+      "integrity": "sha512-6jdRTJvOZVzDPSOXYXv6s9THiicwF3obQXNYqO88R7WA6yLUSICBnwkla4Dl7mB3ZgWaRMb40VpeH3A4G3wZvg==",
       "requires": {
         "@bdelab/jscat": "^4.0.0",
         "@bdelab/roar-firekit": "^4.7.0",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@bdelab/roar-letter": "2.0.4",
     "@bdelab/roar-multichoice": "1.11.7",
     "@bdelab/roar-pa": "2.2.4",
-    "@bdelab/roar-readaloud": "1.1.33",
+    "@bdelab/roar-readaloud": "1.2.0",
     "@bdelab/roar-sre": "1.16.0",
     "@bdelab/roar-swr": "1.13.0",
     "@bdelab/roar-utils": "^1.2.1",


### PR DESCRIPTION
This PR updates the version of `@bdelab/roar-readaloud` to 1.2.0.