### PR TITLE
Update roam-apps version to 1.2.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "roar-dashboard",
       "version": "3.7.1",
       "dependencies": {
-        "@bdelab/roam-apps": "1.2.4",
+        "@bdelab/roam-apps": "1.2.6",
         "@bdelab/roar-firekit": "9.5.2",
         "@bdelab/roar-letter": "2.0.4",
         "@bdelab/roar-multichoice": "1.11.7",
@@ -1705,9 +1705,9 @@
       "integrity": "sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ=="
     },
     "node_modules/@bdelab/roam-apps": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@bdelab/roam-apps/-/roam-apps-1.2.4.tgz",
-      "integrity": "sha512-rFQq4qfKc3dQAw+tmAlUEqY47ozWQ7x+0COzWomewdUjwigs7rYXioMZl1OkwhwooP4aZph0Wj8WvVHjuvsrfg==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@bdelab/roam-apps/-/roam-apps-1.2.6.tgz",
+      "integrity": "sha512-Mw017M9IoM6odbc7Fb/M+Kf9n/jpiqKdufJndpShv3YA8FPswSbNhI3ZGRykKqAu16wzDBBW8s3C7y6zBHBOYw==",
       "license": "Stanford Academic Software License for ROAR",
       "dependencies": {
         "@bdelab/jscat": "5.0.0",
@@ -39820,9 +39820,9 @@
       }
     },
     "@bdelab/roam-apps": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@bdelab/roam-apps/-/roam-apps-1.2.4.tgz",
-      "integrity": "sha512-rFQq4qfKc3dQAw+tmAlUEqY47ozWQ7x+0COzWomewdUjwigs7rYXioMZl1OkwhwooP4aZph0Wj8WvVHjuvsrfg==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@bdelab/roam-apps/-/roam-apps-1.2.6.tgz",
+      "integrity": "sha512-Mw017M9IoM6odbc7Fb/M+Kf9n/jpiqKdufJndpShv3YA8FPswSbNhI3ZGRykKqAu16wzDBBW8s3C7y6zBHBOYw==",
       "requires": {
         "@bdelab/jscat": "5.0.0",
         "@bdelab/roar-firekit": "^9.5.1",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "version": "npm run format && git add -A"
   },
   "dependencies": {
-    "@bdelab/roam-apps": "1.2.4",
+    "@bdelab/roam-apps": "1.2.6",
     "@bdelab/roar-firekit": "9.5.2",
     "@bdelab/roar-letter": "2.0.4",
     "@bdelab/roar-multichoice": "1.11.7",


### PR DESCRIPTION
This PR updates the version of `@bdelab/roam-apps` to 1.2.6.