### PR TITLE
Update MEP version to 1.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "@bdelab/roar-utils": "^1.2.1",
         "@bdelab/roar-vocab": "1.8.0",
         "@bdelab/roav-crowding": "1.1.35",
-        "@bdelab/roav-mep": "1.1.37",
+        "@bdelab/roav-mep": "1.2.0",
         "@bdelab/roav-ran": "1.0.33",
         "@dotenvx/dotenvx": "^1.24.4",
         "@levante-framework/core-tasks": "1.0.0-beta.37",
@@ -7530,9 +7530,9 @@
       }
     },
     "node_modules/@bdelab/roav-mep": {
-      "version": "1.1.37",
-      "resolved": "https://registry.npmjs.org/@bdelab/roav-mep/-/roav-mep-1.1.37.tgz",
-      "integrity": "sha512-1yw9fu94dtnMLAAP1cULctO6zHiavR4e7hkA0B+da8JtJX6TgwTt+4rd6iINwHQuD1w+a4RV9In817garW2PSg==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@bdelab/roav-mep/-/roav-mep-1.2.0.tgz",
+      "integrity": "sha512-UEHOU6kn0RFGgl1/mey3FG7IsqYx9DaavIwr7RerE5ypvctT2v1yySZvqyrp2lmUmP7JfWILH2sSDQRQig6iQA==",
       "license": "Stanford Academic Software License for ROAR",
       "dependencies": {
         "@bdelab/jscat": "^4.0.0",
@@ -44482,9 +44482,9 @@
       }
     },
     "@bdelab/roav-mep": {
-      "version": "1.1.37",
-      "resolved": "https://registry.npmjs.org/@bdelab/roav-mep/-/roav-mep-1.1.37.tgz",
-      "integrity": "sha512-1yw9fu94dtnMLAAP1cULctO6zHiavR4e7hkA0B+da8JtJX6TgwTt+4rd6iINwHQuD1w+a4RV9In817garW2PSg==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@bdelab/roav-mep/-/roav-mep-1.2.0.tgz",
+      "integrity": "sha512-UEHOU6kn0RFGgl1/mey3FG7IsqYx9DaavIwr7RerE5ypvctT2v1yySZvqyrp2lmUmP7JfWILH2sSDQRQig6iQA==",
       "requires": {
         "@bdelab/jscat": "^4.0.0",
         "@bdelab/roar-firekit": "^4.7.0",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@bdelab/roar-utils": "^1.2.1",
     "@bdelab/roar-vocab": "1.8.0",
     "@bdelab/roav-crowding": "1.1.35",
-    "@bdelab/roav-mep": "1.1.37",
+    "@bdelab/roav-mep": "1.2.0",
     "@bdelab/roav-ran": "1.0.33",
     "@dotenvx/dotenvx": "^1.24.4",
     "@levante-framework/core-tasks": "1.0.0-beta.37",


### PR DESCRIPTION
This PR updates the version of `@bdelab/roav-mep` to 1.2.0.