### PR TITLE
Update Read Aloud version to 1.2.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@bdelab/roar-letter": "2.0.4",
         "@bdelab/roar-multichoice": "1.11.7",
         "@bdelab/roar-pa": "2.2.4",
-        "@bdelab/roar-readaloud": "1.2.1",
+        "@bdelab/roar-readaloud": "1.2.2",
         "@bdelab/roar-sre": "1.16.0",
         "@bdelab/roar-swr": "1.13.0",
         "@bdelab/roar-utils": "^1.2.1",
@@ -4640,9 +4640,9 @@
       }
     },
     "node_modules/@bdelab/roar-readaloud": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@bdelab/roar-readaloud/-/roar-readaloud-1.2.1.tgz",
-      "integrity": "sha512-ANmAobTj0+TLmxzfeMqyM5yCegZ3fsGmej7slrj/7E+AVBv7g2URNRO6KoBcleOqbmHrodZLbcVI5lWMBRHv6g==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@bdelab/roar-readaloud/-/roar-readaloud-1.2.2.tgz",
+      "integrity": "sha512-+mgGz9Pp8Zsi2A4Z3g31N9qASYKboR2WvOiRJhM73TEX5u4DjsOeiNC5EOl0lAcMQ7OYpHtAaBm3UDBSnD/QBA==",
       "license": "Stanford Academic Software License for ROAR",
       "dependencies": {
         "@bdelab/jscat": "^4.0.0",
@@ -42189,9 +42189,9 @@
       }
     },
     "@bdelab/roar-readaloud": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@bdelab/roar-readaloud/-/roar-readaloud-1.2.1.tgz",
-      "integrity": "sha512-ANmAobTj0+TLmxzfeMqyM5yCegZ3fsGmej7slrj/7E+AVBv7g2URNRO6KoBcleOqbmHrodZLbcVI5lWMBRHv6g==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@bdelab/roar-readaloud/-/roar-readaloud-1.2.2.tgz",
+      "integrity": "sha512-+mgGz9Pp8Zsi2A4Z3g31N9qASYKboR2WvOiRJhM73TEX5u4DjsOeiNC5EOl0lAcMQ7OYpHtAaBm3UDBSnD/QBA==",
       "requires": {
         "@bdelab/jscat": "^4.0.0",
         "@bdelab/roar-firekit": "^4.7.0",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@bdelab/roar-letter": "2.0.4",
     "@bdelab/roar-multichoice": "1.11.7",
     "@bdelab/roar-pa": "2.2.4",
-    "@bdelab/roar-readaloud": "1.2.1",
+    "@bdelab/roar-readaloud": "1.2.2",
     "@bdelab/roar-sre": "1.16.0",
     "@bdelab/roar-swr": "1.13.0",
     "@bdelab/roar-utils": "^1.2.1",

--- a/src/components/tasks/TaskReadAloud.vue
+++ b/src/components/tasks/TaskReadAloud.vue
@@ -16,7 +16,7 @@ import useUserStudentDataQuery from '@/composables/queries/useUserStudentDataQue
 import packageLockJson from '../../../package-lock.json';
 
 const props = defineProps({
-  taskId: { type: String, default: 'roar-readoud' },
+  taskId: { type: String, default: 'roar-readaloud' },
   language: { type: String, default: 'en' },
 });
 


### PR DESCRIPTION
This PR updates the version of `@bdelab/roar-readaloud` to 1.2.2.