### PR TITLE
Update Read Aloud version to 1.2.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@bdelab/roar-letter": "2.0.4",
         "@bdelab/roar-multichoice": "1.11.7",
         "@bdelab/roar-pa": "2.2.4",
-        "@bdelab/roar-readaloud": "1.2.1",
+        "@bdelab/roar-readaloud": "1.2.3",
         "@bdelab/roar-sre": "1.16.0",
         "@bdelab/roar-swr": "1.13.0",
         "@bdelab/roar-utils": "^1.2.1",
@@ -4640,9 +4640,9 @@
       }
     },
     "node_modules/@bdelab/roar-readaloud": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@bdelab/roar-readaloud/-/roar-readaloud-1.2.1.tgz",
-      "integrity": "sha512-ANmAobTj0+TLmxzfeMqyM5yCegZ3fsGmej7slrj/7E+AVBv7g2URNRO6KoBcleOqbmHrodZLbcVI5lWMBRHv6g==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@bdelab/roar-readaloud/-/roar-readaloud-1.2.3.tgz",
+      "integrity": "sha512-EZZmm67PK8WUnK7nX17GL8/irfjOzm3CWl+SDbNl5OW09vPlihLWYHXMDPnQdwcXSwbz32AZqLvjGEnDm9KxOA==",
       "license": "Stanford Academic Software License for ROAR",
       "dependencies": {
         "@bdelab/jscat": "^4.0.0",
@@ -42189,9 +42189,9 @@
       }
     },
     "@bdelab/roar-readaloud": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@bdelab/roar-readaloud/-/roar-readaloud-1.2.1.tgz",
-      "integrity": "sha512-ANmAobTj0+TLmxzfeMqyM5yCegZ3fsGmej7slrj/7E+AVBv7g2URNRO6KoBcleOqbmHrodZLbcVI5lWMBRHv6g==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@bdelab/roar-readaloud/-/roar-readaloud-1.2.3.tgz",
+      "integrity": "sha512-EZZmm67PK8WUnK7nX17GL8/irfjOzm3CWl+SDbNl5OW09vPlihLWYHXMDPnQdwcXSwbz32AZqLvjGEnDm9KxOA==",
       "requires": {
         "@bdelab/jscat": "^4.0.0",
         "@bdelab/roar-firekit": "^4.7.0",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@bdelab/roar-letter": "2.0.4",
     "@bdelab/roar-multichoice": "1.11.7",
     "@bdelab/roar-pa": "2.2.4",
-    "@bdelab/roar-readaloud": "1.2.1",
+    "@bdelab/roar-readaloud": "1.2.3",
     "@bdelab/roar-sre": "1.16.0",
     "@bdelab/roar-swr": "1.13.0",
     "@bdelab/roar-utils": "^1.2.1",


### PR DESCRIPTION
This PR updates the version of `@bdelab/roar-readaloud` to 1.2.3.