### PR TITLE
Update Letter version to 3.0.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@bdelab/roam-apps": "1.2.8",
         "@bdelab/roar-firekit": "^9.7.1",
-        "@bdelab/roar-letter": "3.0.1",
+        "@bdelab/roar-letter": "3.0.2",
         "@bdelab/roar-multichoice": "1.11.8",
         "@bdelab/roar-pa": "2.2.5",
         "@bdelab/roar-readaloud": "1.2.1",
@@ -2751,9 +2751,9 @@
       "license": "MIT"
     },
     "node_modules/@bdelab/roar-letter": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@bdelab/roar-letter/-/roar-letter-3.0.1.tgz",
-      "integrity": "sha512-2gaFwcQav+A7KdgjwcVmQq9rBiXgknS6crwzXl/q8AqFQxY+mkVd7cI2bFlJo7etimed9FpTvEkMX3MfjpYztA==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@bdelab/roar-letter/-/roar-letter-3.0.2.tgz",
+      "integrity": "sha512-gxraIuwcS4U6dF2NQf4c/KWmLMc5vVnh8U1YavJ+Nu5L9OwM0a5YyDPLGIxsJktglrybD6IWAZ8k3l75Wc6EBA==",
       "license": "Stanford Academic Software License for ROAR",
       "dependencies": {
         "@bdelab/jscat": "5.0.0",
@@ -40511,9 +40511,9 @@
       }
     },
     "@bdelab/roar-letter": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@bdelab/roar-letter/-/roar-letter-3.0.1.tgz",
-      "integrity": "sha512-2gaFwcQav+A7KdgjwcVmQq9rBiXgknS6crwzXl/q8AqFQxY+mkVd7cI2bFlJo7etimed9FpTvEkMX3MfjpYztA==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@bdelab/roar-letter/-/roar-letter-3.0.2.tgz",
+      "integrity": "sha512-gxraIuwcS4U6dF2NQf4c/KWmLMc5vVnh8U1YavJ+Nu5L9OwM0a5YyDPLGIxsJktglrybD6IWAZ8k3l75Wc6EBA==",
       "requires": {
         "@bdelab/jscat": "5.0.0",
         "@bdelab/roar-firekit": "^9.6.0",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "@bdelab/roam-apps": "1.2.8",
     "@bdelab/roar-firekit": "^9.7.1",
-    "@bdelab/roar-letter": "3.0.1",
+    "@bdelab/roar-letter": "3.0.2",
     "@bdelab/roar-multichoice": "1.11.8",
     "@bdelab/roar-pa": "2.2.5",
     "@bdelab/roar-readaloud": "1.2.1",


### PR DESCRIPTION
This PR updates the version of `@bdelab/roar-letter` to 3.0.2.