### PR TITLE
Display date only in CSV export of scores

### DIFF
--- a/src/pages/ScoreReport.vue
+++ b/src/pages/ScoreReport.vue
@@ -939,8 +939,8 @@ const createExportData = ({ rows, includeProgress = false }) => {
       tableRow['PID'] = user?.assessmentPid;
     }
 
-    tableRow['Start Date'] = startDate?.split?.('T')?.[0];
-    tableRow['Completion Date'] = completionDate?.split?.('T')?.[0];
+    tableRow['Start Date'] = startDate ? new Date(startDate).toLocaleDateString('en-US') : null;
+    tableRow['Completion Date'] = completionDate ? new Date(completionDate).toLocaleDateString('en-US') : null;
 
     if (props.orgType === 'district') {
       tableRow['School'] = user?.schoolName;

--- a/src/pages/ScoreReport.vue
+++ b/src/pages/ScoreReport.vue
@@ -939,8 +939,8 @@ const createExportData = ({ rows, includeProgress = false }) => {
       tableRow['PID'] = user?.assessmentPid;
     }
 
-    tableRow['Start Date'] = startDate;
-    tableRow['Completion Date'] = completionDate;
+    tableRow['Start Date'] = startDate?.split?.('T')?.[0];
+    tableRow['Completion Date'] = completionDate?.split?.('T')?.[0];
 
     if (props.orgType === 'district') {
       tableRow['School'] = user?.schoolName;


### PR DESCRIPTION
## Proposed changes

This PR formats the start and completion date in the score report CSV export to display only the date (not the time).

## Types of changes

What types of changes does this pull request introduce?

<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (non-breaking change that does not add functionality but makes code cleaner or more efficient)
- [ ] Documentation Update
- [ ] Tests (new or updated tests)
- [ ] Style (changes to code styling)
- [ ] CI (continuous integration changes)
- [ ] Repository Maintenance
- [ ] Other (please describe below)

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask.  We're here
to help! This is simply a reminder of what we are going to look for before
merging your code.
-->

- [x] I have read the [guidelines for contributing](https://github.com/yeatmanlab/roar-dashboard/blob/main/.github/CONTRIBUTING.md).
- [x] The changes in this PR are as small as they can be. They represent one and only one fix or enhancement.
- [x] Linting checks pass with my changes.
- [x] Any existing unit tests pass with my changes.
- [x] Any existing end-to-end tests pass with my changes.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] If this PR fixes an existing issue, I have added a unit or end-to-end test that will detect if this issue reoccurs.
- [x] I have added JSDoc comments as appropriate.
- [x] I have added the necessary documentation to the [roar-docs repository](https://github.com/yeatmanlab/roar-docs).
- [x] I have shared this PR on the roar-pr-reviews channel (if I have access)
- [x] I have linked relevant issues (if any)