### PR TITLE
[FIX] Filter search results for named variants

### DIFF
--- a/src/components/TaskPicker/TaskPicker.vue
+++ b/src/components/TaskPicker/TaskPicker.vue
@@ -368,7 +368,7 @@ const searchCards = (term) => {
     );
   } else if (currentCardType.value === CARD_TYPES.VARIANT) {
     Object.values(props.allVariants).forEach((variants) => {
-      const matchingVariants = _filter(variants, (variant) => {
+      let matchingVariants = _filter(variants, (variant) => {
         if (
           _toLower(variant.variant.name).includes(_toLower(term)) ||
           _toLower(variant.id).includes(_toLower(term)) ||
@@ -378,6 +378,9 @@ const searchCards = (term) => {
           return true;
         else return false;
       });
+      if (namedOnly.value) {
+        matchingVariants = _filter(matchingVariants, (variant) => variant.variant.name);
+      }
       searchResults.value.push(
         ...matchingVariants.map((variant) => {
           return {
@@ -399,7 +402,7 @@ function clearSearch() {
 
 const debounceSearch = _debounce(searchCards, 250);
 
-watch([searchTerm, currentCardType], ([term]) => {
+watch([searchTerm, currentCardType, namedOnly], ([term]) => {
   if (term.length >= 3) {
     debounceSearch(term);
   } else {


### PR DESCRIPTION
## Proposed changes
Currently, the task picker allows a user to view only named variants via a toggle on the component. This affects the variants listed when browsing, however does not affect search results. This PR fixes that issue.

## Testing steps
- Navigate to the task picker (on the create administration page)
- Switch to Individual tasks, and choose a taskId from the dropdown. SWR has named and unnamed variants.
- Notice that only named variants show.
- Uncheck the 'Show only named variants' toggle and note the list now includes variants with no name field populated.
- Search for the task ID using the search bar ('swr' or 'word')
- Notice that several variants show up without the name field populated.
- Reenable the named variants toggle.
- Notice the search results filter out unnamed variants automatically. 

## Types of changes

What types of changes does this pull request introduce?

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (non-breaking change that does not add functionality but makes code cleaner or more efficient)
- [ ] Documentation Update
- [ ] Tests (new or updated tests)
- [ ] Style (changes to code styling)
- [ ] CI (continuous integration changes)
- [ ] Repository Maintenance
- [ ] Other (please describe below)

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask.  We're here
to help! This is simply a reminder of what we are going to look for before
merging your code.
-->

- [x] I have read the [guidelines for contributing](https://github.com/yeatmanlab/roar-dashboard/blob/main/.github/CONTRIBUTING.md).
- [x] The changes in this PR are as small as they can be. They represent one and only one fix or enhancement.
- [x] Linting checks pass with my changes.
- [x] Any existing unit tests pass with my changes.
- [x] Any existing end-to-end tests pass with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] If this PR fixes an existing issue, I have added a unit or end-to-end test that will detect if this issue reoccurs.
- [x] I have added JSDoc comments as appropriate.
- [x] I have added the necessary documentation to the [roar-docs repository](https://github.com/yeatmanlab/roar-docs).
- [x] I have shared this PR on the roar-pr-reviews channel (if I have access)
- [x] I have linked relevant issues (if any)

## Justification of missing checklist items

<!--
If you feel that a checklist item above is not applicable to this PR, please
provide your justification here. Otherwise, delete this section.
-->

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
