### PR TITLE
Set user grade in score reports from the assignment data rather than user data

### DIFF
--- a/src/pages/ProgressReport.vue
+++ b/src/pages/ProgressReport.vue
@@ -275,7 +275,7 @@ const computedProgressData = computed(() => {
 
   for (const { assignment, user } of assignmentData.value) {
     // for each row, compute: username, firstName, lastName, assessmentPID, grade, school, all the scores, and routeParams for report link
-    const grade = user.studentData?.grade;
+    const grade = String(assignment.userData?.grade);
     // compute schoolName
     let schoolName = '';
     const schoolId = user?.schools?.current[0];

--- a/src/pages/ScoreReport.vue
+++ b/src/pages/ScoreReport.vue
@@ -616,7 +616,7 @@ const computeAssignmentAndRunData = computed(() => {
 
     for (const { assignment, user } of assignmentData.value) {
       // for each row, compute: username, firstName, lastName, assessmentPID, grade, school, all the scores, and routeParams for report link
-      const grade = String(user.studentData?.grade);
+      const grade = String(assignment.userData?.grade);
       // compute schoolName. Use the schoolId from the assignment's assigningOrgs, as this should be correct even when the
       //   user is unenrolled. The assigningOrgs should be up to date and persistant. Fallback to the student's current schools.
       let schoolName = '';
@@ -701,11 +701,11 @@ const computeAssignmentAndRunData = computed(() => {
         }
 
         const { percentileScoreKey, rawScoreKey, percentileScoreDisplayKey, standardScoreDisplayKey } =
-          getScoreKeysByRow(assessment, getGrade(_get(user, 'studentData.grade')));
+          getScoreKeysByRow(assessment, getGrade(grade));
         // compute and add scores data in next step as so
         const { support_level, tag_color, percentile, percentileString, standardScore, rawScore } =
           getScoresAndSupportFromAssessment({
-            grade: grade,
+            grade,
             assessment,
             percentileScoreKey,
             percentileScoreDisplayKey,
@@ -835,7 +835,7 @@ const computeAssignmentAndRunData = computed(() => {
           },
           taskId,
           user: {
-            grade: grade,
+            grade,
             schoolName: schoolsDictWithGrade.value[schoolId] ?? '0 Unknown School',
           },
           tag_color: tag_color,


### PR DESCRIPTION
## Proposed changes

In score and progress reports, display the user's grade at time of assignment, rather than the user's current grade.

## Types of changes

What types of changes does this pull request introduce?

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (non-breaking change that does not add functionality but makes code cleaner or more efficient)
- [ ] Documentation Update
- [ ] Tests (new or updated tests)
- [ ] Style (changes to code styling)
- [ ] CI (continuous integration changes)
- [ ] Repository Maintenance
- [ ] Other (please describe below)

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask.  We're here
to help! This is simply a reminder of what we are going to look for before
merging your code.
-->

- [x] I have read the [guidelines for contributing](https://github.com/yeatmanlab/roar-dashboard/blob/main/.github/CONTRIBUTING.md).
- [x] The changes in this PR are as small as they can be. They represent one and only one fix or enhancement.
- [x] Linting checks pass with my changes.
- [x] Any existing unit tests pass with my changes.
- [x] Any existing end-to-end tests pass with my changes.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] If this PR fixes an existing issue, I have added a unit or end-to-end test that will detect if this issue reoccurs.
- [x] I have added JSDoc comments as appropriate.
- [x] I have added the necessary documentation to the [roar-docs repository](https://github.com/yeatmanlab/roar-docs).
- [x] I have shared this PR on the roar-pr-reviews channel (if I have access)
- [x] I have linked relevant issues (if any)