### PR TITLE
Update ROAM fluency scores 

### DIFF
--- a/apps/dashboard/src/components/reports/SubscoreTable.vue
+++ b/apps/dashboard/src/components/reports/SubscoreTable.vue
@@ -23,7 +23,7 @@ import {
   roamAlpacaSubskills,
   roamAlpacaSubskillHeaders,
   roamFluencySubskillHeaders,
-  fluencyTasks,
+  roamFluencyTasks,
 } from '@/helpers/reports';
 
 const props = defineProps({
@@ -108,7 +108,7 @@ const columns = computed(() => {
       { field: 'scores.pa.skills', header: 'Skills To Work On', dataType: 'text', sort: false },
     );
   }
-  if (fluencyTasks.includes(props.taskId)) {
+  if (roamFluencyTasks.includes(props.taskId)) {
     tableColumns.push(
       { field: `scores.${props.taskId}.fr.rawScore`, header: 'Free Response', dataType: 'text', sort: false },
       { field: `scores.${props.taskId}.fc.rawScore`, header: 'Multiple Choice', dataType: 'text', sort: false },
@@ -166,7 +166,7 @@ const exportSelected = (selectedRows) => {
       _set(tableRow, 'Total', _get(scores, 'pa.total'));
       _set(tableRow, 'Skills To Work On', _get(scores, 'pa.skills'));
     }
-    if (['fluency-calf', 'fluency-arf', 'fluency-calf-es', 'fluency-arf-es'].includes(props.taskId)) {
+    if (roamFluencyTasks.includes(props.taskId)) {
       Object.keys(roamFluencySubskillHeaders).forEach((property) => {
         _set(
           tableRow,
@@ -220,7 +220,7 @@ const exportAll = async () => {
       _set(tableRow, 'Deletion', _get(scores, 'pa.deletion'));
       _set(tableRow, 'Total', _get(scores, 'pa.total'));
       _set(tableRow, 'Skills To Work On', _get(scores, 'pa.skills'));
-    } else if (fluencyTasks.includes(props.taskId)) {
+    } else if (roamFluencyTasks.includes(props.taskId)) {
       Object.keys(roamFluencySubskillHeaders).forEach((property) => {
         _set(
           tableRow,

--- a/apps/dashboard/src/components/reports/SubscoreTable.vue
+++ b/apps/dashboard/src/components/reports/SubscoreTable.vue
@@ -19,7 +19,7 @@ import { exportCsv } from '@/helpers/query/utils';
 import { useAuthStore } from '@/store/auth';
 import { storeToRefs } from 'pinia';
 import RoarDataTable from '@/components/RoarDataTable';
-import { roamAlpacaSubskills, roamAlpacaSubskillHeaders } from '@/helpers/reports';
+import { roamAlpacaSubskills, roamAlpacaSubskillHeaders, roamFluencySubskillHeaders } from '@/helpers/reports';
 
 const props = defineProps({
   administrationId: { type: String, required: true, default: '' },
@@ -162,8 +162,21 @@ const exportSelected = (selectedRows) => {
       _set(tableRow, 'Skills To Work On', _get(scores, 'pa.skills'));
     }
     if (['fluency-calf', 'fluency-arf', 'fluency-calf-es', 'fluency-arf-es'].includes(props.taskId)) {
-      _set(tableRow, 'Free Response', _get(scores, `${props.taskId}.fr.rawScore`));
-      _set(tableRow, 'Multiple Choice', _get(scores, `${props.taskId}.fc.rawScore`));
+      Object.keys(roamFluencySubskillHeaders).forEach((property) => {
+        _set(
+          tableRow,
+          `Free Response - ${roamFluencySubskillHeaders[property]}`,
+          _get(scores, `${props.taskId}.fr.${property}`),
+        );
+      });
+
+      Object.keys(roamFluencySubskillHeaders).forEach((property) => {
+        _set(
+          tableRow,
+          `Multiple Choice - ${roamFluencySubskillHeaders[property]}`,
+          _get(scores, `${props.taskId}.fc.${property}`),
+        );
+      });
     }
     if (props.taskId === 'roam-alpaca') {
       _set(tableRow, 'Raw Score', _get(scores, `${props.taskId}.composite.roarScore`));
@@ -203,8 +216,21 @@ const exportAll = async () => {
       _set(tableRow, 'Total', _get(scores, 'pa.total'));
       _set(tableRow, 'Skills To Work On', _get(scores, 'pa.skills'));
     } else if (['fluency-calf', 'fluency-arf', 'fluency-calf-es', 'fluency-arf-es'].includes(props.taskId)) {
-      _set(tableRow, 'Free Response', _get(scores, `${props.taskId}.fr.rawScore`));
-      _set(tableRow, 'Multiple Choice', _get(scores, `${props.taskId}.fc.rawScore`));
+      Object.keys(roamFluencySubskillHeaders).forEach((property) => {
+        _set(
+          tableRow,
+          `Free Response - ${roamFluencySubskillHeaders[property]}`,
+          _get(scores, `${props.taskId}.fr.${property}`),
+        );
+      });
+
+      Object.keys(roamFluencySubskillHeaders).forEach((property) => {
+        _set(
+          tableRow,
+          `Multiple Choice - ${roamFluencySubskillHeaders[property]}`,
+          _get(scores, `${props.taskId}.fc.${property}`),
+        );
+      });
     } else if (props.taskId === 'roam-alpaca') {
       _set(tableRow, 'Raw Score', _get(scores, `${props.taskId}.composite.roarScore`));
       _set(tableRow, 'Grade Estimate', _get(scores, `${props.taskId}.composite.gradeEstimate`));

--- a/apps/dashboard/src/components/reports/SubscoreTable.vue
+++ b/apps/dashboard/src/components/reports/SubscoreTable.vue
@@ -19,7 +19,12 @@ import { exportCsv } from '@/helpers/query/utils';
 import { useAuthStore } from '@/store/auth';
 import { storeToRefs } from 'pinia';
 import RoarDataTable from '@/components/RoarDataTable';
-import { roamAlpacaSubskills, roamAlpacaSubskillHeaders, roamFluencySubskillHeaders } from '@/helpers/reports';
+import {
+  roamAlpacaSubskills,
+  roamAlpacaSubskillHeaders,
+  roamFluencySubskillHeaders,
+  fluencyTasks,
+} from '@/helpers/reports';
 
 const props = defineProps({
   administrationId: { type: String, required: true, default: '' },
@@ -103,7 +108,7 @@ const columns = computed(() => {
       { field: 'scores.pa.skills', header: 'Skills To Work On', dataType: 'text', sort: false },
     );
   }
-  if (['fluency-calf', 'fluency-arf', 'fluency-calf-es', 'fluency-arf-es'].includes(props.taskId)) {
+  if (fluencyTasks.includes(props.taskId)) {
     tableColumns.push(
       { field: `scores.${props.taskId}.fr.rawScore`, header: 'Free Response', dataType: 'text', sort: false },
       { field: `scores.${props.taskId}.fc.rawScore`, header: 'Multiple Choice', dataType: 'text', sort: false },
@@ -215,7 +220,7 @@ const exportAll = async () => {
       _set(tableRow, 'Deletion', _get(scores, 'pa.deletion'));
       _set(tableRow, 'Total', _get(scores, 'pa.total'));
       _set(tableRow, 'Skills To Work On', _get(scores, 'pa.skills'));
-    } else if (['fluency-calf', 'fluency-arf', 'fluency-calf-es', 'fluency-arf-es'].includes(props.taskId)) {
+    } else if (fluencyTasks.includes(props.taskId)) {
       Object.keys(roamFluencySubskillHeaders).forEach((property) => {
         _set(
           tableRow,

--- a/apps/dashboard/src/components/reports/SubscoreTable.vue
+++ b/apps/dashboard/src/components/reports/SubscoreTable.vue
@@ -167,20 +167,12 @@ const exportSelected = (selectedRows) => {
       _set(tableRow, 'Skills To Work On', _get(scores, 'pa.skills'));
     }
     if (roamFluencyTasks.includes(props.taskId)) {
-      Object.keys(roamFluencySubskillHeaders).forEach((property) => {
-        _set(
-          tableRow,
-          `Free Response - ${roamFluencySubskillHeaders[property]}`,
-          _get(scores, `${props.taskId}.fr.${property}`),
-        );
+      Object.entries(roamFluencySubskillHeaders).forEach(([property, propertyHeader]) => {
+        _set(tableRow, `Free Response - ${propertyHeader}`, _get(scores, `${props.taskId}.fr.${property}`));
       });
 
-      Object.keys(roamFluencySubskillHeaders).forEach((property) => {
-        _set(
-          tableRow,
-          `Multiple Choice - ${roamFluencySubskillHeaders[property]}`,
-          _get(scores, `${props.taskId}.fc.${property}`),
-        );
+      Object.entries(roamFluencySubskillHeaders).forEach(([property, propertyHeader]) => {
+        _set(tableRow, `Multiple Choice - ${propertyHeader}`, _get(scores, `${props.taskId}.fc.${property}`));
       });
     }
     if (props.taskId === 'roam-alpaca') {
@@ -221,20 +213,12 @@ const exportAll = async () => {
       _set(tableRow, 'Total', _get(scores, 'pa.total'));
       _set(tableRow, 'Skills To Work On', _get(scores, 'pa.skills'));
     } else if (roamFluencyTasks.includes(props.taskId)) {
-      Object.keys(roamFluencySubskillHeaders).forEach((property) => {
-        _set(
-          tableRow,
-          `Free Response - ${roamFluencySubskillHeaders[property]}`,
-          _get(scores, `${props.taskId}.fr.${property}`),
-        );
+      Object.entries(roamFluencySubskillHeaders).forEach(([property, propertyHeader]) => {
+        _set(tableRow, `Free Response - ${propertyHeader}`, _get(scores, `${props.taskId}.fr.${property}`));
       });
 
-      Object.keys(roamFluencySubskillHeaders).forEach((property) => {
-        _set(
-          tableRow,
-          `Multiple Choice - ${roamFluencySubskillHeaders[property]}`,
-          _get(scores, `${props.taskId}.fc.${property}`),
-        );
+      Object.entries(roamFluencySubskillHeaders).forEach(([property, propertyHeader]) => {
+        _set(tableRow, `Multiple Choice - ${propertyHeader}`, _get(scores, `${props.taskId}.fc.${property}`));
       });
     } else if (props.taskId === 'roam-alpaca') {
       _set(tableRow, 'Raw Score', _get(scores, `${props.taskId}.composite.roarScore`));

--- a/apps/dashboard/src/components/reports/SubscoreTable.vue
+++ b/apps/dashboard/src/components/reports/SubscoreTable.vue
@@ -105,8 +105,8 @@ const columns = computed(() => {
   }
   if (['fluency-calf', 'fluency-arf', 'fluency-calf-es', 'fluency-arf-es'].includes(props.taskId)) {
     tableColumns.push(
-      { field: `scores.${props.taskId}.fr`, header: 'Free Response', dataType: 'text', sort: false },
-      { field: `scores.${props.taskId}.fc`, header: 'Multiple Choice', dataType: 'text', sort: false },
+      { field: `scores.${props.taskId}.fr.rawScore`, header: 'Free Response', dataType: 'text', sort: false },
+      { field: `scores.${props.taskId}.fc.rawScore`, header: 'Multiple Choice', dataType: 'text', sort: false },
     );
   }
   if (props.taskId === 'roam-alpaca') {
@@ -162,8 +162,8 @@ const exportSelected = (selectedRows) => {
       _set(tableRow, 'Skills To Work On', _get(scores, 'pa.skills'));
     }
     if (['fluency-calf', 'fluency-arf', 'fluency-calf-es', 'fluency-arf-es'].includes(props.taskId)) {
-      _set(tableRow, 'Free Response', _get(scores, `${props.taskId}.fr`));
-      _set(tableRow, 'Multiple Choice', _get(scores, `${props.taskId}.fc`));
+      _set(tableRow, 'Free Response', _get(scores, `${props.taskId}.fr.rawScore`));
+      _set(tableRow, 'Multiple Choice', _get(scores, `${props.taskId}.fc.rawScore`));
     }
     if (props.taskId === 'roam-alpaca') {
       _set(tableRow, 'Raw Score', _get(scores, `${props.taskId}.composite.roarScore`));
@@ -203,8 +203,8 @@ const exportAll = async () => {
       _set(tableRow, 'Total', _get(scores, 'pa.total'));
       _set(tableRow, 'Skills To Work On', _get(scores, 'pa.skills'));
     } else if (['fluency-calf', 'fluency-arf', 'fluency-calf-es', 'fluency-arf-es'].includes(props.taskId)) {
-      _set(tableRow, 'Free Response', _get(scores, `${props.taskId}.fr`));
-      _set(tableRow, 'Multiple Choice', _get(scores, `${props.taskId}.fc`));
+      _set(tableRow, 'Free Response', _get(scores, `${props.taskId}.fr.rawScore`));
+      _set(tableRow, 'Multiple Choice', _get(scores, `${props.taskId}.fc.rawScore`));
     } else if (props.taskId === 'roam-alpaca') {
       _set(tableRow, 'Raw Score', _get(scores, `${props.taskId}.composite.roarScore`));
       _set(tableRow, 'Grade Estimate', _get(scores, `${props.taskId}.composite.gradeEstimate`));

--- a/apps/dashboard/src/components/reports/TableScoreTag.vue
+++ b/apps/dashboard/src/components/reports/TableScoreTag.vue
@@ -147,6 +147,7 @@ function handleSubskillToolTip(_taskId, _subskillId, _toolTip, _colData) {
       _toolTip += 'Grade Estimate: ' + subskillInfo?.gradeEstimate + '\n';
     }
   } else if (fluencyTasks.includes(_taskId)) {
+    _toolTip += 'Raw Score: ' + subskillInfo?.rawScore + '\n';
     _toolTip += 'Num Correct: ' + subskillInfo?.totalCorrect + '\n';
     _toolTip += 'Num Incorrect: ' + subskillInfo?.totalIncorrect + '\n';
     _toolTip += 'Num Attempted: ' + subskillInfo?.totalNumAttempted + '\n';

--- a/apps/dashboard/src/components/reports/TableScoreTag.vue
+++ b/apps/dashboard/src/components/reports/TableScoreTag.vue
@@ -101,24 +101,18 @@ function handleToolTip(_taskId, _toolTip, _colData) {
       _toolTip += 'Correct - Incorrect: ' + _colData.scores?.[_taskId]?.correctIncorrectDifference + '\n';
     } else if (tasksToDisplayTotalCorrect.includes(_taskId)) {
       const numCorrect = _colData.scores?.[_taskId]?.numCorrect;
-      const numIncorrect = _colData.scores?.[_taskId]?.numIncorrect;
       const numAttempted = _colData.scores?.[_taskId]?.numAttempted;
 
-      if (numCorrect === 0 && numIncorrect === 0 && numAttempted === 0) {
+      if (!(numCorrect != undefined && numAttempted != undefined)) {
         return '';
       }
 
-      if (_colData.scores?.[_taskId]?.recruitment !== 'responseModality') {
-        _toolTip += 'Raw Score: ' + _colData.scores?.[_taskId]?.rawScore + '\n';
-      }
-
-      Object.entries(roamFluencySubskillHeaders)
-        .slice(1)
-        .forEach(([property, propertyHeader]) => {
-          if (_colData.scores?.[_taskId]?.[property] != undefined) {
-            _toolTip += `${propertyHeader}: ${_colData.scores?.[_taskId]?.[property]}\n`;
-          }
-        });
+      const isResponseModality = _colData.scores?.[_taskId]?.recruitment === 'responseModality';
+      Object.entries(roamFluencySubskillHeaders).forEach(([property, propertyHeader]) => {
+        if (_colData.scores?.[_taskId]?.[property] != undefined && !(isResponseModality && property === 'rawScore')) {
+          _toolTip += `${propertyHeader}: ${_colData.scores?.[_taskId]?.[property]}\n`;
+        }
+      });
     } else if (tasksToDisplayPercentCorrect.includes(_taskId)) {
       _toolTip += 'Num Correct: ' + _colData.scores?.[_taskId]?.numCorrect + '\n';
       _toolTip += 'Num Attempted: ' + _colData.scores?.[_taskId]?.numAttempted + '\n';
@@ -161,7 +155,8 @@ function handleSubskillToolTip(_taskId, _subskillId, _toolTip, _colData) {
     }
   } else if (roamFluencyTasks.includes(_taskId)) {
     Object.entries(roamFluencySubskillHeaders).forEach(([property, propertyHeader]) => {
-      if (subskillInfo?.[property] != undefined) {
+      const isResponseModality = _colData.scores?.[_taskId]?.recruitment === 'responseModality';
+      if (!isResponseModality && subskillInfo?.[property] != undefined) {
         _toolTip += `${propertyHeader}: ${subskillInfo?.[property]}\n`;
       }
     });

--- a/apps/dashboard/src/components/reports/TableScoreTag.vue
+++ b/apps/dashboard/src/components/reports/TableScoreTag.vue
@@ -61,7 +61,7 @@ let returnScoreTooltip = (colData, fieldPath) => {
   // Subskill fieldPaths are formatted as scores.taskId.subskillId.property
   const subskillId = pathSegments.length > 3 ? pathSegments[2] : null;
   let toolTip = '';
-
+  console.log(pathSegments);
   if (subskillTasks.includes(taskId) && subskillId) {
     // Prevent any tooltips from rendering for the incorrectSkills column.
     if (taskId === 'roam-alpaca' && pathSegments[3] === 'incorrectSkills') {
@@ -135,7 +135,7 @@ function handleToolTip(_taskId, _toolTip, _colData) {
 
 function handleSubskillToolTip(_taskId, _subskillId, _toolTip, _colData) {
   const subskillInfo = _colData.scores?.[_taskId]?.[_subskillId];
-
+  const fluencyTasks = ['fluency-arf', 'fluency-calf', 'fluency-arf-es', 'fluency-calf-es'];
   if (_taskId === 'roam-alpaca') {
     if (subskillInfo?.supportLevel) {
       _toolTip += subskillInfo?.supportLevel + '\n' + '\n';
@@ -146,6 +146,10 @@ function handleSubskillToolTip(_taskId, _subskillId, _toolTip, _colData) {
     if (subskillInfo?.gradeEstimate) {
       _toolTip += 'Grade Estimate: ' + subskillInfo?.gradeEstimate + '\n';
     }
+  } else if (fluencyTasks.includes(_taskId)) {
+    _toolTip += 'Num Correct: ' + subskillInfo?.totalCorrect + '\n';
+    _toolTip += 'Num Incorrect: ' + subskillInfo?.totalIncorrect + '\n';
+    _toolTip += 'Num Attempted: ' + subskillInfo?.totalNumAttempted + '\n';
   }
 
   return _toolTip;

--- a/apps/dashboard/src/components/reports/TableScoreTag.vue
+++ b/apps/dashboard/src/components/reports/TableScoreTag.vue
@@ -61,7 +61,7 @@ let returnScoreTooltip = (colData, fieldPath) => {
   // Subskill fieldPaths are formatted as scores.taskId.subskillId.property
   const subskillId = pathSegments.length > 3 ? pathSegments[2] : null;
   let toolTip = '';
-  console.log(pathSegments);
+
   if (subskillTasks.includes(taskId) && subskillId) {
     // Prevent any tooltips from rendering for the incorrectSkills column.
     if (taskId === 'roam-alpaca' && pathSegments[3] === 'incorrectSkills') {

--- a/apps/dashboard/src/components/reports/TableScoreTag.vue
+++ b/apps/dashboard/src/components/reports/TableScoreTag.vue
@@ -38,6 +38,7 @@ import {
   rawOnlyTasks,
   scoredTasks,
   subskillTasks,
+  roamFluencySubskillHeaders,
 } from '@/helpers/reports.js';
 import { taskDisplayNames } from '@/helpers/reports';
 import { includedValidityFlags } from '@/helpers/reports';
@@ -146,10 +147,9 @@ function handleSubskillToolTip(_taskId, _subskillId, _toolTip, _colData) {
       _toolTip += 'Grade Estimate: ' + subskillInfo?.gradeEstimate + '\n';
     }
   } else if (fluencyTasks.includes(_taskId)) {
-    _toolTip += 'Raw Score: ' + subskillInfo?.rawScore + '\n';
-    _toolTip += 'Num Correct: ' + subskillInfo?.totalCorrect + '\n';
-    _toolTip += 'Num Incorrect: ' + subskillInfo?.totalIncorrect + '\n';
-    _toolTip += 'Num Attempted: ' + subskillInfo?.totalNumAttempted + '\n';
+    Object.keys(roamFluencySubskillHeaders).forEach((property) => {
+      _toolTip += `${roamFluencySubskillHeaders[property]}: ${subskillInfo?.[property]}\n`;
+    });
   }
 
   return _toolTip;

--- a/apps/dashboard/src/components/reports/TableScoreTag.vue
+++ b/apps/dashboard/src/components/reports/TableScoreTag.vue
@@ -100,12 +100,20 @@ function handleToolTip(_taskId, _toolTip, _colData) {
       _toolTip += 'Num Incorrect: ' + _colData.scores?.[_taskId]?.numIncorrect + '\n';
       _toolTip += 'Correct - Incorrect: ' + _colData.scores?.[_taskId]?.correctIncorrectDifference + '\n';
     } else if (tasksToDisplayTotalCorrect.includes(_taskId)) {
+      const numCorrect = _colData.scores?.[_taskId]?.numCorrect;
+      const numIncorrect = _colData.scores?.[_taskId]?.numIncorrect;
+      const numAttempted = _colData.scores?.[_taskId]?.numAttempted;
+
+      if (numCorrect === 0 && numIncorrect === 0 && numAttempted === 0) {
+        return '';
+      }
+
       if (_colData.scores?.[_taskId]?.recruitment !== 'responseModality') {
         _toolTip += 'Raw Score: ' + _colData.scores?.[_taskId]?.rawScore + '\n';
       }
-      _toolTip += 'Num Correct: ' + (_colData.scores?.[_taskId]?.numCorrect ?? 0) + '\n';
-      _toolTip += 'Num Incorrect: ' + _colData.scores?.[_taskId]?.numIncorrect + '\n';
-      _toolTip += 'Num Attempted: ' + _colData.scores?.[_taskId]?.numAttempted + '\n';
+      _toolTip += 'Num Correct: ' + numCorrect + '\n';
+      _toolTip += 'Num Incorrect: ' + numIncorrect + '\n';
+      _toolTip += 'Num Attempted: ' + numAttempted + '\n';
     } else if (tasksToDisplayPercentCorrect.includes(_taskId)) {
       _toolTip += 'Num Correct: ' + _colData.scores?.[_taskId]?.numCorrect + '\n';
       _toolTip += 'Num Attempted: ' + _colData.scores?.[_taskId]?.numAttempted + '\n';

--- a/apps/dashboard/src/components/reports/TableScoreTag.vue
+++ b/apps/dashboard/src/components/reports/TableScoreTag.vue
@@ -39,6 +39,7 @@ import {
   scoredTasks,
   subskillTasks,
   roamFluencySubskillHeaders,
+  fluencyTasks,
 } from '@/helpers/reports.js';
 import { taskDisplayNames } from '@/helpers/reports';
 import { includedValidityFlags } from '@/helpers/reports';
@@ -135,7 +136,6 @@ function handleToolTip(_taskId, _toolTip, _colData) {
 
 function handleSubskillToolTip(_taskId, _subskillId, _toolTip, _colData) {
   const subskillInfo = _colData.scores?.[_taskId]?.[_subskillId];
-  const fluencyTasks = ['fluency-arf', 'fluency-calf', 'fluency-arf-es', 'fluency-calf-es'];
   if (_taskId === 'roam-alpaca') {
     if (subskillInfo?.supportLevel) {
       _toolTip += subskillInfo?.supportLevel + '\n' + '\n';

--- a/apps/dashboard/src/components/reports/TableScoreTag.vue
+++ b/apps/dashboard/src/components/reports/TableScoreTag.vue
@@ -107,13 +107,15 @@ function handleToolTip(_taskId, _toolTip, _colData) {
         return '';
       }
 
-
-      const isResponseModality = _colData.scores?.[_taskId]?.isNewScoring && _colData.scores?.[_taskId]?.recruitment === 'responseModality';
+      const isResponseModality =
+        _colData.scores?.[_taskId]?.isNewScoring && _colData.scores?.[_taskId]?.recruitment === 'responseModality';
       const isOldScoring = !_colData.scores?.[_taskId]?.isNewScoring;
       Object.entries(roamFluencySubskillHeaders).forEach(([property, propertyHeader]) => {
-        if (_colData.scores?.[_taskId]?.[property] != undefined 
-            && !(isResponseModality && property === 'rawScore')
-            && !(isOldScoring && (property === 'rawScore' || property === 'numIncorrect'))) {
+        if (
+          _colData.scores?.[_taskId]?.[property] != undefined &&
+          !(isResponseModality && property === 'rawScore') &&
+          !(isOldScoring && (property === 'rawScore' || property === 'numIncorrect'))
+        ) {
           _toolTip += `${propertyHeader}: ${_colData.scores?.[_taskId]?.[property]}\n`;
         }
       });

--- a/apps/dashboard/src/components/reports/TableScoreTag.vue
+++ b/apps/dashboard/src/components/reports/TableScoreTag.vue
@@ -98,13 +98,12 @@ function handleToolTip(_taskId, _toolTip, _colData) {
       _toolTip += 'Num Incorrect: ' + _colData.scores?.[_taskId]?.numIncorrect + '\n';
       _toolTip += 'Correct - Incorrect: ' + _colData.scores?.[_taskId]?.correctIncorrectDifference + '\n';
     } else if (tasksToDisplayTotalCorrect.includes(_taskId)) {
-      if (_colData.scores?.[_taskId]?.numCorrect === undefined) {
-        _toolTip += 'Num Correct: ' + 0 + '\n';
-        _toolTip += 'Num Attempted: ' + _colData.scores?.[_taskId]?.numAttempted + '\n';
-      } else {
-        _toolTip += 'Num Correct: ' + _colData.scores?.[_taskId]?.numCorrect + '\n';
-        _toolTip += 'Num Attempted: ' + _colData.scores?.[_taskId]?.numAttempted + '\n';
+      if (_colData.scores?.[_taskId]?.recruitment !== 'responseModality') {
+        _toolTip += 'Raw Score: ' + _colData.scores?.[_taskId]?.rawScore + '\n';
       }
+      _toolTip += 'Num Correct: ' + (_colData.scores?.[_taskId]?.numCorrect ?? 0) + '\n';
+      _toolTip += 'Num Incorrect: ' + _colData.scores?.[_taskId]?.numIncorrect + '\n';
+      _toolTip += 'Num Attempted: ' + _colData.scores?.[_taskId]?.numAttempted + '\n';
     } else if (tasksToDisplayPercentCorrect.includes(_taskId)) {
       _toolTip += 'Num Correct: ' + _colData.scores?.[_taskId]?.numCorrect + '\n';
       _toolTip += 'Num Attempted: ' + _colData.scores?.[_taskId]?.numAttempted + '\n';

--- a/apps/dashboard/src/components/reports/TableScoreTag.vue
+++ b/apps/dashboard/src/components/reports/TableScoreTag.vue
@@ -109,13 +109,8 @@ function handleToolTip(_taskId, _toolTip, _colData) {
 
       const isResponseModality =
         _colData.scores?.[_taskId]?.isNewScoring && _colData.scores?.[_taskId]?.recruitment === 'responseModality';
-      const isOldScoring = !_colData.scores?.[_taskId]?.isNewScoring;
       Object.entries(roamFluencySubskillHeaders).forEach(([property, propertyHeader]) => {
-        if (
-          _colData.scores?.[_taskId]?.[property] != undefined &&
-          !(isResponseModality && property === 'rawScore') &&
-          !(isOldScoring && (property === 'rawScore' || property === 'numIncorrect'))
-        ) {
+        if (_colData.scores?.[_taskId]?.[property] != undefined && !(isResponseModality && property === 'rawScore')) {
           _toolTip += `${propertyHeader}: ${_colData.scores?.[_taskId]?.[property]}\n`;
         }
       });

--- a/apps/dashboard/src/components/reports/TableScoreTag.vue
+++ b/apps/dashboard/src/components/reports/TableScoreTag.vue
@@ -155,8 +155,8 @@ function handleSubskillToolTip(_taskId, _subskillId, _toolTip, _colData) {
       _toolTip += 'Grade Estimate: ' + subskillInfo?.gradeEstimate + '\n';
     }
   } else if (roamFluencyTasks.includes(_taskId)) {
-    Object.keys(roamFluencySubskillHeaders).forEach((property) => {
-      _toolTip += `${roamFluencySubskillHeaders[property]}: ${subskillInfo?.[property]}\n`;
+    Object.entries(roamFluencySubskillHeaders).forEach(([property, propertyHeader]) => {
+      _toolTip += `${propertyHeader}: ${subskillInfo?.[property]}\n`;
     });
   }
 

--- a/apps/dashboard/src/components/reports/TableScoreTag.vue
+++ b/apps/dashboard/src/components/reports/TableScoreTag.vue
@@ -111,9 +111,14 @@ function handleToolTip(_taskId, _toolTip, _colData) {
       if (_colData.scores?.[_taskId]?.recruitment !== 'responseModality') {
         _toolTip += 'Raw Score: ' + _colData.scores?.[_taskId]?.rawScore + '\n';
       }
-      _toolTip += 'Num Correct: ' + numCorrect + '\n';
-      _toolTip += 'Num Incorrect: ' + numIncorrect + '\n';
-      _toolTip += 'Num Attempted: ' + numAttempted + '\n';
+
+      Object.entries(roamFluencySubskillHeaders)
+        .slice(1)
+        .forEach(([property, propertyHeader]) => {
+          if (_colData.scores?.[_taskId]?.[property] != undefined) {
+            _toolTip += `${propertyHeader}: ${_colData.scores?.[_taskId]?.[property]}\n`;
+          }
+        });
     } else if (tasksToDisplayPercentCorrect.includes(_taskId)) {
       _toolTip += 'Num Correct: ' + _colData.scores?.[_taskId]?.numCorrect + '\n';
       _toolTip += 'Num Attempted: ' + _colData.scores?.[_taskId]?.numAttempted + '\n';
@@ -156,7 +161,9 @@ function handleSubskillToolTip(_taskId, _subskillId, _toolTip, _colData) {
     }
   } else if (roamFluencyTasks.includes(_taskId)) {
     Object.entries(roamFluencySubskillHeaders).forEach(([property, propertyHeader]) => {
-      _toolTip += `${propertyHeader}: ${subskillInfo?.[property]}\n`;
+      if (subskillInfo?.[property] != undefined) {
+        _toolTip += `${propertyHeader}: ${subskillInfo?.[property]}\n`;
+      }
     });
   }
 

--- a/apps/dashboard/src/components/reports/TableScoreTag.vue
+++ b/apps/dashboard/src/components/reports/TableScoreTag.vue
@@ -107,9 +107,13 @@ function handleToolTip(_taskId, _toolTip, _colData) {
         return '';
       }
 
-      const isResponseModality = _colData.scores?.[_taskId]?.recruitment === 'responseModality';
+
+      const isResponseModality = _colData.scores?.[_taskId]?.isNewScoring && _colData.scores?.[_taskId]?.recruitment === 'responseModality';
+      const isOldScoring = !_colData.scores?.[_taskId]?.isNewScoring;
       Object.entries(roamFluencySubskillHeaders).forEach(([property, propertyHeader]) => {
-        if (_colData.scores?.[_taskId]?.[property] != undefined && !(isResponseModality && property === 'rawScore')) {
+        if (_colData.scores?.[_taskId]?.[property] != undefined 
+            && !(isResponseModality && property === 'rawScore')
+            && !(isOldScoring && (property === 'rawScore' || property === 'numIncorrect'))) {
           _toolTip += `${propertyHeader}: ${_colData.scores?.[_taskId]?.[property]}\n`;
         }
       });

--- a/apps/dashboard/src/components/reports/TableScoreTag.vue
+++ b/apps/dashboard/src/components/reports/TableScoreTag.vue
@@ -39,7 +39,7 @@ import {
   scoredTasks,
   subskillTasks,
   roamFluencySubskillHeaders,
-  fluencyTasks,
+  roamFluencyTasks,
 } from '@/helpers/reports.js';
 import { taskDisplayNames } from '@/helpers/reports';
 import { includedValidityFlags } from '@/helpers/reports';
@@ -146,7 +146,7 @@ function handleSubskillToolTip(_taskId, _subskillId, _toolTip, _colData) {
     if (subskillInfo?.gradeEstimate) {
       _toolTip += 'Grade Estimate: ' + subskillInfo?.gradeEstimate + '\n';
     }
-  } else if (fluencyTasks.includes(_taskId)) {
+  } else if (roamFluencyTasks.includes(_taskId)) {
     Object.keys(roamFluencySubskillHeaders).forEach((property) => {
       _toolTip += `${roamFluencySubskillHeaders[property]}: ${subskillInfo?.[property]}\n`;
     });

--- a/apps/dashboard/src/components/reports/TableScoreTag.vue
+++ b/apps/dashboard/src/components/reports/TableScoreTag.vue
@@ -155,8 +155,7 @@ function handleSubskillToolTip(_taskId, _subskillId, _toolTip, _colData) {
     }
   } else if (roamFluencyTasks.includes(_taskId)) {
     Object.entries(roamFluencySubskillHeaders).forEach(([property, propertyHeader]) => {
-      const isResponseModality = _colData.scores?.[_taskId]?.recruitment === 'responseModality';
-      if (!isResponseModality && subskillInfo?.[property] != undefined) {
+      if (subskillInfo?.[property] != undefined) {
         _toolTip += `${propertyHeader}: ${subskillInfo?.[property]}\n`;
       }
     });

--- a/apps/dashboard/src/helpers/reports.js
+++ b/apps/dashboard/src/helpers/reports.js
@@ -557,6 +557,13 @@ export const roamAlpacaSubskillHeaders = {
   supportLevel: 'Support Level',
 };
 
+export const roamFluencySubskillHeaders = {
+  rawScore: 'Raw Score',
+  totalCorrect: 'Num Correct',
+  totalIncorrect: 'Num Incorrect',
+  totalNumAttempted: 'Num Attempted',
+};
+
 function getOrdinalSuffix(n) {
   if (n >= 11 && n <= 13) return 'th';
 

--- a/apps/dashboard/src/helpers/reports.js
+++ b/apps/dashboard/src/helpers/reports.js
@@ -443,12 +443,12 @@ export const scoredTasks = ['swr', 'pa', 'sre'];
  *  Fluency Tasks
  *  Temporary variable to differentiate from tasksToDisplayTotalCorrect for backward compatibility
  */
-export const fluencyTasks = ['fluency-arf', 'fluency-calf', 'fluency-arf-es', 'fluency-calf-es'];
+export const roamFluencyTasks = ['fluency-arf', 'fluency-calf', 'fluency-arf-es', 'fluency-calf-es'];
 
 /*
  *  Tasks with subskills that require tooltips for subscore table.
  */
-export const subskillTasks = ['roam-alpaca', ...fluencyTasks];
+export const subskillTasks = ['roam-alpaca', ...roamFluencyTasks];
 
 /*
  *  Support Level Colors

--- a/apps/dashboard/src/helpers/reports.js
+++ b/apps/dashboard/src/helpers/reports.js
@@ -440,9 +440,15 @@ export const tasksToDisplayCorrectIncorrectDifference = ['sre-es'];
 export const scoredTasks = ['swr', 'pa', 'sre'];
 
 /*
+ *  Fluency Tasks
+ *  Temporary variable to differentiate from tasksToDisplayTotalCorrect for backward compatibility
+ */
+export const fluencyTasks = ['fluency-arf', 'fluency-calf', 'fluency-arf-es', 'fluency-calf-es'];
+
+/*
  *  Tasks with subskills that require tooltips for subscore table.
  */
-export const subskillTasks = ['roam-alpaca'];
+export const subskillTasks = ['roam-alpaca', ...fluencyTasks];
 
 /*
  *  Support Level Colors

--- a/apps/dashboard/src/helpers/reports.js
+++ b/apps/dashboard/src/helpers/reports.js
@@ -559,9 +559,9 @@ export const roamAlpacaSubskillHeaders = {
 
 export const roamFluencySubskillHeaders = {
   rawScore: 'Raw Score',
-  totalCorrect: 'Num Correct',
-  totalIncorrect: 'Num Incorrect',
-  totalNumAttempted: 'Num Attempted',
+  numCorrect: 'Num Correct',
+  numIncorrect: 'Num Incorrect',
+  numAttempted: 'Num Attempted',
 };
 
 function getOrdinalSuffix(n) {

--- a/apps/dashboard/src/pages/ScoreReport.vue
+++ b/apps/dashboard/src/pages/ScoreReport.vue
@@ -822,10 +822,11 @@ const computeAssignmentAndRunData = computed(() => {
           currRowScores[taskId].thetaEstimate = thetaEstimate;
         }
         if (['fluency-calf', 'fluency-arf', 'fluency-calf-es', 'fluency-arf-es'].includes(taskId)) {
-          console.log('fluency', assessment);
           const fc = _get(assessment, 'scores.computed.FC');
           const fr = _get(assessment, 'scores.computed.FR');
+          const recruit = _get(assessment, 'params.recruitment');
 
+          currRowScores[taskId].recruitment = recruit;
           currRowScores[taskId].fc = fc;
           currRowScores[taskId].fr = fr;
         }
@@ -952,6 +953,12 @@ watch(
   computeAssignmentAndRunData,
   (newValue) => {
     filteredTableData.value = newValue.assignmentTableData;
+    if (filteredTableData.value.length > 0) {
+      // Assign recruitment values to handle roam response modality raw score reporting
+      for (const [key, value] of Object.entries(filteredTableData.value[0].scores)) {
+        recruitment.value[key] = value?.recruitment;
+      }
+    }
   },
   { immediate: true, deep: true },
 );

--- a/apps/dashboard/src/pages/ScoreReport.vue
+++ b/apps/dashboard/src/pages/ScoreReport.vue
@@ -365,8 +365,6 @@ const exportLoading = ref(false);
 
 const activeTabIndex = ref(0);
 
-const recruitment = ref({});
-
 const pageWidth = 190; // Set page width for calculations
 const returnScaleFactor = (width) => pageWidth / width; // Calculate the scale factor
 
@@ -932,7 +930,8 @@ const computeAssignmentAndRunData = computed(() => {
     const assessments = administrationData.value.assessments;
     for (const assessment of assessments) {
       if (roamFluencyTasks.includes(assessment.taskId)) {
-        if (recruitment.value[assessment.taskId] !== 'responseModality') {
+        const recruitment = assessment.params.recruitment;
+        if (recruitment !== 'responseModality') {
           delete filteredRunsByTaskId[assessment.taskId];
         }
       }
@@ -949,12 +948,6 @@ watch(
   computeAssignmentAndRunData,
   (newValue) => {
     filteredTableData.value = newValue.assignmentTableData;
-    if (filteredTableData.value.length > 0) {
-      // Assign recruitment values to handle roam response modality raw score reporting
-      for (const [key, value] of Object.entries(filteredTableData.value[0].scores)) {
-        recruitment.value[key] = value?.recruitment;
-      }
-    }
   },
   { immediate: true, deep: true },
 );
@@ -1464,8 +1457,11 @@ const scoreReportColumns = computed(() => {
     if (excludeFromScoringTasks.includes(taskId)) continue; // Skip adding this column
     let colField;
     const isOptional = `scores.${taskId}.optional`;
-    const isFluencyResponseModality =
-      roamFluencyTasks.includes(taskId) && recruitment.value[taskId] === 'responseModality';
+    let isFluencyResponseModality = false;
+    if (roamFluencyTasks.includes(taskId)) {
+      const fluencyTasks = administrationData.value?.assessments?.find((assessment) => assessment.taskId === taskId);
+      isFluencyResponseModality = fluencyTasks?.params?.recruitment === 'responseModality';
+    }
 
     // Color needs to include a field to allow sorting.
     if (viewMode.value === 'percentile' || viewMode.value === 'color') {

--- a/apps/dashboard/src/pages/ScoreReport.vue
+++ b/apps/dashboard/src/pages/ScoreReport.vue
@@ -776,6 +776,11 @@ const computeAssignmentAndRunData = computed(() => {
           currRowScores[taskId].recruitment = _get(assessment, 'params.recruitment');
           currRowScores[taskId].fc = _get(assessment, 'scores.computed.FC');
           currRowScores[taskId].fr = _get(assessment, 'scores.computed.FR');
+
+          /**
+           * TODO: If the composite exists, the raw score should exist as well.
+           * Check and see if we need the 2nd ternary and condition in returnColorByReliability.
+           */
           currRowScores[taskId].tagColor =
             numAttempted === undefined || numAttempted === 0 ? '#EEEEF0' : numAttempted !== 0 ? tagColor : '#EEEEF0';
           scoreFilterTags += ' Assessed ';

--- a/apps/dashboard/src/pages/ScoreReport.vue
+++ b/apps/dashboard/src/pages/ScoreReport.vue
@@ -567,6 +567,9 @@ const getScoresAndSupportFromAssessment = ({
     } else {
       support_level = '';
       tag_color = '#A4DDED';
+      if (tasksToDisplayTotalCorrect.includes(taskId)) {
+        rawScore = _get(assessment, 'scores.computed.composite.rawScore');
+      }
     }
   } else {
     ({ support_level, tag_color } = getSupportLevel(grade, percentile, rawScore, taskId, optional));
@@ -822,13 +825,12 @@ const computeAssignmentAndRunData = computed(() => {
           currRowScores[taskId].thetaEstimate = thetaEstimate;
         }
         if (['fluency-calf', 'fluency-arf', 'fluency-calf-es', 'fluency-arf-es'].includes(taskId)) {
-          const fc = _get(assessment, 'scores.computed.FC');
-          const fr = _get(assessment, 'scores.computed.FR');
-          const recruit = _get(assessment, 'params.recruitment');
-
-          currRowScores[taskId].recruitment = recruit;
-          currRowScores[taskId].fc = fc;
-          currRowScores[taskId].fr = fr;
+          currRowScores[taskId].numCorrect = _get(assessment, 'scores.computed.composite.totalCorrect');
+          currRowScores[taskId].numIncorrect = _get(assessment, 'scores.computed.composite.totalIncorrect');
+          currRowScores[taskId].numAttempted = _get(assessment, 'scores.computed.composite.totalNumAttempted');
+          currRowScores[taskId].recruitment = _get(assessment, 'params.recruitment');
+          currRowScores[taskId].fc = _get(assessment, 'scores.computed.FC');
+          currRowScores[taskId].fr = _get(assessment, 'scores.computed.FR');
         }
 
         if (taskId === 'roam-alpaca') {
@@ -1489,7 +1491,7 @@ const scoreReportColumns = computed(() => {
       if (tasksToDisplayCorrectIncorrectDifference.includes(taskId) && viewMode.value === 'raw') {
         colField = `scores.${taskId}.correctIncorrectDifference`;
       } else if (tasksToDisplayTotalCorrect.includes(taskId) && viewMode.value === 'raw') {
-        colField = `scores.${taskId}.numCorrect`;
+        colField = `scores.${taskId}.rawScore`;
       } else if (tasksToDisplayPercentCorrect.includes(taskId) && viewMode.value === 'raw') {
         colField = `scores.${taskId}.percentCorrect`;
       } else if (tasksToDisplayThetaScore.includes(taskId) && viewMode.value === 'raw') {

--- a/apps/dashboard/src/pages/ScoreReport.vue
+++ b/apps/dashboard/src/pages/ScoreReport.vue
@@ -769,15 +769,13 @@ const computeAssignmentAndRunData = computed(() => {
           currRowScores[taskId].tagColor = percentCorrect === null ? 'transparent' : tagColor;
           scoreFilterTags += ' Assessed ';
         } else if (tasksToDisplayTotalCorrect.includes(taskId)) {
-          const numAttempted = assessment.scores?.raw?.composite?.test?.numAttempted;
-          const numCorrect =
-            numAttempted === undefined || numAttempted === 0
-              ? ''
-              : numAttempted !== 0 && assessment.scores?.raw?.composite?.test?.numCorrect !== undefined
-                ? assessment.scores?.raw?.composite?.test?.numCorrect
-                : 0;
+          const numAttempted = _get(assessment, 'scores.computed.composite.numAttempted');
+          currRowScores[taskId].numCorrect = _get(assessment, 'scores.computed.composite.numCorrect');
+          currRowScores[taskId].numIncorrect = _get(assessment, 'scores.computed.composite.numIncorrect');
           currRowScores[taskId].numAttempted = numAttempted;
-          currRowScores[taskId].numCorrect = numCorrect;
+          currRowScores[taskId].recruitment = _get(assessment, 'params.recruitment');
+          currRowScores[taskId].fc = _get(assessment, 'scores.computed.FC');
+          currRowScores[taskId].fr = _get(assessment, 'scores.computed.FR');
           currRowScores[taskId].tagColor =
             numAttempted === undefined || numAttempted === 0 ? '#EEEEF0' : numAttempted !== 0 ? tagColor : '#EEEEF0';
           scoreFilterTags += ' Assessed ';
@@ -824,15 +822,6 @@ const computeAssignmentAndRunData = computed(() => {
           currRowScores[taskId].numIncorrect = numIncorrect;
           currRowScores[taskId].thetaEstimate = thetaEstimate;
         }
-        if (['fluency-calf', 'fluency-arf', 'fluency-calf-es', 'fluency-arf-es'].includes(taskId)) {
-          currRowScores[taskId].numCorrect = _get(assessment, 'scores.computed.composite.numCorrect');
-          currRowScores[taskId].numIncorrect = _get(assessment, 'scores.computed.composite.numIncorrect');
-          currRowScores[taskId].numAttempted = _get(assessment, 'scores.computed.composite.numAttempted');
-          currRowScores[taskId].recruitment = _get(assessment, 'params.recruitment');
-          currRowScores[taskId].fc = _get(assessment, 'scores.computed.FC');
-          currRowScores[taskId].fr = _get(assessment, 'scores.computed.FR');
-        }
-
         if (taskId === 'roam-alpaca') {
           const scores = _get(assessment, 'scores.computed');
           if (scores) {
@@ -937,7 +926,7 @@ const computeAssignmentAndRunData = computed(() => {
     // Otherwise, remove them from the runsByTaskId object to prevent including them in TaskReports.
     const assessments = administrationData.value.assessments;
     for (const assessment of assessments) {
-      if (['fluency-calf', 'fluency-arf', 'fluency-calf-es', 'fluency-arf-es'].includes(assessment.taskId)) {
+      if (fluencyTasks.includes(assessment.taskId)) {
         if (recruitment.value[assessment.taskId] !== 'responseModality') {
           delete filteredRunsByTaskId[assessment.taskId];
         }

--- a/apps/dashboard/src/pages/ScoreReport.vue
+++ b/apps/dashboard/src/pages/ScoreReport.vue
@@ -780,11 +780,13 @@ const computeAssignmentAndRunData = computed(() => {
             currRowScores[taskId].numIncorrect = _get(assessment, `scores.computed.composite.numIncorrect`);
           }
 
-          /**
-           * TODO: If the composite exists, the raw score should exist as well.
-           * Check and see if we can simplify the condition here and in returnColorByReliability.
-           */
           currRowScores[taskId].numAttempted = numAttempted;
+          /**
+           * TODO:
+           * - If the composite exists, the raw score should exist as well.
+           * Check and see if we can simplify the condition here and in returnColorByReliability.
+           * - What happens if numAttempted is 0?
+           */
           currRowScores[taskId].tagColor =
             numAttempted === undefined || numAttempted === 0 ? '#EEEEF0' : numAttempted !== 0 ? tagColor : '#EEEEF0';
           currRowScores[taskId].recruitment = _get(assessment, 'params.recruitment');

--- a/apps/dashboard/src/pages/ScoreReport.vue
+++ b/apps/dashboard/src/pages/ScoreReport.vue
@@ -779,7 +779,7 @@ const computeAssignmentAndRunData = computed(() => {
 
           /**
            * TODO: If the composite exists, the raw score should exist as well.
-           * Check and see if we need the 2nd ternary and condition in returnColorByReliability.
+           * Check and see if we can simplify the condition here and in returnColorByReliability.
            */
           currRowScores[taskId].tagColor =
             numAttempted === undefined || numAttempted === 0 ? '#EEEEF0' : numAttempted !== 0 ? tagColor : '#EEEEF0';

--- a/apps/dashboard/src/pages/ScoreReport.vue
+++ b/apps/dashboard/src/pages/ScoreReport.vue
@@ -567,7 +567,7 @@ const getScoresAndSupportFromAssessment = ({
       tag_color = '#A4DDED';
       if (tasksToDisplayTotalCorrect.includes(taskId)) {
         const isNewScoring = !_get(assessment, 'scores.computed.composite.roamScore');
-        // Previous scoring system returned numCorrect for rawScore in scoreReportColumns
+        // Previous scoring returned numCorrect for rawScore in scoreReportColumns, confirmed roamScore with Kruttika
         rawScore = _get(assessment, `scores.computed.composite.${isNewScoring ? 'rawScore' : 'roamScore'}`);
       }
     }

--- a/apps/dashboard/src/pages/ScoreReport.vue
+++ b/apps/dashboard/src/pages/ScoreReport.vue
@@ -310,7 +310,7 @@ import {
   includedValidityFlags,
   roamAlpacaSubskills,
   getTagColor,
-  fluencyTasks,
+  roamFluencyTasks,
 } from '@/helpers/reports';
 import RoarDataTable from '@/components/RoarDataTable';
 import { CSV_EXPORT_STATIC_COLUMNS } from '@/constants/csvExport';
@@ -926,7 +926,7 @@ const computeAssignmentAndRunData = computed(() => {
     // Otherwise, remove them from the runsByTaskId object to prevent including them in TaskReports.
     const assessments = administrationData.value.assessments;
     for (const assessment of assessments) {
-      if (fluencyTasks.includes(assessment.taskId)) {
+      if (roamFluencyTasks.includes(assessment.taskId)) {
         if (recruitment.value[assessment.taskId] !== 'responseModality') {
           delete filteredRunsByTaskId[assessment.taskId];
         }
@@ -1459,7 +1459,8 @@ const scoreReportColumns = computed(() => {
     if (excludeFromScoringTasks.includes(taskId)) continue; // Skip adding this column
     let colField;
     const isOptional = `scores.${taskId}.optional`;
-    const isFluencyResponseModality = fluencyTasks.includes(taskId) && recruitment.value[taskId] === 'responseModality';
+    const isFluencyResponseModality =
+      roamFluencyTasks.includes(taskId) && recruitment.value[taskId] === 'responseModality';
 
     // Color needs to include a field to allow sorting.
     if (viewMode.value === 'percentile' || viewMode.value === 'color') {

--- a/apps/dashboard/src/pages/ScoreReport.vue
+++ b/apps/dashboard/src/pages/ScoreReport.vue
@@ -768,22 +768,25 @@ const computeAssignmentAndRunData = computed(() => {
         } else if (tasksToDisplayTotalCorrect.includes(taskId)) {
           // isNewScoring is 1.2.23+, otherwise handles 1.2.14
           const isNewScoring = _has(assessment, 'scores.computed.composite.numCorrect');
-          const propertyKeys = isNewScoring ? ['numCorrect', 'numIncorrect', 'numAttempted'] : ['totalCorrect', 'totalIncorrect', 'totalNumAttempted'];
-         
-          const [rawNumCorrect, numIncorrect, numAttempted] = propertyKeys.map(key => 
-            _get(assessment, `scores.computed.composite.${key}`));
+          const propertyKeys = isNewScoring
+            ? ['numCorrect', 'numIncorrect', 'numAttempted']
+            : ['totalCorrect', 'totalIncorrect', 'totalNumAttempted'];
+
+          const [rawNumCorrect, numIncorrect, numAttempted] = propertyKeys.map((key) =>
+            _get(assessment, `scores.computed.composite.${key}`),
+          );
 
           // Special handling for older scoring, returns undefined for correct even if attempted != 0
           // Otherwise, return original even if undefined because numAttempted is falsy
           const isOldAttempted = !isNewScoring && numAttempted > 0 && !rawNumCorrect;
           const numCorrect = isOldAttempted ? 0 : rawNumCorrect;
 
-          Object.assign(currRowScores[taskId], {numCorrect, numIncorrect, numAttempted, isNewScoring});
+          Object.assign(currRowScores[taskId], { numCorrect, numIncorrect, numAttempted, isNewScoring });
 
           currRowScores[taskId].recruitment = _get(assessment, 'params.recruitment');
           currRowScores[taskId].fc = _get(assessment, 'scores.computed.FC');
           currRowScores[taskId].fr = _get(assessment, 'scores.computed.FR');
-        
+
           scoreFilterTags += ' Assessed ';
         }
         if ((taskId === 'letter' || taskId === 'letter-en-ca') && assessment.scores) {
@@ -1029,7 +1032,7 @@ const createExportData = ({ rows, includeProgress = false }) => {
         tableRow[`${taskName} - Num Incorrect`] = score.numIncorrect;
         tableRow[`${taskName} - Num Correct`] = score.numCorrect;
       } else if (tasksToDisplayTotalCorrect.includes(taskId)) {
-        if ((score.isNewScoring && score.recruitment !== 'responseModality')) {
+        if (score.isNewScoring && score.recruitment !== 'responseModality') {
           tableRow[`${taskName} - Raw Score`] = score.rawScore;
         }
         tableRow[`${taskName} - Num Correct`] = score.numCorrect;

--- a/apps/dashboard/src/pages/ScoreReport.vue
+++ b/apps/dashboard/src/pages/ScoreReport.vue
@@ -819,8 +819,9 @@ const computeAssignmentAndRunData = computed(() => {
           currRowScores[taskId].thetaEstimate = thetaEstimate;
         }
         if (['fluency-calf', 'fluency-arf', 'fluency-calf-es', 'fluency-arf-es'].includes(taskId)) {
-          const fc = _get(assessment, 'scores.computed.FC.roamScore');
-          const fr = _get(assessment, 'scores.computed.FR.roamScore');
+          console.log('fluency', assessment);
+          const fc = _get(assessment, 'scores.computed.FC');
+          const fr = _get(assessment, 'scores.computed.FR');
 
           currRowScores[taskId].fc = fc;
           currRowScores[taskId].fr = fr;

--- a/apps/dashboard/src/pages/ScoreReport.vue
+++ b/apps/dashboard/src/pages/ScoreReport.vue
@@ -825,9 +825,9 @@ const computeAssignmentAndRunData = computed(() => {
           currRowScores[taskId].thetaEstimate = thetaEstimate;
         }
         if (['fluency-calf', 'fluency-arf', 'fluency-calf-es', 'fluency-arf-es'].includes(taskId)) {
-          currRowScores[taskId].numCorrect = _get(assessment, 'scores.computed.composite.totalCorrect');
-          currRowScores[taskId].numIncorrect = _get(assessment, 'scores.computed.composite.totalIncorrect');
-          currRowScores[taskId].numAttempted = _get(assessment, 'scores.computed.composite.totalNumAttempted');
+          currRowScores[taskId].numCorrect = _get(assessment, 'scores.computed.composite.numCorrect');
+          currRowScores[taskId].numIncorrect = _get(assessment, 'scores.computed.composite.numIncorrect');
+          currRowScores[taskId].numAttempted = _get(assessment, 'scores.computed.composite.numAttempted');
           currRowScores[taskId].recruitment = _get(assessment, 'params.recruitment');
           currRowScores[taskId].fc = _get(assessment, 'scores.computed.FC');
           currRowScores[taskId].fr = _get(assessment, 'scores.computed.FR');

--- a/apps/dashboard/src/pages/ScoreReport.vue
+++ b/apps/dashboard/src/pages/ScoreReport.vue
@@ -560,12 +560,11 @@ const getScoresAndSupportFromAssessment = ({
       support_level = '';
       tag_color = '#A4DDED';
       if (tasksToDisplayTotalCorrect.includes(taskId)) {
-        const isNewScoring = _has(assessment, 'scores.computed.composite.numAttempted');
-        const numAttempted = _get(assessment, 'scores.computed.composite.totalNumAttempted');
-        // Handles tag color for old scoring
-        tag_color = !isNewScoring && !numAttempted ? '#EEEEF0' : '#A4DDED';
-        // Do not display raw score for old scoring
+        const numAttempted = _get(assessment, 'scores.computed.composite.numAttempted');
+        const oldNumAttempted = _get(assessment, 'scores.computed.composite.totalNumAttempted');
         rawScore = _get(assessment, 'scores.computed.composite.rawScore');
+        // If numAttempted, set as assessed
+        tag_color = oldNumAttempted || numAttempted ? '#A4DDED' : '#EEEEF0';
       }
     }
   } else {
@@ -772,14 +771,9 @@ const computeAssignmentAndRunData = computed(() => {
             ? ['numCorrect', 'numIncorrect', 'numAttempted']
             : ['totalCorrect', 'totalIncorrect', 'totalNumAttempted'];
 
-          const [rawNumCorrect, numIncorrect, numAttempted] = propertyKeys.map((key) =>
+          const [numCorrect, numIncorrect, numAttempted] = propertyKeys.map((key) =>
             _get(assessment, `scores.computed.composite.${key}`),
           );
-
-          // Special handling for older scoring, returns undefined for correct even if attempted != 0
-          // Otherwise, return original even if undefined because numAttempted is falsy
-          const isOldAttempted = !isNewScoring && numAttempted > 0 && !rawNumCorrect;
-          const numCorrect = isOldAttempted ? 0 : rawNumCorrect;
 
           Object.assign(currRowScores[taskId], { numCorrect, numIncorrect, numAttempted, isNewScoring });
 

--- a/apps/dashboard/src/pages/ScoreReport.vue
+++ b/apps/dashboard/src/pages/ScoreReport.vue
@@ -310,6 +310,7 @@ import {
   includedValidityFlags,
   roamAlpacaSubskills,
   getTagColor,
+  fluencyTasks,
 } from '@/helpers/reports';
 import RoarDataTable from '@/components/RoarDataTable';
 import { CSV_EXPORT_STATIC_COLUMNS } from '@/constants/csvExport';
@@ -363,6 +364,8 @@ const handleViewChange = () => {
 const exportLoading = ref(false);
 
 const activeTabIndex = ref(0);
+
+const recruitment = ref({});
 
 const pageWidth = 190; // Set page width for calculations
 const returnScaleFactor = (width) => pageWidth / width; // Calculate the scale factor
@@ -932,8 +935,7 @@ const computeAssignmentAndRunData = computed(() => {
     const assessments = administrationData.value.assessments;
     for (const assessment of assessments) {
       if (['fluency-calf', 'fluency-arf', 'fluency-calf-es', 'fluency-arf-es'].includes(assessment.taskId)) {
-        const recruitment = assessment?.params?.recruitment;
-        if (recruitment !== 'responseModality') {
+        if (recruitment.value[assessment.taskId] !== 'responseModality') {
           delete filteredRunsByTaskId[assessment.taskId];
         }
       }
@@ -1455,6 +1457,7 @@ const scoreReportColumns = computed(() => {
     if (excludeFromScoringTasks.includes(taskId)) continue; // Skip adding this column
     let colField;
     const isOptional = `scores.${taskId}.optional`;
+    const isFluencyResponseModality = fluencyTasks.includes(taskId) && recruitment.value[taskId] === 'responseModality';
 
     // Color needs to include a field to allow sorting.
     if (viewMode.value === 'percentile' || viewMode.value === 'color') {
@@ -1504,6 +1507,7 @@ const scoreReportColumns = computed(() => {
     } else {
       backgroundColor = '#EEEEF0';
     }
+
     tableColumns.push({
       field: colField,
       header: tasksDictionary.value[taskId]?.publicName ?? taskId,
@@ -1513,7 +1517,7 @@ const scoreReportColumns = computed(() => {
       filter: true,
       sortField: colField ? colField : `scores.${taskId}.percentile`,
       tag: viewMode.value !== 'color',
-      emptyTag: viewMode.value === 'color' || isOptional,
+      emptyTag: viewMode.value === 'color' || isFluencyResponseModality || isOptional,
       tagColor: `scores.${taskId}.tagColor`,
       style: (() => {
         return `text-align: center; ${getTaskStyle(taskId, backgroundColor, orderedTasks)}`;

--- a/apps/dashboard/src/pages/ScoreReport.vue
+++ b/apps/dashboard/src/pages/ScoreReport.vue
@@ -1039,7 +1039,11 @@ const createExportData = ({ rows, includeProgress = false }) => {
         tableRow[`${taskName} - Num Incorrect`] = score.numIncorrect;
         tableRow[`${taskName} - Num Correct`] = score.numCorrect;
       } else if (tasksToDisplayTotalCorrect.includes(taskId)) {
+        if (score.recruitment !== 'responseModality') {
+          tableRow[`${taskName} - Raw Score`] = score.rawScore;
+        }
         tableRow[`${taskName} - Num Correct`] = score.numCorrect;
+        tableRow[`${taskName} - Num Incorrect`] = score.numIncorrect;
         tableRow[`${taskName} - Num Attempted`] = score.numAttempted;
       } else if (rawOnlyTasks.includes(taskId)) {
         tableRow[`${taskName} - Raw`] = score.rawScore;


### PR DESCRIPTION
## Proposed changes

This PR updates ROAM fluency scores and variables according to the changes made in ROAM's newest version 1.2.23. 

Changes:

**1.2.23**
Score report
- Tasks with recruitment = responseModality will not show raw scores, only the assessed circle. Other variants are not affected and will continue to show raw score 

Subscore table
- Free Choice and Multiple Choice score now returns rawScore instead of roamScore.
- Tooltips show raw score, num correct, num incorrect, and num attempted. 
- Exported tables contain the tooltip values. 


### 8/28 Update


Handles score report for versions  < 1.2.14 and 1.2.23 (no student data between 1.2.15 and 1.2.22)

**1.2.14** 
- Tooltips show numCorrect (totalNumCorrect) and numAttempted (numAttempted). No raw score is shown, regardless of response modality. (empty tag = old score)
- Replaced the previous undefined check for numCorrect and tagColor. The only situation where totalNumCorrect is undefined is when we are retrieving it from assessment.scores.raw.composite.test, not from assessment.scores.computed.composite.

Requested changes: https://docs.google.com/document/d/1PTMjLBW6qLplMy7IPS_AtSOfLcM5v6LDRjF7Tn0EczY/edit?tab=t.0 


https://github.com/user-attachments/assets/d5e070b8-1a82-42d2-adfe-d255bd1f8b55



### New changes only
https://github.com/user-attachments/assets/d34dd060-df78-4f70-98dd-5af654192d19



## Types of changes

What types of changes does this pull request introduce?

<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (non-breaking change that does not add functionality but makes code cleaner or more efficient)
- [ ] Documentation Update
- [ ] Tests (new or updated tests)
- [ ] Style (changes to code styling)
- [ ] CI (continuous integration changes)
- [ ] Repository Maintenance
- [ ] Other (please describe below)

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask.  We're here
to help! This is simply a reminder of what we are going to look for before
merging your code.
-->

- [x] I have read the [guidelines for contributing](https://github.com/yeatmanlab/roar-dashboard/blob/main/.github/CONTRIBUTING.md).
- [x] The changes in this PR are as small as they can be. They represent one and only one fix or enhancement.
- [x] Linting checks pass with my changes.
- [x] Any existing unit tests pass with my changes.
- [x] Any existing end-to-end tests pass with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] If this PR fixes an existing issue, I have added a unit or end-to-end test that will detect if this issue reoccurs.
- [ ] I have added JSDoc comments as appropriate.
- [ ] I have added the necessary documentation to the [roar-docs repository](https://github.com/yeatmanlab/roar-docs).
- [x] I have shared this PR on the roar-pr-reviews channel (if I have access)
- [ ] I have linked relevant issues (if any)

## Justification of missing checklist items

<!--
If you feel that a checklist item above is not applicable to this PR, please
provide your justification here. Otherwise, delete this section.
-->

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
