### PR TITLE
Fix package lookup path for assessment E2E testing condition

### DIFF
--- a/apps/dashboard/cypress/support/utils.js
+++ b/apps/dashboard/cypress/support/utils.js
@@ -22,7 +22,7 @@ export const isCurrentVersion = async (app) => {
 
   const owner = 'yeatmanlab';
   const repository = 'roar-dashboard';
-  const filePath = 'package.json';
+  const filePath = 'apps/dashboard/package.json';
   const branch = 'main';
 
   const url = `https://api.github.com/repos/${owner}/${repository}/contents/${filePath}?ref=${branch}`;


### PR DESCRIPTION
## Proposed changes
This PR updates the `package.json` path used in assessment E2E test to set run conditions. 

For the time being, no changes are made to the existing semver-range string comparison to decide whether to run assessment E2E tests. We should however consider changing this to compare resolved versions from package-lock.json to avoid semver-range masking.

## Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (non-breaking change that does not add functionality but makes code cleaner or more efficient)
- [ ] Documentation Update
- [ ] Tests (new or updated tests)
- [ ] Style (changes to code styling)
- [ ] CI (continuous integration changes)
- [ ] Repository Maintenance
- [ ] Other (please describe below)

