### PR TITLE
Checkout repository conditionally in `deploy-firestore-config` action

### DIFF
--- a/.github/actions/deploy-firestore-config/action.yml
+++ b/.github/actions/deploy-firestore-config/action.yml
@@ -20,14 +20,16 @@ inputs:
   commit-sha:
     description: 'The commit SHA to deploy.'
     required: false
+    default: 'false'
 
 runs:
   using: composite
   steps:
     - name: Checkout repository
       uses: actions/checkout@v4
+      if: ${{ inputs.commit-sha != 'false' }}
       with:
-        ref: ${{ inputs.commit-sha || github.sha }}
+        ref: ${{ inputs.commit-sha }}
         repository: yeatmanlab/roar-dashboard
         path: roar-dashboard
 


### PR DESCRIPTION
## Proposed changes
This PR changes the `deploy-firestore-config` action to only checkout the repository if a `commit-sha` input was provided. This input is required to support the `roar-clinic` repository, but not needed when the action is called within a dashboard deployment workflow. 

## Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (non-breaking change that does not add functionality but makes code cleaner or more efficient)
- [ ] Documentation Update
- [ ] Tests (new or updated tests)
- [ ] Style (changes to code styling)
- [ ] CI (continuous integration changes)
- [ ] Repository Maintenance
- [ ] Other (please describe below)


Resolves https://github.com/yeatmanlab/roar-project-management/issues/1185