### PR TITLE
Refactor administration orgs into subcollections

### DIFF
--- a/apps/dashboard/firebase/admin/firestore.rules
+++ b/apps/dashboard/firebase/admin/firestore.rules
@@ -99,8 +99,8 @@ service cloud.firestore {
       // If the authenticated user (requestor) is creating a new user (target), then
       // the requestor must satisfy one of the following conditions
       // - the requestor is a district admin for the districtId of the target. The schoolId and classId must be in that district. And families and groups must be empty.
-    // - the requestor is a school admin for the schoolId of the target. The districtId of the target must match that of the school. And the classId must be in the school.
-    // - the requestor is a class admin for the classId of the target. The districtId and schoolId of the target must match that of the class.
+      // - the requestor is a school admin for the schoolId of the target. The districtId of the target must match that of the school. And the classId must be in the school.
+      // - the requestor is a class admin for the classId of the target. The districtId and schoolId of the target must match that of the class.
       // - the requestor is a family admin and the target is in the same family. No educational orgs can be set
       // - the requestor is a group admin for the groupId of the target. No educational orgs can be set
 
@@ -246,7 +246,7 @@ service cloud.firestore {
       // the requestor must satisfy one of the following conditions
       // - the requestor is a district admin for the districtId of the target. They can only update common + educational keys. Any added schools and classes must be in the district.
       // - the requestor is a school admin for the schoolId of the target. They may not update district info. They can only update common + educational keys. Any added classes must be in the school.
-    // - the requestor is a class admin for the classId of the target. The districtId and schoolId of the target must match that of the class.
+      // - the requestor is a class admin for the classId of the target. The districtId and schoolId of the target must match that of the class.
       // - the requestor is a family admin for a current family of the target. No educational orgs can be set
       // - the requestor is a group admin for a current group of the target. No educational orgs can be set
 
@@ -368,7 +368,7 @@ service cloud.firestore {
         }
 
         function canUpdateAssignment() {
-          return (myData() || isAdminForAnyAssignedOrg() || isAdminForAnyReadOrg()) && lengthOfAssessmentsUnchanged() && keysNotUpdated(['assigningOrgs', 'readOrgs']);
+          return (myData() || isAdminForAnyAssigningOrg() || isAdminForAnyReadOrg()) && lengthOfAssessmentsUnchanged() && keysNotUpdated(['assigningOrgs', 'readOrgs']);
         }
 
         allow read: if canReadAssignment();
@@ -420,14 +420,36 @@ service cloud.firestore {
     // N.B. This assumes that the assigningOrgs are exhaustively listed. E.g., if district 1 assigns an administration,
     // then schools A and B, which are in district 1, are assumed to also be listed in assigningOrgs.
     match /administrations/{administrationId} {
+      // Helper function to check if administration uses new subcollection format
+      function isNewFormat() {
+        return resource.data.get('formatVersion', 1) == 2;
+      }
+
+      // Helper function to check if user is assigned to administration (hybrid approach)
       function userAssignedToAdministration() {
         let userData = get(/databases/$(database)/documents/users/$(roarUid())).data;
-        return userData.get(['districts', 'current'], []).hasAny(resource.data.districts)
-          || userData.get(['schools', 'current'], []).hasAny(resource.data.schools)
-          || userData.get(['classes', 'current'], []).hasAny(resource.data.classes)
-          || userData.get(['groups', 'current'], []).hasAny(resource.data.groups)
-          || userData.get(['families', 'current'], []).hasAny(resource.data.families);
+        
+        // Use ternary operator instead of if/else (Firestore rules requirement)
+        return isNewFormat() 
+          ? (
+              // For new format, just check if user has any current orgs
+              // The client will handle precise filtering using collection group queries
+              userData.get(['districts', 'current'], []).size() > 0
+              || userData.get(['schools', 'current'], []).size() > 0
+              || userData.get(['classes', 'current'], []).size() > 0
+              || userData.get(['groups', 'current'], []).size() > 0
+              || userData.get(['families', 'current'], []).size() > 0
+            )
+          : (
+              // For old format, check arrays in main document (exact matching)
+              userData.get(['districts', 'current'], []).hasAny(resource.data.districts)
+              || userData.get(['schools', 'current'], []).hasAny(resource.data.schools)
+              || userData.get(['classes', 'current'], []).hasAny(resource.data.classes)
+              || userData.get(['groups', 'current'], []).hasAny(resource.data.groups)
+              || userData.get(['families', 'current'], []).hasAny(resource.data.families)
+            );
       }
+
 
       function userCreatedExistingAdministration() {
         return roarUid() == resource.data.get('createdBy', 'nullId');
@@ -558,6 +580,48 @@ service cloud.firestore {
 
         allow read: if loggedIn() && canReadStats();
         allow write: if false;
+      }
+
+      // Rules for assignedOrgs subcollection
+      match /assignedOrgs/{orgId} {
+        function canReadAssignedOrg() {
+          let adminOrgs = get(/databases/$(database)/documents/userClaims/$(request.auth.uid)).data.get('claims', {}).get('adminOrgs', {});
+          let orgType = resource.data.get('orgType', '');
+          let orgIdFromDoc = resource.data.get('orgId', '');
+          
+          // Check if user is admin for this specific org
+          return adminOrgs.get(orgType, []).hasAny([orgIdFromDoc])
+            || getUserClaims().get('super_admin', false) == true;
+        }
+
+        function canWriteAssignedOrg() {
+          // Only allow writes from cloud functions (admin SDK) or super admins
+          return getUserClaims().get('super_admin', false) == true;
+        }
+
+        allow read: if loggedIn() && canReadAssignedOrg();
+        allow write: if canWriteAssignedOrg();
+      }
+
+      // Rules for readOrgs subcollection
+      match /readOrgs/{orgId} {
+        function canReadReadOrg() {
+          let adminOrgs = get(/databases/$(database)/documents/userClaims/$(request.auth.uid)).data.get('claims', {}).get('adminOrgs', {});
+          let orgType = resource.data.get('orgType', '');
+          let orgIdFromDoc = resource.data.get('orgId', '');
+          
+          // Check if user is admin for this specific org
+          return adminOrgs.get(orgType, []).hasAny([orgIdFromDoc])
+            || getUserClaims().get('super_admin', false) == true;
+        }
+
+        function canWriteReadOrg() {
+          // Only allow writes from cloud functions (admin SDK) or super admins
+          return getUserClaims().get('super_admin', false) == true;
+        }
+
+        allow read: if loggedIn() && canReadReadOrg();
+        allow write: if canWriteReadOrg();
       }
     }
 

--- a/apps/dashboard/src/helpers/query/administrations.js
+++ b/apps/dashboard/src/helpers/query/administrations.js
@@ -44,18 +44,128 @@ const processBatchStats = async (axiosInstance, statsPaths, batchSize = 5) => {
   return batchStatsDocs;
 };
 
+/**
+ * Get assigned orgs for administrations, handling both old and new formats
+ * @param {Array} administrationData - Array of administration documents
+ * @returns {Object} Object mapping administration IDs to their assigned orgs
+ */
+const getAdministrationOrgs = async (administrationData) => {
+  const axiosInstance = getAxiosInstance();
+  const documentPrefix = axiosInstance.defaults.baseURL.replace('https://firestore.googleapis.com/v1/', '');
+  const result = {};
+
+  // Separate old and new format administrations
+  const oldFormatAdmins = [];
+  const newFormatAdmins = [];
+
+  administrationData.forEach(({ data: admin }) => {
+    if (admin.formatVersion === 2) {
+      newFormatAdmins.push(admin);
+    } else {
+      // Old format or no formatVersion (defaults to old format)
+      oldFormatAdmins.push(admin);
+    }
+  });
+
+  // Handle old format administrations (read from arrays in main document)
+  oldFormatAdmins.forEach((admin) => {
+    result[admin.id] = {
+      districts: admin.districts || [],
+      schools: admin.schools || [],
+      classes: admin.classes || [],
+      groups: admin.groups || [],
+      families: admin.families || [],
+    };
+  });
+
+  // Handle new format administrations (read from subcollections)
+  if (newFormatAdmins.length > 0) {
+    const subcollectionOrgs = await getOrgsFromSubcollections(newFormatAdmins, axiosInstance, documentPrefix);
+    Object.assign(result, subcollectionOrgs);
+  }
+
+  return result;
+};
+
+/**
+ * Get orgs from subcollections for new format administrations
+ * @param {Array} administrations - Array of new format administration documents
+ * @param {Object} axiosInstance - Axios instance for API calls
+ * @param {string} documentPrefix - Document path prefix
+ * @returns {Object} Object mapping administration IDs to their assigned orgs
+ */
+const getOrgsFromSubcollections = async (administrations, axiosInstance, documentPrefix) => {
+  const result = {};
+
+  // Initialize empty org structures for all administrations
+  administrations.forEach((admin) => {
+    result[admin.id] = {
+      districts: [],
+      schools: [],
+      classes: [],
+      groups: [],
+      families: [],
+    };
+  });
+
+  // Batch query all assignedOrgs subcollections
+  const subcollectionPaths = administrations.map(
+    (admin) => `${documentPrefix}/administrations/${admin.id}/assignedOrgs`,
+  );
+
+  try {
+    // Query each subcollection
+    for (const subcollectionPath of subcollectionPaths) {
+      const adminId = subcollectionPath.split('/').slice(-2, -1)[0]; // Extract admin ID from path
+
+      const { data } = await axiosInstance.post(':runQuery', {
+        parent: subcollectionPath.replace('/assignedOrgs', ''),
+        structuredQuery: {
+          from: [{ collectionId: 'assignedOrgs' }],
+          select: {
+            fields: [{ fieldPath: 'orgType' }, { fieldPath: 'orgId' }],
+          },
+        },
+      });
+
+      // Process the results
+      if (data && Array.isArray(data)) {
+        data.forEach((item) => {
+          if (item.document && item.document.fields) {
+            const orgType = convertValues(item.document.fields.orgType);
+            const orgId = convertValues(item.document.fields.orgId);
+
+            if (orgType && orgId && result[adminId] && result[adminId][orgType]) {
+              result[adminId][orgType].push(orgId);
+            }
+          }
+        });
+      }
+    }
+  } catch (error) {
+    console.error('Error fetching subcollection orgs:', error);
+    // Return empty org structures on error
+  }
+
+  return result;
+};
+
 const mapAdministrations = async ({ isSuperAdmin, data, adminOrgs }) => {
+  // Get assigned orgs for all administrations (handling both old and new formats)
+  const administrationOrgs = await getAdministrationOrgs(data);
+
   // First format the administration documents
   const administrationData = data
     .map((a) => a.data)
     .map((a) => {
-      let assignedOrgs = {
-        districts: a.districts,
-        schools: a.schools,
-        classes: a.classes,
-        groups: a.groups,
-        families: a.families,
+      let assignedOrgs = administrationOrgs[a.id] || {
+        districts: [],
+        schools: [],
+        classes: [],
+        groups: [],
+        families: [],
       };
+
       if (!isSuperAdmin.value) {
         assignedOrgs = filterAdminOrgs(adminOrgs.value, assignedOrgs);
       }

--- a/apps/dashboard/src/helpers/query/administrations.test.js
+++ b/apps/dashboard/src/helpers/query/administrations.test.js
@@ -102,7 +102,7 @@ describe('query/administrations', () => {
   });
 
   describe('administrationPageFetcher', () => {
-    it('should fetch and process administration data', async () => {
+    it('should fetch and process old format administration data', async () => {
       mockPost.mockResolvedValueOnce({
         data: [
           {
@@ -198,6 +198,327 @@ describe('query/administrations', () => {
       expect(result[1].name).toBe('Admin 2');
       expect(result[1].publicName).toBeUndefined();
       expect(result[1].testData).toBe(true);
+    });
+
+    it('should fetch and process new format administration data with subcollections', async () => {
+      // Mock the main administration documents (new format)
+      mockPost.mockResolvedValueOnce({
+        data: [
+          {
+            found: {
+              name: 'projects/test/databases/test/documents/administrations/admin1',
+              fields: {
+                name: { stringValue: 'New Format Admin 1' },
+                publicName: { stringValue: 'Public New Admin 1' },
+                dateOpened: { timestampValue: '2023-01-01T00:00:00Z' },
+                dateClosed: { timestampValue: '2023-12-31T00:00:00Z' },
+                dateCreated: { timestampValue: '2022-12-01T00:00:00Z' },
+                assessments: { arrayValue: { values: [{ stringValue: 'assessment1' }] } },
+                formatVersion: { integerValue: '2' },
+                // Empty arrays for new format
+                districts: { arrayValue: { values: [] } },
+                schools: { arrayValue: { values: [] } },
+                classes: { arrayValue: { values: [] } },
+                groups: { arrayValue: { values: [] } },
+                families: { arrayValue: { values: [] } },
+                testData: { booleanValue: false },
+              },
+            },
+          },
+          {
+            found: {
+              name: 'projects/test/databases/test/documents/administrations/admin2',
+              fields: {
+                name: { stringValue: 'New Format Admin 2' },
+                dateOpened: { timestampValue: '2023-02-01T00:00:00Z' },
+                dateClosed: { timestampValue: '2023-11-30T00:00:00Z' },
+                dateCreated: { timestampValue: '2023-01-15T00:00:00Z' },
+                assessments: { arrayValue: { values: [{ stringValue: 'assessment2' }] } },
+                formatVersion: { integerValue: '2' },
+                // Empty arrays for new format
+                districts: { arrayValue: { values: [] } },
+                schools: { arrayValue: { values: [] } },
+                classes: { arrayValue: { values: [] } },
+                groups: { arrayValue: { values: [] } },
+                families: { arrayValue: { values: [] } },
+                testData: { booleanValue: true },
+              },
+            },
+          },
+        ],
+      });
+
+      // Mock subcollection queries for assignedOrgs
+      mockPost
+        .mockResolvedValueOnce({
+          // admin1 assignedOrgs subcollection
+          data: [
+            {
+              document: {
+                name: 'projects/test/databases/test/documents/administrations/admin1/assignedOrgs/district1',
+                fields: {
+                  orgType: { stringValue: 'districts' },
+                  orgId: { stringValue: 'district1' },
+                },
+              },
+            },
+            {
+              document: {
+                name: 'projects/test/databases/test/documents/administrations/admin1/assignedOrgs/school1',
+                fields: {
+                  orgType: { stringValue: 'schools' },
+                  orgId: { stringValue: 'school1' },
+                },
+              },
+            },
+          ],
+        })
+        .mockResolvedValueOnce({
+          // admin2 assignedOrgs subcollection
+          data: [
+            {
+              document: {
+                name: 'projects/test/databases/test/documents/administrations/admin2/assignedOrgs/district2',
+                fields: {
+                  orgType: { stringValue: 'districts' },
+                  orgId: { stringValue: 'district2' },
+                },
+              },
+            },
+            {
+              document: {
+                name: 'projects/test/databases/test/documents/administrations/admin2/assignedOrgs/class2',
+                fields: {
+                  orgType: { stringValue: 'classes' },
+                  orgId: { stringValue: 'class2' },
+                },
+              },
+            },
+          ],
+        });
+
+      // Mock stats queries
+      mockPost.mockResolvedValueOnce({
+        data: [
+          {
+            found: {
+              name: 'projects/test/databases/test/documents/administrations/admin1/stats/total',
+              fields: {
+                completed: { integerValue: '15' },
+                started: { integerValue: '25' },
+                assigned: { integerValue: '35' },
+              },
+            },
+          },
+          {
+            found: {
+              name: 'projects/test/databases/test/documents/administrations/admin2/stats/total',
+              fields: {
+                completed: { integerValue: '8' },
+                started: { integerValue: '18' },
+                assigned: { integerValue: '28' },
+              },
+            },
+          },
+        ],
+      });
+
+      const result = await administrationPageFetcher(
+        { value: true }, // isSuperAdmin
+        { value: {} }, // exhaustiveAdminOrgs
+        false, // fetchTestData
+        { value: [{ field: { fieldPath: 'name' }, direction: 'ASCENDING' }] }, // orderBy
+      );
+
+      expect(getAxiosInstance).toHaveBeenCalled();
+      expect(mockPost).toHaveBeenCalledTimes(4); // 1 for main docs + 2 for subcollections + 1 for stats
+      expect(result).toHaveLength(2);
+
+      // Verify first administration
+      expect(result[0].id).toBe('admin1');
+      expect(result[0].name).toBe('New Format Admin 1');
+      expect(result[0].publicName).toBe('Public New Admin 1');
+      expect(result[0].assignedOrgs.districts).toEqual(['district1']);
+      expect(result[0].assignedOrgs.schools).toEqual(['school1']);
+      expect(result[0].assignedOrgs.classes).toEqual([]);
+      expect(result[0].assignedOrgs.groups).toEqual([]);
+      expect(result[0].assignedOrgs.families).toEqual([]);
+      expect(result[0].stats.total.completed).toBe(15);
+
+      // Verify second administration
+      expect(result[1].id).toBe('admin2');
+      expect(result[1].name).toBe('New Format Admin 2');
+      expect(result[1].assignedOrgs.districts).toEqual(['district2']);
+      expect(result[1].assignedOrgs.schools).toEqual([]);
+      expect(result[1].assignedOrgs.classes).toEqual(['class2']);
+      expect(result[1].testData).toBe(true);
+    });
+
+    it('should handle mixed old and new format administrations', async () => {
+      // Mock mixed format administration documents
+      mockPost.mockResolvedValueOnce({
+        data: [
+          {
+            found: {
+              name: 'projects/test/databases/test/documents/administrations/oldAdmin',
+              fields: {
+                name: { stringValue: 'Old Format Admin' },
+                dateOpened: { timestampValue: '2023-01-01T00:00:00Z' },
+                dateClosed: { timestampValue: '2023-12-31T00:00:00Z' },
+                dateCreated: { timestampValue: '2022-12-01T00:00:00Z' },
+                assessments: { arrayValue: { values: [{ stringValue: 'assessment1' }] } },
+                // No formatVersion (defaults to old format)
+                districts: { arrayValue: { values: [{ stringValue: 'oldDistrict' }] } },
+                schools: { arrayValue: { values: [{ stringValue: 'oldSchool' }] } },
+                classes: { arrayValue: { values: [] } },
+                groups: { arrayValue: { values: [] } },
+                families: { arrayValue: { values: [] } },
+                testData: { booleanValue: false },
+              },
+            },
+          },
+          {
+            found: {
+              name: 'projects/test/databases/test/documents/administrations/newAdmin',
+              fields: {
+                name: { stringValue: 'New Format Admin' },
+                dateOpened: { timestampValue: '2023-02-01T00:00:00Z' },
+                dateClosed: { timestampValue: '2023-11-30T00:00:00Z' },
+                dateCreated: { timestampValue: '2023-01-15T00:00:00Z' },
+                assessments: { arrayValue: { values: [{ stringValue: 'assessment2' }] } },
+                formatVersion: { integerValue: '2' },
+                // Empty arrays for new format
+                districts: { arrayValue: { values: [] } },
+                schools: { arrayValue: { values: [] } },
+                classes: { arrayValue: { values: [] } },
+                groups: { arrayValue: { values: [] } },
+                families: { arrayValue: { values: [] } },
+                testData: { booleanValue: false },
+              },
+            },
+          },
+        ],
+      });
+
+      // Mock subcollection query for new format admin only
+      mockPost.mockResolvedValueOnce({
+        data: [
+          {
+            document: {
+              name: 'projects/test/databases/test/documents/administrations/newAdmin/assignedOrgs/newDistrict',
+              fields: {
+                orgType: { stringValue: 'districts' },
+                orgId: { stringValue: 'newDistrict' },
+              },
+            },
+          },
+          {
+            document: {
+              name: 'projects/test/databases/test/documents/administrations/newAdmin/assignedOrgs/newClass',
+              fields: {
+                orgType: { stringValue: 'classes' },
+                orgId: { stringValue: 'newClass' },
+              },
+            },
+          },
+        ],
+      });
+
+      // Mock stats queries
+      mockPost.mockResolvedValueOnce({
+        data: [
+          {
+            found: {
+              name: 'projects/test/databases/test/documents/administrations/oldAdmin/stats/total',
+              fields: { completed: { integerValue: '5' } },
+            },
+          },
+          {
+            found: {
+              name: 'projects/test/databases/test/documents/administrations/newAdmin/stats/total',
+              fields: { completed: { integerValue: '10' } },
+            },
+          },
+        ],
+      });
+
+      const result = await administrationPageFetcher(
+        { value: true }, // isSuperAdmin
+        { value: {} }, // exhaustiveAdminOrgs
+        false, // fetchTestData
+        { value: [{ field: { fieldPath: 'name' }, direction: 'ASCENDING' }] }, // orderBy
+      );
+
+      expect(result).toHaveLength(2);
+
+      // Verify old format admin uses arrays from main document
+      const oldAdmin = result.find((admin) => admin.id === 'oldAdmin');
+      expect(oldAdmin.assignedOrgs.districts).toEqual(['oldDistrict']);
+      expect(oldAdmin.assignedOrgs.schools).toEqual(['oldSchool']);
+
+      // Verify new format admin uses subcollection data
+      const newAdmin = result.find((admin) => admin.id === 'newAdmin');
+      expect(newAdmin.assignedOrgs.districts).toEqual(['newDistrict']);
+      expect(newAdmin.assignedOrgs.schools).toEqual([]);
+      expect(newAdmin.assignedOrgs.classes).toEqual(['newClass']);
+    });
+
+    it('should handle subcollection query errors gracefully', async () => {
+      // Mock administration document (new format)
+      mockPost.mockResolvedValueOnce({
+        data: [
+          {
+            found: {
+              name: 'projects/test/databases/test/documents/administrations/admin1',
+              fields: {
+                name: { stringValue: 'Admin with Error' },
+                dateOpened: { timestampValue: '2023-01-01T00:00:00Z' },
+                dateClosed: { timestampValue: '2023-12-31T00:00:00Z' },
+                dateCreated: { timestampValue: '2022-12-01T00:00:00Z' },
+                assessments: { arrayValue: { values: [] } },
+                formatVersion: { integerValue: '2' },
+                districts: { arrayValue: { values: [] } },
+                schools: { arrayValue: { values: [] } },
+                classes: { arrayValue: { values: [] } },
+                groups: { arrayValue: { values: [] } },
+                families: { arrayValue: { values: [] } },
+              },
+            },
+          },
+        ],
+      });
+
+      // Mock subcollection query error
+      mockPost.mockRejectedValueOnce(new Error('Subcollection query failed'));
+
+      // Mock stats query
+      mockPost.mockResolvedValueOnce({
+        data: [
+          {
+            found: {
+              name: 'projects/test/databases/test/documents/administrations/admin1/stats/total',
+              fields: { completed: { integerValue: '0' } },
+            },
+          },
+        ],
+      });
+
+      const result = await administrationPageFetcher(
+        { value: true }, // isSuperAdmin
+        { value: {} }, // exhaustiveAdminOrgs
+        false, // fetchTestData
+        { value: [{ field: { fieldPath: 'name' }, direction: 'ASCENDING' }] }, // orderBy
+      );
+
+      expect(result).toHaveLength(1);
+      expect(result[0].id).toBe('admin1');
+      expect(result[0].name).toBe('Admin with Error');
+      // Should fallback to empty org arrays on error
+      expect(result[0].assignedOrgs.districts).toEqual([]);
+      expect(result[0].assignedOrgs.schools).toEqual([]);
+      expect(result[0].assignedOrgs.classes).toEqual([]);
+      expect(result[0].assignedOrgs.groups).toEqual([]);
+      expect(result[0].assignedOrgs.families).toEqual([]);
     });
 
     it('should filter and sort administrations correctly', async () => {


### PR DESCRIPTION
## Proposed changes

### Motivation

We need to migrate from storing organization IDs in arrays within administration documents to using subcollections due to Firestore document size limits. As administrations grow to include thousands of organizations (and potentially tens of thousands of classes), we hit the 1MB document size limit, causing failures in administration creation and updates. Unfortunately, this can't wait until after the backend refactor.

### New Architecture:

Administration docs will come in two formats:

- Format v1 (Legacy): Org IDs stored in districts, schools, classes, groups, families arrays within the administration document
- Format v2 (New): Org IDs stored in minimalOrgs field (source of truth) with computed subcollections:
  - `/administrations/{id}/assignedOrgs/{orgId}` - Organizations assigned to this administration
  - `/administrations/{id}/readOrgs/{orgId}` - Organizations with read access to this administration
This migration enables unlimited organization scaling while maintaining backward compatibility during the transition period.

### Companion PRs

- Firekit:
- Firebase Functions: 

### Changes in roar-dashboard

This PR updates the dashboard's administration querying system to seamlessly work with both format versions:

- Hybrid Administration Queries
  - `getAdministrationOrgs()` detects format version and uses appropriate data source
  - Added `getOrgsFromSubcollections()` function for efficient batch querying of v2 administrations
  - Implemented format detection logic to separate old and new format administrations
- Performance Optimizations
  - Added field selection to subcollection queries (`orgType`, `orgId` only)
  - Batch processing of multiple administration subcollections
- Backward Compatibility
  - Maintained existing behavior for v1 administrations (read from arrays)
- Firestore Rules Updates: updated Firestore security rules to support subcollection access patterns
- Test coverage for hybrid administration queries

## Types of changes

What types of changes does this pull request introduce?

<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactoring (non-breaking change that does not add functionality but makes code cleaner or more efficient)
- [ ] Documentation Update
- [ ] Tests (new or updated tests)
- [ ] Style (changes to code styling)
- [ ] CI (continuous integration changes)
- [ ] Repository Maintenance
- [ ] Other (please describe below)

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask.  We're here
to help! This is simply a reminder of what we are going to look for before
merging your code.
-->

- [x] I have read the [guidelines for contributing](https://github.com/yeatmanlab/roar-dashboard/blob/main/.github/CONTRIBUTING.md).
- [x] The changes in this PR are as small as they can be. They represent one and only one fix or enhancement.
- [x] Linting checks pass with my changes.
- [x] Any existing unit tests pass with my changes.
- [x] Any existing end-to-end tests pass with my changes.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] If this PR fixes an existing issue, I have added a unit or end-to-end test that will detect if this issue reoccurs.
- [x] I have added JSDoc comments as appropriate.
- [x] I have added the necessary documentation to the [roar-docs repository](https://github.com/yeatmanlab/roar-docs).
- [x] I have shared this PR on the roar-pr-reviews channel (if I have access)
- [x] I have linked relevant issues (if any)