### PR TITLE
Fix individual score report texts for updated norms 

### DIFF
--- a/apps/dashboard/src/containers/StudentScoreReport/components/ScoreList/useScoreListData.js
+++ b/apps/dashboard/src/containers/StudentScoreReport/components/ScoreList/useScoreListData.js
@@ -88,7 +88,7 @@ export function useScoreListData(params) {
   });
 
   const getTaskDescription = computed(() => {
-    return (task) => ScoreReportService.getScoreDescription(task, gradeLevel, { t });
+    return (task) => ScoreReportService.getScoreDescription(task, gradeLevel, { t }, taskScoringVersions[task.taskId]);
   });
 
   const getTaskScoresArray = computed(() => {

--- a/apps/dashboard/src/containers/StudentScoreReport/components/ScoreList/useScoreListData.test.js
+++ b/apps/dashboard/src/containers/StudentScoreReport/components/ScoreList/useScoreListData.test.js
@@ -560,13 +560,18 @@ describe('useScoreListData', () => {
         taskData,
         longitudinalData: null,
         t: mockT,
-        taskScoringVersions: {},
+        taskScoringVersions: { task1: 1 },
       };
 
       const { computedTaskData, getTaskDescription } = useScoreListData(params);
 
       const result = getTaskDescription.value(computedTaskData.value[0]);
-      expect(ScoreReportService.getScoreDescription).toHaveBeenCalledWith(computedTaskData.value[0], 5, { t: mockT });
+      expect(ScoreReportService.getScoreDescription).toHaveBeenCalledWith(
+        computedTaskData.value[0],
+        5,
+        { t: mockT },
+        1,
+      );
       expect(result).toEqual({ keypath: 'test.description' });
     });
   });

--- a/apps/dashboard/src/services/ScoreReport.service.js
+++ b/apps/dashboard/src/services/ScoreReport.service.js
@@ -60,8 +60,8 @@ const ScoreReportService = (() => {
     return `${percentile}${getPercentileSuffix(percentile, i18n)}`;
   };
 
-  const getSupportLevelLanguage = (grade, percentile, rawScore, taskId, i18n) => {
-    const { support_level: supportLevel } = getSupportLevel(grade, percentile, rawScore, taskId);
+  const getSupportLevelLanguage = (grade, percentile, rawScore, taskId, i18n, scoringVersion) => {
+    const { support_level: supportLevel } = getSupportLevel(grade, percentile, rawScore, taskId, null, scoringVersion);
 
     switch (supportLevel) {
       case SCORE_SUPPORT_SKILL_LEVELS.ACHIEVED_SKILL:
@@ -161,8 +161,9 @@ const ScoreReportService = (() => {
     return `{value}${getPercentileSuffix(percentile, i18n)}`;
   };
 
-  const getScoreDescription = (task, grade, i18n) => {
+  const getScoreDescription = (task, grade, i18n, scoringVersion) => {
     const taskName = taskDisplayNames[task.taskId]?.extendedName;
+
     // --- CHANGED: use safe wrapper instead of direct call ---
     const taskDescription = safeGetExtendedDescription(String(task.taskId));
 
@@ -177,6 +178,7 @@ const ScoreReportService = (() => {
             task?.rawScore.value,
             task.taskId,
             i18n,
+            scoringVersion,
           ),
           taskName,
           taskDescription,
@@ -206,6 +208,7 @@ const ScoreReportService = (() => {
             task?.rawScore.value,
             task.taskId,
             i18n,
+            scoringVersion,
           ),
           taskName,
           taskDescription,
@@ -225,6 +228,7 @@ const ScoreReportService = (() => {
           task.rawScore.value,
           task.taskId,
           i18n,
+          scoringVersion,
         ),
         taskName,
         taskDescription,
@@ -253,7 +257,7 @@ const ScoreReportService = (() => {
     return grade >= 6 ? SCORE_TYPES.STANDARD_SCORE : SCORE_TYPES.PERCENTILE_SCORE;
   };
 
-  const processTaskScores = (taskData, grade, i18n, taskScoringVersions = {}) => {
+  const processTaskScores = (taskData, grade, i18n, scoringVersions = {}) => {
     const tasksBlacklist = ['vocab', 'cva'];
     const computedTaskAcc = {};
 
@@ -262,7 +266,7 @@ const ScoreReportService = (() => {
 
       let rawScore = null;
 
-      const useSpanishNorms = (taskId === 'swr-es' || taskId === 'sre-es') && taskScoringVersions[taskId] >= 1;
+      const useSpanishNorms = (taskId === 'swr-es' || taskId === 'sre-es') && scoringVersions[taskId] >= 1;
       if (!taskId.includes('vocab') && (!taskId.includes('es') || useSpanishNorms)) {
         rawScore = getScoreValue(compositeScores, taskId, grade, 'rawScore');
       } else {
@@ -273,14 +277,7 @@ const ScoreReportService = (() => {
         const percentileScore = getScoreValue(compositeScores, taskId, grade, 'percentile');
         const standardScore = getScoreValue(compositeScores, taskId, grade, SCORE_TYPES.STANDARD_SCORE);
         const rawScoreRange = getRawScoreRange(taskId);
-        const supportColor = getDialColor(
-          grade,
-          percentileScore,
-          rawScore,
-          taskId,
-          optional,
-          taskScoringVersions[taskId],
-        );
+        const supportColor = getDialColor(grade, percentileScore, rawScore, taskId, optional, scoringVersions[taskId]);
 
         const scoresForTask = {
           standardScore: {

--- a/apps/dashboard/src/services/ScoreReport.service.test.js
+++ b/apps/dashboard/src/services/ScoreReport.service.test.js
@@ -150,6 +150,35 @@ describe('ScoreReportService', () => {
       expect(result.slots.taskDescription).toBe('Description for task two');
       expect(result.slots.supportCategory).toBe('scoreReports.developingText');
     });
+
+    it('should pass scoringVersion to getSupportLevel for percentile description', () => {
+      getSupportLevel.mockImplementation((grade, percentile, rawScore, taskId, optional, scoringVersion) => {
+        if (scoringVersion === 4) {
+          return {
+            support_level: SCORE_SUPPORT_SKILL_LEVELS.ACHIEVED_SKILL,
+            tag_color: 'green',
+          };
+        }
+        return {
+          support_level: SCORE_SUPPORT_SKILL_LEVELS.DEVELOPING_SKILL,
+          tag_color: 'orange',
+        };
+      });
+
+      const task = {
+        taskId: 'sre',
+        rawScore: { value: 56 },
+        percentileScore: { value: 70 },
+        standardScore: { value: 104 },
+      };
+
+      const result = ScoreReportService.getScoreDescription(task, 8, mockI18n, 4);
+
+      expect(result.keypath).toBe('scoreReports.standardTaskDescription');
+      expect(result.slots.supportCategory).toBe('scoreReports.achievedText');
+
+      expect(getSupportLevel).toHaveBeenCalledWith(8, 70, 56, 'sre', null, 4);
+    });
   });
 
   describe('getScoresArrayForTask', () => {


### PR DESCRIPTION
## Proposed changes

<!--
Describe your changes here. Why are they necessary?

If it fixes a bug or resolves a feature request, be sure to link to that issue.

If appropriate, include images of the expected behavior or user experience.
You can drag and drop images into this text box.
-->
This PR fixes a bug where the card language did not align with the students' results, mainly affecting those who scored on the cusps of the cutoffs. The issue was due to forgetting to pass `scoringVersion` to `getSupportLevelLanguage`, which returns text based on `getSupportLevel`.

The issue can be seen in a screenshot from an older individual score reports PR: https://github.com/yeatmanlab/roar-dashboard/pull/1404. In the picture, Student 33a's card shows that they achieved the skill of sre with the green dial, yet the description still says "... which indicates they are developing the skill of Sentence Reading Efficiency". 


#### Old screenshot from PR 1404
<img width="2210" height="1582" alt="image" src="https://github.com/user-attachments/assets/22bd52b1-0453-49c4-b0a8-a1ad769474e3" />

#### Updated text 
<img width="758" height="782" alt="Screenshot 2025-11-24 at 4 25 59 PM" src="https://github.com/user-attachments/assets/7b6b6256-5f65-49ef-9a48-eac87ea57e6b" />




## Types of changes

What types of changes does this pull request introduce?

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (non-breaking change that does not add functionality but makes code cleaner or more efficient)
- [ ] Documentation Update
- [ ] Tests (new or updated tests)
- [ ] Style (changes to code styling)
- [ ] CI (continuous integration changes)
- [ ] Repository Maintenance
- [ ] Other (please describe below)

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask.  We're here
to help! This is simply a reminder of what we are going to look for before
merging your code.
-->

- [x] I have read the [guidelines for contributing](https://github.com/yeatmanlab/roar-dashboard/blob/main/.github/CONTRIBUTING.md).
- [x] The changes in this PR are as small as they can be. They represent one and only one fix or enhancement.
- [x] Linting checks pass with my changes.
- [x] Any existing unit tests pass with my changes.
- [x] Any existing end-to-end tests pass with my changes.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] If this PR fixes an existing issue, I have added a unit or end-to-end test that will detect if this issue reoccurs.
- [ ] I have added JSDoc comments as appropriate.
- [ ] I have added the necessary documentation to the [roar-docs repository](https://github.com/yeatmanlab/roar-docs).
- [x] I have shared this PR on the roar-pr-reviews channel (if I have access)
- [ ] I have linked relevant issues (if any)

## Justification of missing checklist items

<!--
If you feel that a checklist item above is not applicable to this PR, please
provide your justification here. Otherwise, delete this section.
-->

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
