### PR TITLE
Fix assessment E2E current version check

### DIFF
--- a/apps/dashboard/cypress/support/utils.js
+++ b/apps/dashboard/cypress/support/utils.js
@@ -35,9 +35,13 @@ export const isCurrentVersion = async (app) => {
     const mainAppVersion = mainDependencies[app];
     const currentAppVersion = featureDependencies[app];
 
+    console.log(`${app} currently on v${currentAppVersion}, main branch on v${mainAppVersion}`);
+
     return mainAppVersion === currentAppVersion;
   } catch (error) {
+    // On error (e.g., GitHub API rate limit), assume version hasn't changed = skip test
+    // This prevents tests from running unnecessarily when we can't verify the version
     console.error(`Failed to check if ${app} is the current version: ${error}`);
-    return false;
+    return true;
   }
 };


### PR DESCRIPTION
## Proposed changes
This PR changes `isCurrentVersion()` error handling to return `true` (skip test) instead of `false` (run test) when the GitHub API call fails. Previously, when hitting GitHub's rate limit, all assessment tests would run unnecessarily. Now they safely skip.


## Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (non-breaking change that does not add functionality but makes code cleaner or more efficient)
- [ ] Documentation Update
- [ ] Tests (new or updated tests)
- [ ] Style (changes to code styling)
- [ ] CI (continuous integration changes)
- [ ] Repository Maintenance
- [ ] Other (please describe below)

Resolves https://github.com/yeatmanlab/roar-project-management/issues/1434