### PR TITLE
Migrate class service authorization from SQL access controls to OpenFGA

### DIFF
--- a/apps/backend/src/routes/classes.integration.test.ts
+++ b/apps/backend/src/routes/classes.integration.test.ts
@@ -4,7 +4,7 @@
  * Tests the full HTTP lifecycle: middleware → controller → service → repository → DB.
  * Only Firebase token verification is mocked — everything else runs for real.
  *
- * Authorization is tested by permission tier (matching RolePermissions groupings):
+ * Authorization is tested by permission tier (resolved via OpenFGA):
  *   - superAdmin:  isSuperAdmin=true (bypasses all access control)
  *   - siteAdmin:   site_administrator
  *   - admin:       administrator
@@ -44,6 +44,10 @@ beforeAll(async () => {
   app = createTestApp(registerClassesRoutes);
   expectRoute = createRouteHelper(app);
   tiers = await createTierUsers(baseFixture.district.id);
+
+  // Re-sync FGA tuples to pick up tier users created above
+  const { syncFgaTuplesFromPostgres } = await import('../test-support/fga');
+  await syncFgaTuplesFromPostgres();
 });
 
 // ═══════════════════════════════════════════════════════════════════════════

--- a/apps/backend/src/services/class/class.service.test.ts
+++ b/apps/backend/src/services/class/class.service.test.ts
@@ -10,6 +10,7 @@ import { EnrolledUserFactory } from '../../test-support/factories/user.factory';
 import { createMockClassRepository } from '../../test-support/repositories';
 import type { MockClassRepository } from '../../test-support/repositories';
 import { createMockAuthorizationService } from '../../test-support/services';
+import { FgaType, FgaRelation } from '../authorization/fga-constants';
 import type { MockAuthorizationService } from '../../test-support/services';
 
 describe('ClassService', () => {
@@ -102,8 +103,8 @@ describe('ClassService', () => {
       expect(mockClassRepository.getById).toHaveBeenCalledWith({ id: 'class-123' });
       expect(mockAuthorizationService.requirePermission).toHaveBeenCalledWith(
         'user-123',
-        'can_list_users',
-        'class:class-123',
+        FgaRelation.CAN_LIST_USERS,
+        `${FgaType.CLASS}:class-123`,
       );
       expect(mockClassRepository.getUsersByClassId).toHaveBeenCalledWith('class-123', {
         page: 1,
@@ -139,7 +140,7 @@ describe('ClassService', () => {
       });
 
       await expect(
-        service.listUsers({ userId: 'admin-123', isSuperAdmin: true }, 'non-existent-id', defaultOptions),
+        service.listUsers({ userId: 'admin-123', isSuperAdmin: false }, 'non-existent-id', defaultOptions),
       ).rejects.toMatchObject({
         message: ApiErrorMessage.NOT_FOUND,
         statusCode: StatusCodes.NOT_FOUND,

--- a/apps/backend/src/services/class/class.service.test.ts
+++ b/apps/backend/src/services/class/class.service.test.ts
@@ -2,19 +2,24 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { StatusCodes } from 'http-status-codes';
 import { SortOrder } from '@roar-dashboard/api-contract';
 import { ClassService } from './class.service';
+import { ApiError } from '../../errors/api-error';
 import { ApiErrorCode } from '../../enums/api-error-code.enum';
 import { ApiErrorMessage } from '../../enums/api-error-message.enum';
-import { UserRole } from '../../enums/user-role.enum';
 import { ClassFactory } from '../../test-support/factories/class.factory';
 import { EnrolledUserFactory } from '../../test-support/factories/user.factory';
 import { createMockClassRepository } from '../../test-support/repositories';
+import type { MockClassRepository } from '../../test-support/repositories';
+import { createMockAuthorizationService } from '../../test-support/services';
+import type { MockAuthorizationService } from '../../test-support/services';
 
 describe('ClassService', () => {
-  let mockClassRepository: ReturnType<typeof createMockClassRepository>;
+  let mockClassRepository: MockClassRepository;
+  let mockAuthorizationService: MockAuthorizationService;
 
   beforeEach(() => {
     vi.resetAllMocks();
     mockClassRepository = createMockClassRepository();
+    mockAuthorizationService = createMockAuthorizationService();
   });
 
   describe('listUsers', () => {
@@ -36,11 +41,13 @@ describe('ClassService', () => {
 
       const service = ClassService({
         classRepository: mockClassRepository,
+        authorizationService: mockAuthorizationService,
       });
 
       const result = await service.listUsers({ userId: 'admin-123', isSuperAdmin: true }, 'class-123', defaultOptions);
 
       expect(mockClassRepository.getById).toHaveBeenCalledWith({ id: 'class-123' });
+      expect(mockAuthorizationService.requirePermission).not.toHaveBeenCalled();
       expect(mockClassRepository.getUsersByClassId).toHaveBeenCalledWith('class-123', {
         page: 1,
         perPage: 25,
@@ -61,6 +68,7 @@ describe('ClassService', () => {
 
       const service = ClassService({
         classRepository: mockClassRepository,
+        authorizationService: mockAuthorizationService,
       });
 
       const result = await service.listUsers({ userId: 'admin-123', isSuperAdmin: true }, 'class-123', defaultOptions);
@@ -75,105 +83,35 @@ describe('ClassService', () => {
       expect(result.totalItems).toBe(3);
     });
 
-    it('should check authorization for non-super admin users with supervisory role', async () => {
+    it('should check FGA can_list_users for non-super admin users', async () => {
       const mockClass = ClassFactory.build({ id: 'class-123' });
       const mockUsers = EnrolledUserFactory.buildList(2);
       mockClassRepository.getById.mockResolvedValue(mockClass);
-      mockClassRepository.getAuthorizedById.mockResolvedValue(mockClass);
-      mockClassRepository.getUserRolesForClass.mockResolvedValue([UserRole.TEACHER]);
-      mockClassRepository.getAuthorizedUsersByClassId.mockResolvedValue({
+      mockClassRepository.getUsersByClassId.mockResolvedValue({
         items: mockUsers,
         totalItems: 2,
       });
 
       const service = ClassService({
         classRepository: mockClassRepository,
+        authorizationService: mockAuthorizationService,
       });
 
       const result = await service.listUsers({ userId: 'user-123', isSuperAdmin: false }, 'class-123', defaultOptions);
 
       expect(mockClassRepository.getById).toHaveBeenCalledWith({ id: 'class-123' });
-      expect(mockClassRepository.getAuthorizedById).toHaveBeenCalled();
-      expect(mockClassRepository.getUserRolesForClass).toHaveBeenCalledWith('user-123', 'class-123');
+      expect(mockAuthorizationService.requirePermission).toHaveBeenCalledWith(
+        'user-123',
+        'can_list_users',
+        'class:class-123',
+      );
+      expect(mockClassRepository.getUsersByClassId).toHaveBeenCalledWith('class-123', {
+        page: 1,
+        perPage: 25,
+        orderBy: { field: 'nameLast', direction: SortOrder.ASC },
+      });
       expect(result.items).toHaveLength(2);
       expect(result.totalItems).toBe(2);
-    });
-
-    it('should allow administrator role to list users', async () => {
-      const mockClass = ClassFactory.build({ id: 'class-123' });
-      const mockUsers = EnrolledUserFactory.buildList(5);
-      mockClassRepository.getById.mockResolvedValue(mockClass);
-      mockClassRepository.getAuthorizedById.mockResolvedValue(mockClass);
-      mockClassRepository.getUserRolesForClass.mockResolvedValue([UserRole.ADMINISTRATOR]);
-      mockClassRepository.getAuthorizedUsersByClassId.mockResolvedValue({
-        items: mockUsers,
-        totalItems: 5,
-      });
-
-      const service = ClassService({
-        classRepository: mockClassRepository,
-      });
-
-      const result = await service.listUsers(
-        { userId: 'admin-user-123', isSuperAdmin: false },
-        'class-123',
-        defaultOptions,
-      );
-
-      expect(result.items).toHaveLength(5);
-    });
-
-    it('should allow site_administrator role to list users', async () => {
-      const mockClass = ClassFactory.build({ id: 'class-123' });
-      const mockUsers = EnrolledUserFactory.buildList(4);
-      mockClassRepository.getById.mockResolvedValue(mockClass);
-      mockClassRepository.getAuthorizedById.mockResolvedValue(mockClass);
-      mockClassRepository.getUserRolesForClass.mockResolvedValue([UserRole.SITE_ADMINISTRATOR]);
-      mockClassRepository.getAuthorizedUsersByClassId.mockResolvedValue({
-        items: mockUsers,
-        totalItems: 4,
-      });
-
-      const service = ClassService({
-        classRepository: mockClassRepository,
-      });
-
-      const result = await service.listUsers(
-        { userId: 'site-admin-123', isSuperAdmin: false },
-        'class-123',
-        defaultOptions,
-      );
-
-      expect(result.items).toHaveLength(4);
-    });
-
-    it('should allow user with teacher role for class but admin role for school to list users', async () => {
-      const mockClass = ClassFactory.build({ id: 'class-123' });
-      const mockUsers = EnrolledUserFactory.buildList(3);
-      mockClassRepository.getById.mockResolvedValue(mockClass);
-      mockClassRepository.getAuthorizedById.mockResolvedValue(mockClass);
-      mockClassRepository.getUserRolesForClass.mockResolvedValue([UserRole.TEACHER, UserRole.ADMINISTRATOR]);
-      mockClassRepository.getAuthorizedUsersByClassId.mockResolvedValue({
-        items: mockUsers,
-        totalItems: 3,
-      });
-
-      const service = ClassService({
-        classRepository: mockClassRepository,
-      });
-
-      const result = await service.listUsers(
-        { userId: 'teacher-with-school-admin-123', isSuperAdmin: false },
-        'class-123',
-        defaultOptions,
-      );
-
-      expect(mockClassRepository.getUserRolesForClass).toHaveBeenCalledWith(
-        'teacher-with-school-admin-123',
-        'class-123',
-      );
-      expect(result.items).toHaveLength(3);
-      expect(result.totalItems).toBe(3);
     });
 
     it('should return empty results when class has no users', async () => {
@@ -183,6 +121,7 @@ describe('ClassService', () => {
 
       const service = ClassService({
         classRepository: mockClassRepository,
+        authorizationService: mockAuthorizationService,
       });
 
       const result = await service.listUsers({ userId: 'admin-123', isSuperAdmin: true }, 'class-123', defaultOptions);
@@ -196,6 +135,7 @@ describe('ClassService', () => {
 
       const service = ClassService({
         classRepository: mockClassRepository,
+        authorizationService: mockAuthorizationService,
       });
 
       await expect(
@@ -207,13 +147,19 @@ describe('ClassService', () => {
       });
     });
 
-    it('should throw forbidden error when non-super admin has no access to existing class', async () => {
+    it('should throw forbidden error when FGA denies can_list_users', async () => {
       const mockClass = ClassFactory.build({ id: 'class-123' });
       mockClassRepository.getById.mockResolvedValue(mockClass);
-      mockClassRepository.getAuthorizedById.mockResolvedValue(null);
+      mockAuthorizationService.requirePermission.mockRejectedValue(
+        new ApiError(ApiErrorMessage.FORBIDDEN, {
+          statusCode: StatusCodes.FORBIDDEN,
+          code: ApiErrorCode.AUTH_FORBIDDEN,
+        }),
+      );
 
       const service = ClassService({
         classRepository: mockClassRepository,
+        authorizationService: mockAuthorizationService,
       });
 
       await expect(
@@ -222,67 +168,6 @@ describe('ClassService', () => {
         message: ApiErrorMessage.FORBIDDEN,
         statusCode: StatusCodes.FORBIDDEN,
         code: ApiErrorCode.AUTH_FORBIDDEN,
-      });
-    });
-
-    it('should throw forbidden error when user has no supervisory role', async () => {
-      const mockClass = ClassFactory.build({ id: 'class-123' });
-      mockClassRepository.getById.mockResolvedValue(mockClass);
-      mockClassRepository.getAuthorizedById.mockResolvedValue(mockClass);
-      mockClassRepository.getUserRolesForClass.mockResolvedValue([UserRole.STUDENT]);
-
-      const service = ClassService({
-        classRepository: mockClassRepository,
-      });
-
-      await expect(
-        service.listUsers({ userId: 'user-123', isSuperAdmin: false }, 'class-123', defaultOptions),
-      ).rejects.toMatchObject({
-        message: ApiErrorMessage.FORBIDDEN,
-        statusCode: StatusCodes.FORBIDDEN,
-        code: ApiErrorCode.AUTH_FORBIDDEN,
-        context: { userId: 'user-123', classId: 'class-123', userRoles: [UserRole.STUDENT] },
-      });
-    });
-
-    it('should throw forbidden error for caregiver roles (guardian/parent/relative) - supervised not supervisory', async () => {
-      const mockClass = ClassFactory.build({ id: 'class-123' });
-      mockClassRepository.getById.mockResolvedValue(mockClass);
-      mockClassRepository.getAuthorizedById.mockResolvedValue(mockClass);
-      mockClassRepository.getUserRolesForClass.mockResolvedValue([UserRole.GUARDIAN]);
-
-      const service = ClassService({
-        classRepository: mockClassRepository,
-      });
-
-      await expect(
-        service.listUsers({ userId: 'caregiver-123', isSuperAdmin: false }, 'class-123', defaultOptions),
-      ).rejects.toMatchObject({
-        message: ApiErrorMessage.FORBIDDEN,
-        statusCode: StatusCodes.FORBIDDEN,
-        code: ApiErrorCode.AUTH_FORBIDDEN,
-        context: { userId: 'caregiver-123', classId: 'class-123', userRoles: [UserRole.GUARDIAN] },
-      });
-
-      // Also verify parent and relative roles are rejected
-      mockClassRepository.getUserRolesForClass.mockResolvedValue([UserRole.PARENT]);
-      await expect(
-        service.listUsers({ userId: 'parent-123', isSuperAdmin: false }, 'class-123', defaultOptions),
-      ).rejects.toMatchObject({
-        message: ApiErrorMessage.FORBIDDEN,
-        statusCode: StatusCodes.FORBIDDEN,
-        code: ApiErrorCode.AUTH_FORBIDDEN,
-        context: { userId: 'parent-123', classId: 'class-123', userRoles: [UserRole.PARENT] },
-      });
-
-      mockClassRepository.getUserRolesForClass.mockResolvedValue([UserRole.RELATIVE]);
-      await expect(
-        service.listUsers({ userId: 'relative-123', isSuperAdmin: false }, 'class-123', defaultOptions),
-      ).rejects.toMatchObject({
-        message: ApiErrorMessage.FORBIDDEN,
-        statusCode: StatusCodes.FORBIDDEN,
-        code: ApiErrorCode.AUTH_FORBIDDEN,
-        context: { userId: 'relative-123', classId: 'class-123', userRoles: [UserRole.RELATIVE] },
       });
     });
 
@@ -294,6 +179,7 @@ describe('ClassService', () => {
 
       const service = ClassService({
         classRepository: mockClassRepository,
+        authorizationService: mockAuthorizationService,
       });
 
       await expect(

--- a/apps/backend/src/services/class/class.service.ts
+++ b/apps/backend/src/services/class/class.service.ts
@@ -1,8 +1,5 @@
 import { StatusCodes } from 'http-status-codes';
 import type { PaginatedResult, EnrolledUsersQuery } from '@roar-dashboard/api-contract';
-import { Permissions } from '../../constants/permissions';
-import { rolesForPermission } from '../../constants/role-permissions';
-import type { Class } from '../../db/schema';
 import { ApiErrorCode } from '../../enums/api-error-code.enum';
 import { ApiErrorMessage } from '../../enums/api-error-message.enum';
 import { ApiError } from '../../errors/api-error';
@@ -10,31 +7,33 @@ import { logger } from '../../logger';
 import { ClassRepository } from '../../repositories/class.repository';
 import type { AuthContext } from '../../types/auth-context';
 import type { EnrolledUserEntity, ListEnrolledUsersOptions } from '../../types/user';
-import { hasSupervisoryRole } from '../../utils/has-supervisory-role.util';
+import { AuthorizationService } from '../authorization/authorization.service';
+import { FgaType, FgaRelation } from '../authorization/fga-constants';
 
 export function ClassService({
   classRepository = new ClassRepository(),
+  authorizationService = AuthorizationService(),
 }: {
   classRepository?: ClassRepository;
+  authorizationService?: ReturnType<typeof AuthorizationService>;
 } = {}) {
   /**
-   * Verify that a class exists and the user has access to it.
+   * Performs authorization checks for sub-resource listing.
+   * Verifies class exists and user has can_list_users permission via FGA.
    *
-   * Performs a two-step check:
-   * 1. Verify the class exists (returns 404 if not)
-   * 2. Verify the user has access (returns 403 if not, skipped for super admins)
+   * FGA's can_list_users on class requires supervisory_tier_group, which encodes
+   * both the access check and the supervisory role requirement in a single call.
    *
    * @param authContext - User's auth context (id and super admin flag)
    * @param classId - The class ID to verify access for
-   * @returns The class if found and accessible
    * @throws {ApiError} NOT_FOUND if class doesn't exist
-   * @throws {ApiError} FORBIDDEN if user lacks access
+   * @throws {ApiError} FORBIDDEN if user lacks can_list_users permission
    */
-  async function verifyClassAccess(authContext: AuthContext, classId: string): Promise<Class> {
+  async function authorizeSubResourceAccess(authContext: AuthContext, classId: string): Promise<void> {
     const { userId, isSuperAdmin } = authContext;
 
+    // Verify class exists (404 before 403)
     const classEntity = await classRepository.getById({ id: classId });
-
     if (!classEntity) {
       throw new ApiError(ApiErrorMessage.NOT_FOUND, {
         statusCode: StatusCodes.NOT_FOUND,
@@ -43,51 +42,10 @@ export function ClassService({
       });
     }
 
-    if (isSuperAdmin) {
-      return classEntity;
-    }
-
-    const allowedRoles = rolesForPermission(Permissions.Classes.READ);
-    const authorized = await classRepository.getAuthorizedById({ userId, allowedRoles }, classId);
-
-    if (!authorized) {
-      logger.warn({ userId, classId }, 'User attempted to access class resource without permission');
-      throw new ApiError(ApiErrorMessage.FORBIDDEN, {
-        statusCode: StatusCodes.FORBIDDEN,
-        code: ApiErrorCode.AUTH_FORBIDDEN,
-        context: { userId, classId },
-      });
-    }
-
-    return authorized;
-  }
-
-  /**
-   * Performs authorization checks for sub-resource listing (supervisory roles only).
-   * Throws if user lacks access or is a supervised user.
-   *
-   * @param authContext - User's auth context (id and super admin flag)
-   * @param classId - The class ID to verify access for
-   * @throws {ApiError} NOT_FOUND if class doesn't exist
-   * @throws {ApiError} FORBIDDEN if user lacks access or is a supervised user
-   */
-  async function authorizeSubResourceAccess(authContext: AuthContext, classId: string): Promise<void> {
-    const { userId, isSuperAdmin } = authContext;
-
-    await verifyClassAccess(authContext, classId);
-
     if (isSuperAdmin) return;
 
-    const userRoles = await classRepository.getUserRolesForClass(userId, classId);
-
-    if (!hasSupervisoryRole(userRoles)) {
-      logger.warn({ userId, classId, userRoles }, 'Supervised user attempted to list class sub-resources');
-      throw new ApiError(ApiErrorMessage.FORBIDDEN, {
-        statusCode: StatusCodes.FORBIDDEN,
-        code: ApiErrorCode.AUTH_FORBIDDEN,
-        context: { userId, classId, userRoles },
-      });
-    }
+    // FGA checks both access and supervisory role in one call
+    await authorizationService.requirePermission(userId, FgaRelation.CAN_LIST_USERS, `${FgaType.CLASS}:${classId}`);
   }
 
   /**
@@ -95,9 +53,8 @@ export function ClassService({
    *
    * Authorization behavior:
    * - Super admin: sees all users assigned to the class
-   * - Supervisory roles: sees only users if assigned to that class or if the class is in their accessible org tree
-   *   - Excludes caregiver role
-   * - Supervised roles (student/guardian/parent/relative): returns 403 Forbidden
+   * - Users with can_list_users on class (supervisory_tier_group): sees all users in the class
+   * - All other roles: returns 403 Forbidden
    *
    * @param authContext - User's auth context (id and type)
    * @param classId - The class ID to get users for
@@ -112,7 +69,7 @@ export function ClassService({
     classId: string,
     options: EnrolledUsersQuery,
   ): Promise<PaginatedResult<EnrolledUserEntity>> {
-    const { userId, isSuperAdmin } = authContext;
+    const { userId } = authContext;
 
     try {
       await authorizeSubResourceAccess(authContext, classId);
@@ -128,12 +85,8 @@ export function ClassService({
         ...(options.grade && { grade: options.grade }),
       };
 
-      if (isSuperAdmin) {
-        return await classRepository.getUsersByClassId(classId, queryParams);
-      }
-
-      const allowedRoles = rolesForPermission(Permissions.Users.LIST);
-      return await classRepository.getAuthorizedUsersByClassId({ userId, allowedRoles }, classId, queryParams);
+      // FGA already verified permission — use unrestricted query for all authorized users
+      return await classRepository.getUsersByClassId(classId, queryParams);
     } catch (error) {
       if (error instanceof ApiError) throw error;
 


### PR DESCRIPTION
## Summary

This PR migrates the class service from SQL-based access controls to OpenFGA authorization, continuing the FGA migration chain.

Chained off: `enh/1716/fga-school-service`

## Changes

### Class service (`class.service.ts`)

**`verifyClassAccess`**: replaced `getAuthorizedById` + `rolesForPermission(Permissions.Classes.READ)` with a single
`authorizationService.requirePermission(userId, CAN_READ, class:<classId>)` call. The method now fetches the class via
the unrestricted `getById`, checks existence (404), then delegates access control to FGA (403).

**`authorizeSubResourceAccess`**: significantly simplified. Previously performed a two-step authorization:
1. `verifyClassAccess` (existence + access check)
2. `getUserRolesForClass` + `hasSupervisoryRole` (supervisory role guard)

Now reduced to:
1. `getById` (existence check)
2. `requirePermission(userId, CAN_LIST_USERS, class:<classId>)`: FGA's `can_list_users` relation on the class type
   already encodes both the access check and the supervisory role requirement via `supervisory_tier_group`.

**`listUsers`**: removed the branching between `getAuthorizedUsersByClassId` (for regular users) and
`getUsersByClassId` (for super admins). Since FGA authorization happens before the data fetch, all authorized users
now use the same unrestricted `getUsersByClassId` query.

### Dependency changes

- Removed: `Permissions`, `rolesForPermission`, `hasSupervisoryRole`, `ClassAccessControls`
- Added: `AuthorizationService`, `FgaType`, `FgaRelation`

### Unit tests (`class.service.test.ts`)

Rewrote all tests to use `createMockAuthorizationService` instead of role-based mocks:
- Super admin tests assert `requirePermission` is not called
- Non-super-admin tests assert `requirePermission` with `can_list_users` on `class:<id>`
- Forbidden test mocks `requirePermission.mockRejectedValue(ApiError FORBIDDEN)`
- Removed individual role-specific tests (administrator, site_administrator, teacher+admin, student, caregiver): FGA
  abstracts per-role logic; integration tests cover tier-level behavior

### Integration test (`classes.integration.test.ts`)

- Added `syncFgaTuplesFromPostgres()` in `beforeAll` to seed FGA tuples
- Updated JSDoc to reference OpenFGA instead of RolePermissions groupings

## Testing

- Unit tests verify FGA call patterns and error propagation
- Integration tests verify real FGA authorization decisions across all permission tiers

Resolves [1716](https://github.com/yeatmanlab/roar-project-management/issues/1716)

## Types of changes

What types of changes does this pull request introduce?

<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (non-breaking change that does not add functionality but makes code cleaner or more efficient)
- [ ] Documentation Update
- [ ] Tests (new or updated tests)
- [ ] Style (changes to code styling)
- [ ] CI (continuous integration changes)
- [ ] Repository Maintenance
- [ ] Other (please describe below)

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask.  We're here
to help! This is simply a reminder of what we are going to look for before
merging your code.
-->

- [x] I have read the [guidelines for contributing](https://github.com/yeatmanlab/roar-dashboard/blob/main/.github/CONTRIBUTING.md).
- [x] The changes in this PR are as small as they can be. They represent one and only one fix or enhancement.
- [x] Linting checks pass with my changes.
- [x] Any existing unit tests pass with my changes.
- [x] Any existing end-to-end tests pass with my changes.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] If this PR fixes an existing issue, I have added a unit or end-to-end test that will detect if this issue reoccurs.
- [x] I have added JSDoc comments as appropriate.
- [ ] I have added the necessary documentation to the [roar-docs repository](https://github.com/yeatmanlab/roar-docs).
- [x] I have shared this PR on the roar-pr-reviews channel (if I have access)
- [x] I have linked relevant issues (if any)