### PR TITLE
Add `GET /v1/users/:userId/administrations` endpoint

### DIFF
--- a/apps/backend/src/controllers/administrations.controller.test.ts
+++ b/apps/backend/src/controllers/administrations.controller.test.ts
@@ -48,6 +48,7 @@ describe('AdministrationsController', () => {
   const mockListTaskVariants = vi.fn();
   const mockListAgreements = vi.fn();
   const mockDeleteById = vi.fn();
+  const mockListUserAdministrations = vi.fn();
   const mockListProgressStudents = vi.fn();
   const mockGetProgressOverview = vi.fn();
   const mockAuthContext = { userId: 'user-123', isSuperAdmin: false };
@@ -67,6 +68,7 @@ describe('AdministrationsController', () => {
       listTaskVariants: mockListTaskVariants,
       listAgreements: mockListAgreements,
       deleteById: mockDeleteById,
+      listUserAdministrations: mockListUserAdministrations,
     });
 
     vi.mocked(ReportService).mockReturnValue({

--- a/apps/backend/src/controllers/users.controller.test.ts
+++ b/apps/backend/src/controllers/users.controller.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { StatusCodes } from 'http-status-codes';
 import type { UpdateUserRequestBody } from '@roar-dashboard/api-contract';
 import { UserFactory, AuthContextFactory } from '../test-support/factories/user.factory';
+import { AdministrationFactory } from '../test-support/factories/administration.factory';
 import { MockedUserService } from '../test-support/services/user.service';
 import { ApiError } from '../errors/api-error';
 import { ApiErrorCode } from '../enums/api-error-code.enum';
@@ -12,7 +13,13 @@ vi.mock('../services/user', () => ({
   UserService: vi.fn(),
 }));
 
+// Mock the AdministrationService module
+vi.mock('../services/administration/administration.service', () => ({
+  AdministrationService: vi.fn(),
+}));
+
 import { UserService } from '../services/user';
+import { AdministrationService } from '../services/administration/administration.service';
 
 /**
  * Type-safe assertion helper for success responses.
@@ -40,6 +47,7 @@ describe('UsersController', () => {
   const mockGetById = vi.fn();
   const mockUpdate = vi.fn();
   const mockRecordUserAgreement = vi.fn();
+  const mockListUserAdministrations = vi.fn();
   const mockAuthContext = AuthContextFactory.build({ userId: 'user-123', isSuperAdmin: false });
 
   beforeEach(() => {
@@ -52,6 +60,20 @@ describe('UsersController', () => {
       update: mockUpdate,
       recordUserAgreement: mockRecordUserAgreement,
     } as MockedUserService);
+
+    vi.mocked(AdministrationService).mockReturnValue({
+      verifyAdministrationAccess: vi.fn(),
+      list: vi.fn(),
+      getById: vi.fn(),
+      listDistricts: vi.fn(),
+      listSchools: vi.fn(),
+      listClasses: vi.fn(),
+      listGroups: vi.fn(),
+      listTaskVariants: vi.fn(),
+      listAgreements: vi.fn(),
+      deleteById: vi.fn(),
+      listUserAdministrations: mockListUserAdministrations,
+    });
   });
 
   describe('get', () => {
@@ -672,6 +694,176 @@ describe('UsersController', () => {
       const data = expectCreatedResponse(result);
       expect(data.id).toBe('agreement-parent-child-123');
       expect(mockRecordUserAgreement).toHaveBeenCalledWith(parentAuthContext, childUserId, validBody);
+    });
+  });
+
+  describe('listUserAdministrations', () => {
+    const targetUserId = 'target-user-456';
+    const defaultQuery = {
+      page: 1,
+      perPage: 25,
+      sortBy: 'createdAt' as const,
+      sortOrder: 'desc' as const,
+      embed: [] as ('stats' | 'tasks')[],
+    };
+
+    it('should return 200 with paginated administrations', async () => {
+      const mockAdmins = [
+        AdministrationFactory.build({
+          namePublic: 'Public Name',
+          dateStart: new Date('2025-01-01T00:00:00.000Z'),
+          dateEnd: new Date('2025-06-01T00:00:00.000Z'),
+          createdAt: new Date('2024-12-01T00:00:00.000Z'),
+          updatedAt: new Date('2024-12-15T00:00:00.000Z'),
+        }),
+      ];
+
+      mockListUserAdministrations.mockResolvedValue({
+        items: mockAdmins,
+        totalItems: 1,
+      });
+
+      const { UsersController: Controller } = await import('./users.controller');
+
+      const result = await Controller.listUserAdministrations(mockAuthContext, targetUserId, defaultQuery);
+
+      expect(result.status).toBe(StatusCodes.OK);
+      const body = (result.body as { data: { items: unknown[]; pagination: unknown } }).data;
+      expect(body.items).toHaveLength(1);
+      expect(body.pagination).toEqual({
+        page: 1,
+        perPage: 25,
+        totalItems: 1,
+        totalPages: 1,
+      });
+    });
+
+    it('should transform administration fields to API format', async () => {
+      const mockAdmin = AdministrationFactory.build({
+        namePublic: 'Public Assessment',
+        dateStart: new Date('2025-01-01T00:00:00.000Z'),
+        dateEnd: new Date('2025-06-01T00:00:00.000Z'),
+        createdAt: new Date('2024-12-01T00:00:00.000Z'),
+      });
+
+      mockListUserAdministrations.mockResolvedValue({
+        items: [mockAdmin],
+        totalItems: 1,
+      });
+
+      const { UsersController: Controller } = await import('./users.controller');
+
+      const result = await Controller.listUserAdministrations(mockAuthContext, targetUserId, defaultQuery);
+
+      const body = (result.body as { data: { items: Record<string, unknown>[] } }).data;
+      const item = body.items[0] as Record<string, unknown>;
+      // Transform maps namePublic → publicName and nests dates
+      expect(item.publicName).toBe('Public Assessment');
+      const dates = item.dates as Record<string, string>;
+      expect(dates.start).toBe('2025-01-01T00:00:00.000Z');
+      expect(dates.end).toBe('2025-06-01T00:00:00.000Z');
+      expect(dates.created).toBe('2024-12-01T00:00:00.000Z');
+    });
+
+    it('should pass query options to service with conditional status spread', async () => {
+      mockListUserAdministrations.mockResolvedValue({ items: [], totalItems: 0 });
+
+      const { UsersController: Controller } = await import('./users.controller');
+
+      await Controller.listUserAdministrations(mockAuthContext, targetUserId, {
+        ...defaultQuery,
+        status: 'active',
+      });
+
+      expect(mockListUserAdministrations).toHaveBeenCalledWith(mockAuthContext, targetUserId, {
+        page: 1,
+        perPage: 25,
+        sortBy: 'createdAt',
+        sortOrder: 'desc',
+        embed: [],
+        status: 'active',
+      });
+    });
+
+    it('should not include status when undefined', async () => {
+      mockListUserAdministrations.mockResolvedValue({ items: [], totalItems: 0 });
+
+      const { UsersController: Controller } = await import('./users.controller');
+
+      await Controller.listUserAdministrations(mockAuthContext, targetUserId, defaultQuery);
+
+      const callArgs = mockListUserAdministrations.mock.calls[0]![2];
+      expect(callArgs).not.toHaveProperty('status');
+    });
+
+    it('should return 401 when service throws UNAUTHORIZED', async () => {
+      mockListUserAdministrations.mockRejectedValue(
+        new ApiError(ApiErrorMessage.UNAUTHORIZED, {
+          statusCode: StatusCodes.UNAUTHORIZED,
+          code: ApiErrorCode.AUTH_REQUIRED,
+        }),
+      );
+
+      const { UsersController: Controller } = await import('./users.controller');
+      const result = await Controller.listUserAdministrations(mockAuthContext, targetUserId, defaultQuery);
+
+      const error = expectErrorResponse(result, StatusCodes.UNAUTHORIZED);
+      expect(error.message).toBe(ApiErrorMessage.UNAUTHORIZED);
+    });
+
+    it('should return 403 when service throws FORBIDDEN', async () => {
+      mockListUserAdministrations.mockRejectedValue(
+        new ApiError(ApiErrorMessage.FORBIDDEN, {
+          statusCode: StatusCodes.FORBIDDEN,
+          code: ApiErrorCode.AUTH_FORBIDDEN,
+        }),
+      );
+
+      const { UsersController: Controller } = await import('./users.controller');
+      const result = await Controller.listUserAdministrations(mockAuthContext, targetUserId, defaultQuery);
+
+      const error = expectErrorResponse(result, StatusCodes.FORBIDDEN);
+      expect(error.message).toBe(ApiErrorMessage.FORBIDDEN);
+    });
+
+    it('should return 404 when service throws NOT_FOUND', async () => {
+      mockListUserAdministrations.mockRejectedValue(
+        new ApiError(ApiErrorMessage.NOT_FOUND, {
+          statusCode: StatusCodes.NOT_FOUND,
+          code: ApiErrorCode.RESOURCE_NOT_FOUND,
+        }),
+      );
+
+      const { UsersController: Controller } = await import('./users.controller');
+      const result = await Controller.listUserAdministrations(mockAuthContext, targetUserId, defaultQuery);
+
+      const error = expectErrorResponse(result, StatusCodes.NOT_FOUND);
+      expect(error.message).toBe(ApiErrorMessage.NOT_FOUND);
+    });
+
+    it('should return 500 when service throws INTERNAL_SERVER_ERROR', async () => {
+      mockListUserAdministrations.mockRejectedValue(
+        new ApiError(ApiErrorMessage.INTERNAL_SERVER_ERROR, {
+          statusCode: StatusCodes.INTERNAL_SERVER_ERROR,
+          code: ApiErrorCode.DATABASE_QUERY_FAILED,
+        }),
+      );
+
+      const { UsersController: Controller } = await import('./users.controller');
+      const result = await Controller.listUserAdministrations(mockAuthContext, targetUserId, defaultQuery);
+
+      const error = expectErrorResponse(result, StatusCodes.INTERNAL_SERVER_ERROR);
+      expect(error.message).toBe(ApiErrorMessage.INTERNAL_SERVER_ERROR);
+    });
+
+    it('should rethrow non-ApiError exceptions', async () => {
+      mockListUserAdministrations.mockRejectedValue(new Error('Unexpected error'));
+
+      const { UsersController: Controller } = await import('./users.controller');
+
+      await expect(Controller.listUserAdministrations(mockAuthContext, targetUserId, defaultQuery)).rejects.toThrow(
+        'Unexpected error',
+      );
     });
   });
 });

--- a/apps/backend/src/controllers/users.controller.ts
+++ b/apps/backend/src/controllers/users.controller.ts
@@ -1,12 +1,20 @@
 import type { AuthContext } from '../types/auth-context';
 import type { User } from '../db/schema';
-import type { UserResponse, UpdateUserRequestBody, RecordUserAgreementRequestBody } from '@roar-dashboard/api-contract';
+import type {
+  UserResponse,
+  UpdateUserRequestBody,
+  RecordUserAgreementRequestBody,
+  AdministrationsListQuery,
+} from '@roar-dashboard/api-contract';
 import { StatusCodes } from 'http-status-codes';
 import { UserService } from '../services/user';
+import { AdministrationService } from '../services/administration/administration.service';
 import { ApiError } from '../errors/api-error';
 import { toErrorResponse } from '../utils/to-error-response.util';
+import { transformAdministration } from './utils/administration.transform';
 
 const userService = UserService();
+const administrationService = AdministrationService();
 
 /**
  * Transform a User database record into a UserResponse API schema.
@@ -155,6 +163,60 @@ export const UsersController = {
           StatusCodes.FORBIDDEN,
           StatusCodes.NOT_FOUND,
           StatusCodes.CONFLICT,
+          StatusCodes.INTERNAL_SERVER_ERROR,
+        ]);
+      }
+      throw error;
+    }
+  },
+
+  /**
+   * List administrations assigned to a specific user.
+   *
+   * Delegates to AdministrationService for authorization and data retrieval.
+   * Super admins see all administrations for the user.
+   * The user themselves sees their own administrations.
+   * Supervisory users see the intersection of target user and their own accessible administrations.
+   * Supervised roles receive 403.
+   *
+   * @param authContext - Requesting user's authentication context.
+   * @param userId - UUID of the target user.
+   * @param query - Query parameters (pagination, sorting, embed options, status filter).
+   */
+  listUserAdministrations: async (
+    authContext: AuthContext,
+    userId: string,
+    query: AdministrationsListQuery,
+  ) => {
+    try {
+      const result = await administrationService.listUserAdministrations(authContext, userId, {
+        page: query.page,
+        perPage: query.perPage,
+        sortBy: query.sortBy,
+        sortOrder: query.sortOrder,
+        embed: query.embed,
+        status: query.status,
+      });
+
+      return {
+        status: StatusCodes.OK as const,
+        body: {
+          data: {
+            items: result.items.map(transformAdministration),
+            pagination: {
+              page: query.page,
+              perPage: query.perPage,
+              totalItems: result.totalItems,
+              totalPages: Math.ceil(result.totalItems / query.perPage),
+            },
+          },
+        },
+      };
+    } catch (error) {
+      if (error instanceof ApiError) {
+        return toErrorResponse(error, [
+          StatusCodes.FORBIDDEN,
+          StatusCodes.NOT_FOUND,
           StatusCodes.INTERNAL_SERVER_ERROR,
         ]);
       }

--- a/apps/backend/src/controllers/users.controller.ts
+++ b/apps/backend/src/controllers/users.controller.ts
@@ -183,11 +183,7 @@ export const UsersController = {
    * @param userId - UUID of the target user.
    * @param query - Query parameters (pagination, sorting, embed options, status filter).
    */
-  listUserAdministrations: async (
-    authContext: AuthContext,
-    userId: string,
-    query: AdministrationsListQuery,
-  ) => {
+  listUserAdministrations: async (authContext: AuthContext, userId: string, query: AdministrationsListQuery) => {
     try {
       const result = await administrationService.listUserAdministrations(authContext, userId, {
         page: query.page,
@@ -195,7 +191,7 @@ export const UsersController = {
         sortBy: query.sortBy,
         sortOrder: query.sortOrder,
         embed: query.embed,
-        status: query.status,
+        ...(query.status && { status: query.status }),
       });
 
       return {
@@ -215,6 +211,7 @@ export const UsersController = {
     } catch (error) {
       if (error instanceof ApiError) {
         return toErrorResponse(error, [
+          StatusCodes.UNAUTHORIZED,
           StatusCodes.FORBIDDEN,
           StatusCodes.NOT_FOUND,
           StatusCodes.INTERNAL_SERVER_ERROR,

--- a/apps/backend/src/controllers/utils/administration.transform.ts
+++ b/apps/backend/src/controllers/utils/administration.transform.ts
@@ -1,0 +1,50 @@
+import type {
+  Administration as ContractAdministration,
+  AdministrationBase as ContractAdministrationBase,
+} from '@roar-dashboard/api-contract';
+import type { Administration } from '../../db/schema';
+import type { AdministrationWithEmbeds } from '../../services/administration/administration.service';
+
+/**
+ * Maps a database Administration entity to the base API schema.
+ * Converts Date fields to ISO strings and renames fields to match the contract.
+ *
+ * @param admin - The database Administration entity
+ * @returns The API-formatted administration base object
+ */
+export function transformAdministrationBase(admin: Administration): ContractAdministrationBase {
+  return {
+    id: admin.id,
+    name: admin.name,
+    publicName: admin.namePublic,
+    dates: {
+      start: admin.dateStart.toISOString(),
+      end: admin.dateEnd.toISOString(),
+      created: admin.createdAt.toISOString(),
+    },
+    isOrdered: admin.isOrdered,
+  };
+}
+
+/**
+ * Maps a database Administration entity to the full API schema, attaching
+ * optional embed data (stats, tasks) when present.
+ *
+ * @param admin - The database Administration entity with optional embeds
+ * @returns The API-formatted administration object with embedded data
+ */
+export function transformAdministration(admin: AdministrationWithEmbeds): ContractAdministration {
+  const result: ContractAdministration = transformAdministrationBase(admin);
+
+  // Include stats if embedded
+  if (admin.stats) {
+    result.stats = admin.stats;
+  }
+
+  // Include tasks if embedded
+  if (admin.tasks) {
+    result.tasks = admin.tasks;
+  }
+
+  return result;
+}

--- a/apps/backend/src/routes/users.ts
+++ b/apps/backend/src/routes/users.ts
@@ -30,6 +30,12 @@ export function registerUserRoutes(routerInstance: Router) {
       handler: async ({ req: { user }, params: { userId }, body }) =>
         UsersController.recordUserAgreement(user!, userId, body),
     },
+    listUserAdministrations: {
+      // @ts-expect-error - Express v4/v5 types mismatch in monorepo
+      middleware: [AuthGuardMiddleware],
+      handler: async ({ req: { user }, params: { userId }, query }) =>
+        UsersController.listUserAdministrations(user!, userId, query),
+    },
   });
 
   // @ts-expect-error - Express v4/v5 types mismatch in monorepo

--- a/apps/backend/src/services/administration/administration.service.test.ts
+++ b/apps/backend/src/services/administration/administration.service.test.ts
@@ -3552,4 +3552,419 @@ describe('AdministrationService', () => {
       );
     });
   });
+
+  describe('listUserAdministrations', () => {
+    const defaultOptions = {
+      page: 1,
+      perPage: 25,
+      sortBy: 'createdAt' as const,
+      sortOrder: 'desc' as const,
+    };
+
+    const expectedQueryParams = {
+      page: 1,
+      perPage: 25,
+      orderBy: { field: 'createdAt', direction: 'desc' },
+    };
+
+    describe('target user validation', () => {
+      it('should throw NOT_FOUND when target user does not exist', async () => {
+        mockUserRepository.getById.mockResolvedValue(null);
+
+        const service = AdministrationService({
+          administrationRepository: mockAdministrationRepository,
+          userRepository: mockUserRepository,
+          authorizationService: mockAuthorizationService,
+        });
+
+        await expect(
+          service.listUserAdministrations(
+            { userId: 'requester-123', isSuperAdmin: false },
+            'non-existent-user',
+            defaultOptions,
+          ),
+        ).rejects.toMatchObject({
+          statusCode: StatusCodes.NOT_FOUND,
+          code: ApiErrorCode.RESOURCE_NOT_FOUND,
+        });
+      });
+    });
+
+    describe('self-access', () => {
+      it('should delegate to list() when requester is the target user', async () => {
+        const selfUserId = 'self-user-123';
+        const mockAdmins = AdministrationFactory.buildList(2);
+
+        mockUserRepository.getById.mockResolvedValue(UserFactory.build({ id: selfUserId }));
+
+        // Self-access delegates to list(), which uses FGA for non-super-admins
+        mockAuthorizationService.listAccessibleObjects.mockResolvedValue(
+          mockAdmins.map((a) => `administration:${a.id}`),
+        );
+        mockAdministrationRepository.getByIds.mockResolvedValue({
+          items: mockAdmins,
+          totalItems: 2,
+        });
+
+        const service = AdministrationService({
+          administrationRepository: mockAdministrationRepository,
+          userRepository: mockUserRepository,
+          authorizationService: mockAuthorizationService,
+        });
+
+        const result = await service.listUserAdministrations(
+          { userId: selfUserId, isSuperAdmin: false },
+          selfUserId,
+          defaultOptions,
+        );
+
+        expect(result.items).toHaveLength(2);
+        expect(result.totalItems).toBe(2);
+        // Self-access delegates to list() — only one FGA call for the requester
+        expect(mockAuthorizationService.listAccessibleObjects).toHaveBeenCalledTimes(1);
+        expect(mockAuthorizationService.listAccessibleObjects).toHaveBeenCalledWith(
+          selfUserId,
+          'can_list',
+          'administration',
+        );
+      });
+    });
+
+    describe('super admin access', () => {
+      it('should return all administrations accessible to the target user', async () => {
+        const targetUserId = 'target-user-123';
+        const mockAdmins = AdministrationFactory.buildList(3);
+
+        mockUserRepository.getById.mockResolvedValue(UserFactory.build({ id: targetUserId }));
+        mockAuthorizationService.listAccessibleObjects.mockResolvedValue(
+          mockAdmins.map((a) => `administration:${a.id}`),
+        );
+        mockAdministrationRepository.getByIds.mockResolvedValue({
+          items: mockAdmins,
+          totalItems: 3,
+        });
+
+        const service = AdministrationService({
+          administrationRepository: mockAdministrationRepository,
+          userRepository: mockUserRepository,
+          authorizationService: mockAuthorizationService,
+        });
+
+        const result = await service.listUserAdministrations(
+          { userId: 'admin-123', isSuperAdmin: true },
+          targetUserId,
+          defaultOptions,
+        );
+
+        expect(result.items).toHaveLength(3);
+        expect(result.totalItems).toBe(3);
+        // FGA called for the target user, not the requester
+        expect(mockAuthorizationService.listAccessibleObjects).toHaveBeenCalledWith(
+          targetUserId,
+          'can_list',
+          'administration',
+        );
+        expect(mockAdministrationRepository.getByIds).toHaveBeenCalledWith(
+          mockAdmins.map((a) => a.id),
+          expectedQueryParams,
+        );
+      });
+
+      it('should return empty result when target user has no accessible administrations', async () => {
+        const targetUserId = 'target-user-empty';
+
+        mockUserRepository.getById.mockResolvedValue(UserFactory.build({ id: targetUserId }));
+        mockAuthorizationService.listAccessibleObjects.mockResolvedValue([]);
+
+        const service = AdministrationService({
+          administrationRepository: mockAdministrationRepository,
+          userRepository: mockUserRepository,
+          authorizationService: mockAuthorizationService,
+        });
+
+        const result = await service.listUserAdministrations(
+          { userId: 'admin-123', isSuperAdmin: true },
+          targetUserId,
+          defaultOptions,
+        );
+
+        expect(result.items).toHaveLength(0);
+        expect(result.totalItems).toBe(0);
+        expect(mockAdministrationRepository.getByIds).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('non-super-admin access (intersection)', () => {
+      it('should return intersection of target and requester accessible administrations', async () => {
+        const targetUserId = 'target-user-456';
+        const requesterId = 'requester-789';
+
+        const sharedAdmin = AdministrationFactory.build();
+        const targetOnlyAdmin = AdministrationFactory.build();
+        const requesterOnlyAdmin = AdministrationFactory.build();
+
+        mockUserRepository.getById.mockResolvedValue(UserFactory.build({ id: targetUserId }));
+
+        // Target user can see sharedAdmin + targetOnlyAdmin
+        mockAuthorizationService.listAccessibleObjects
+          .mockResolvedValueOnce([`administration:${sharedAdmin.id}`, `administration:${targetOnlyAdmin.id}`])
+          // Requester can see sharedAdmin + requesterOnlyAdmin
+          .mockResolvedValueOnce([`administration:${sharedAdmin.id}`, `administration:${requesterOnlyAdmin.id}`]);
+
+        mockAdministrationRepository.getByIds.mockResolvedValue({
+          items: [sharedAdmin],
+          totalItems: 1,
+        });
+
+        const service = AdministrationService({
+          administrationRepository: mockAdministrationRepository,
+          userRepository: mockUserRepository,
+          authorizationService: mockAuthorizationService,
+        });
+
+        const result = await service.listUserAdministrations(
+          { userId: requesterId, isSuperAdmin: false },
+          targetUserId,
+          defaultOptions,
+        );
+
+        expect(result.items).toHaveLength(1);
+        expect(result.items[0]!.id).toBe(sharedAdmin.id);
+        // Two FGA calls: one for target, one for requester
+        expect(mockAuthorizationService.listAccessibleObjects).toHaveBeenCalledTimes(2);
+        expect(mockAuthorizationService.listAccessibleObjects).toHaveBeenCalledWith(
+          targetUserId,
+          'can_list',
+          'administration',
+        );
+        expect(mockAuthorizationService.listAccessibleObjects).toHaveBeenCalledWith(
+          requesterId,
+          'can_list',
+          'administration',
+        );
+        // Only the intersection ID is passed to getByIds
+        expect(mockAdministrationRepository.getByIds).toHaveBeenCalledWith([sharedAdmin.id], expectedQueryParams);
+      });
+
+      it('should return empty result when target user has no accessible administrations', async () => {
+        const targetUserId = 'target-empty';
+        const requesterId = 'requester-123';
+
+        mockUserRepository.getById.mockResolvedValue(UserFactory.build({ id: targetUserId }));
+
+        mockAuthorizationService.listAccessibleObjects
+          .mockResolvedValueOnce([]) // target has nothing
+          .mockResolvedValueOnce(['administration:some-id']); // requester has some
+
+        const service = AdministrationService({
+          administrationRepository: mockAdministrationRepository,
+          userRepository: mockUserRepository,
+          authorizationService: mockAuthorizationService,
+        });
+
+        const result = await service.listUserAdministrations(
+          { userId: requesterId, isSuperAdmin: false },
+          targetUserId,
+          defaultOptions,
+        );
+
+        expect(result.items).toHaveLength(0);
+        expect(result.totalItems).toBe(0);
+        expect(mockAdministrationRepository.getByIds).not.toHaveBeenCalled();
+      });
+
+      it('should return empty result when intersection is empty', async () => {
+        const targetUserId = 'target-456';
+        const requesterId = 'requester-789';
+
+        mockUserRepository.getById.mockResolvedValue(UserFactory.build({ id: targetUserId }));
+
+        // No overlap between target and requester administrations
+        mockAuthorizationService.listAccessibleObjects
+          .mockResolvedValueOnce(['administration:target-only-1'])
+          .mockResolvedValueOnce(['administration:requester-only-1']);
+
+        const service = AdministrationService({
+          administrationRepository: mockAdministrationRepository,
+          userRepository: mockUserRepository,
+          authorizationService: mockAuthorizationService,
+        });
+
+        const result = await service.listUserAdministrations(
+          { userId: requesterId, isSuperAdmin: false },
+          targetUserId,
+          defaultOptions,
+        );
+
+        expect(result.items).toHaveLength(0);
+        expect(result.totalItems).toBe(0);
+        expect(mockAdministrationRepository.getByIds).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('embed resolution', () => {
+      it('should resolve task embeds for user administrations', async () => {
+        const targetUserId = 'target-user-123';
+        const mockAdmin = AdministrationFactory.build();
+
+        mockUserRepository.getById.mockResolvedValue(UserFactory.build({ id: targetUserId }));
+        mockAuthorizationService.listAccessibleObjects.mockResolvedValue([`administration:${mockAdmin.id}`]);
+        mockAdministrationRepository.getByIds.mockResolvedValue({
+          items: [mockAdmin],
+          totalItems: 1,
+        });
+
+        const mockTask = {
+          taskId: 'task-1',
+          taskName: 'Test Task',
+          variantId: 'variant-1',
+          variantName: 'v1',
+          orderIndex: 0,
+        };
+        mockAdministrationTaskVariantRepository.getByAdministrationIds.mockResolvedValue(
+          new Map([[mockAdmin.id, [mockTask]]]),
+        );
+
+        const service = AdministrationService({
+          administrationRepository: mockAdministrationRepository,
+          administrationTaskVariantRepository: mockAdministrationTaskVariantRepository,
+          userRepository: mockUserRepository,
+          authorizationService: mockAuthorizationService,
+        });
+
+        const result = await service.listUserAdministrations(
+          { userId: 'admin-123', isSuperAdmin: true },
+          targetUserId,
+          { ...defaultOptions, embed: ['tasks'] },
+        );
+
+        expect(result.items[0]!.tasks).toEqual([mockTask]);
+      });
+
+      it('should restrict stats embed to super admins', async () => {
+        const targetUserId = 'target-user-123';
+        const requesterId = 'requester-456';
+        const mockAdmin = AdministrationFactory.build();
+
+        mockUserRepository.getById.mockResolvedValue(UserFactory.build({ id: targetUserId }));
+        mockAuthorizationService.listAccessibleObjects
+          .mockResolvedValueOnce([`administration:${mockAdmin.id}`])
+          .mockResolvedValueOnce([`administration:${mockAdmin.id}`]);
+        mockAdministrationRepository.getByIds.mockResolvedValue({
+          items: [mockAdmin],
+          totalItems: 1,
+        });
+
+        const service = AdministrationService({
+          administrationRepository: mockAdministrationRepository,
+          userRepository: mockUserRepository,
+          authorizationService: mockAuthorizationService,
+        });
+
+        const result = await service.listUserAdministrations(
+          { userId: requesterId, isSuperAdmin: false },
+          targetUserId,
+          { ...defaultOptions, embed: ['stats'] },
+        );
+
+        // Stats not embedded because requester is not super admin
+        expect(result.items[0]!.stats).toBeUndefined();
+        expect(mockAdministrationRepository.getAssignedUserCountsByAdministrationIds).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('status filter', () => {
+      it('should pass status filter to repository query params', async () => {
+        const targetUserId = 'target-user-123';
+        const mockAdmin = AdministrationFactory.build();
+
+        mockUserRepository.getById.mockResolvedValue(UserFactory.build({ id: targetUserId }));
+        mockAuthorizationService.listAccessibleObjects.mockResolvedValue([`administration:${mockAdmin.id}`]);
+        mockAdministrationRepository.getByIds.mockResolvedValue({
+          items: [mockAdmin],
+          totalItems: 1,
+        });
+
+        const service = AdministrationService({
+          administrationRepository: mockAdministrationRepository,
+          userRepository: mockUserRepository,
+          authorizationService: mockAuthorizationService,
+        });
+
+        await service.listUserAdministrations({ userId: 'admin-123', isSuperAdmin: true }, targetUserId, {
+          ...defaultOptions,
+          status: 'active',
+        });
+
+        expect(mockAdministrationRepository.getByIds).toHaveBeenCalledWith([mockAdmin.id], {
+          ...expectedQueryParams,
+          status: 'active',
+        });
+      });
+    });
+
+    describe('error handling', () => {
+      it('should wrap FGA service failure for target user resolution', async () => {
+        const targetUserId = 'target-user-123';
+
+        mockUserRepository.getById.mockResolvedValue(UserFactory.build({ id: targetUserId }));
+        mockAuthorizationService.listAccessibleObjects.mockRejectedValue(new Error('FGA unavailable'));
+
+        const service = AdministrationService({
+          administrationRepository: mockAdministrationRepository,
+          userRepository: mockUserRepository,
+          authorizationService: mockAuthorizationService,
+        });
+
+        await expect(
+          service.listUserAdministrations({ userId: 'admin-123', isSuperAdmin: true }, targetUserId, defaultOptions),
+        ).rejects.toMatchObject({
+          statusCode: StatusCodes.INTERNAL_SERVER_ERROR,
+        });
+      });
+
+      it('should wrap unexpected repository errors', async () => {
+        const targetUserId = 'target-user-123';
+
+        mockUserRepository.getById.mockResolvedValue(UserFactory.build({ id: targetUserId }));
+        mockAuthorizationService.listAccessibleObjects.mockResolvedValue(['administration:admin-1']);
+        mockAdministrationRepository.getByIds.mockRejectedValue(new Error('DB connection lost'));
+
+        const service = AdministrationService({
+          administrationRepository: mockAdministrationRepository,
+          userRepository: mockUserRepository,
+          authorizationService: mockAuthorizationService,
+        });
+
+        await expect(
+          service.listUserAdministrations({ userId: 'admin-123', isSuperAdmin: true }, targetUserId, defaultOptions),
+        ).rejects.toMatchObject({
+          statusCode: StatusCodes.INTERNAL_SERVER_ERROR,
+          message: 'Failed to retrieve user administrations',
+        });
+      });
+
+      it('should re-throw ApiError instances without wrapping', async () => {
+        const targetUserId = 'target-user-123';
+
+        mockUserRepository.getById.mockResolvedValue(UserFactory.build({ id: targetUserId }));
+
+        const fgaError = new ApiError(ApiErrorMessage.FORBIDDEN, {
+          statusCode: StatusCodes.FORBIDDEN,
+          code: ApiErrorCode.AUTH_FORBIDDEN,
+        });
+        mockAuthorizationService.listAccessibleObjects.mockRejectedValue(fgaError);
+
+        const service = AdministrationService({
+          administrationRepository: mockAdministrationRepository,
+          userRepository: mockUserRepository,
+          authorizationService: mockAuthorizationService,
+        });
+
+        await expect(
+          service.listUserAdministrations({ userId: 'admin-123', isSuperAdmin: true }, targetUserId, defaultOptions),
+        ).rejects.toThrow(fgaError);
+      });
+    });
+  });
 });

--- a/apps/backend/src/services/administration/administration.service.ts
+++ b/apps/backend/src/services/administration/administration.service.ts
@@ -1053,30 +1053,26 @@ export function AdministrationService({
       } else {
         // Non-super-admin viewing another user: intersection of both users' accessible administrations
         const [targetObjects, requesterObjects] = await Promise.all([
-          authorizationService.listAccessibleObjects(
-            targetUserId,
-            FgaRelation.CAN_LIST,
-            FgaType.ADMINISTRATION,
-          ).catch((err) => {
-            throw new ApiError('Failed to resolve target user administrations', {
-              statusCode: StatusCodes.INTERNAL_SERVER_ERROR,
-              code: ApiErrorCode.EXTERNAL_SERVICE_FAILED,
-              context: { userId, targetUserId },
-              cause: err,
-            });
-          }),
-          authorizationService.listAccessibleObjects(
-            userId,
-            FgaRelation.CAN_LIST,
-            FgaType.ADMINISTRATION,
-          ).catch((err) => {
-            throw new ApiError('Failed to resolve requester administrations', {
-              statusCode: StatusCodes.INTERNAL_SERVER_ERROR,
-              code: ApiErrorCode.EXTERNAL_SERVICE_FAILED,
-              context: { userId, targetUserId },
-              cause: err,
-            });
-          }),
+          authorizationService
+            .listAccessibleObjects(targetUserId, FgaRelation.CAN_LIST, FgaType.ADMINISTRATION)
+            .catch((err) => {
+              throw new ApiError('Failed to resolve target user administrations', {
+                statusCode: StatusCodes.INTERNAL_SERVER_ERROR,
+                code: ApiErrorCode.EXTERNAL_SERVICE_FAILED,
+                context: { userId, targetUserId },
+                cause: err,
+              });
+            }),
+          authorizationService
+            .listAccessibleObjects(userId, FgaRelation.CAN_LIST, FgaType.ADMINISTRATION)
+            .catch((err) => {
+              throw new ApiError('Failed to resolve requester administrations', {
+                statusCode: StatusCodes.INTERNAL_SERVER_ERROR,
+                code: ApiErrorCode.EXTERNAL_SERVICE_FAILED,
+                context: { userId, targetUserId },
+                cause: err,
+              });
+            }),
         ]);
 
         const targetIds = new Set(targetObjects.map(extractFgaObjectId));
@@ -1125,10 +1121,7 @@ export function AdministrationService({
     } catch (error) {
       if (error instanceof ApiError) throw error;
 
-      logger.error(
-        { err: error, context: { userId, targetUserId } },
-        'Failed to list user administrations',
-      );
+      logger.error({ err: error, context: { userId, targetUserId } }, 'Failed to list user administrations');
 
       throw new ApiError('Failed to retrieve user administrations', {
         statusCode: StatusCodes.INTERNAL_SERVER_ERROR,

--- a/apps/backend/src/services/administration/administration.service.ts
+++ b/apps/backend/src/services/administration/administration.service.ts
@@ -985,6 +985,160 @@ export function AdministrationService({
     }
   }
 
+  /**
+   * List administrations assigned to a specific user with access control.
+   *
+   * Authorization behavior:
+   * - Super admin: sees all administrations assigned to the target user
+   * - Same user (req.user.userId === userId): sees their own (delegates to list)
+   * - Supervisory roles with Administrations.LIST: sees intersection of target user's
+   *   and requester's accessible administrations
+   * - Supervised roles: returns 403 Forbidden
+   *
+   * @param authContext - Requester's auth context
+   * @param targetUserId - The user whose administrations to retrieve
+   * @param options - Query options (pagination, sorting, status filter, embeds)
+   * @returns Paginated result with administrations
+   * @throws {ApiError} NOT_FOUND if target user doesn't exist
+   * @throws {ApiError} FORBIDDEN if requester lacks access
+   * @throws {ApiError} INTERNAL_SERVER_ERROR if the database query fails
+   */
+  async function listUserAdministrations(
+    authContext: AuthContext,
+    targetUserId: string,
+    options: ListOptions,
+  ): Promise<PaginatedResult<AdministrationWithEmbeds>> {
+    const { userId, isSuperAdmin } = authContext;
+
+    try {
+      // Verify target user exists
+      const targetUser = await userRepository.getById({ id: targetUserId });
+      if (!targetUser) {
+        throw new ApiError(ApiErrorMessage.NOT_FOUND, {
+          statusCode: StatusCodes.NOT_FOUND,
+          code: ApiErrorCode.RESOURCE_NOT_FOUND,
+          context: { userId, targetUserId },
+        });
+      }
+
+      // Self-access: delegate to list() which handles own administrations
+      if (userId === targetUserId) {
+        return list(authContext, options);
+      }
+
+      // Transform API contract format to repository format
+      const queryParams = {
+        page: options.page,
+        perPage: options.perPage,
+        orderBy: {
+          field: options.sortBy,
+          direction: options.sortOrder,
+        },
+        ...(options.status && { status: options.status }),
+      };
+
+      let result;
+      if (isSuperAdmin) {
+        // Super admin: get all administrations the target user can access
+        const targetObjects = await authorizationService.listAccessibleObjects(
+          targetUserId,
+          FgaRelation.CAN_LIST,
+          FgaType.ADMINISTRATION,
+        );
+        const targetIds = targetObjects.map(extractFgaObjectId);
+        if (targetIds.length === 0) {
+          return { items: [], totalItems: 0 };
+        }
+        result = await administrationRepository.getByIds(targetIds, queryParams);
+      } else {
+        // Non-super-admin viewing another user: intersection of both users' accessible administrations
+        const [targetObjects, requesterObjects] = await Promise.all([
+          authorizationService.listAccessibleObjects(
+            targetUserId,
+            FgaRelation.CAN_LIST,
+            FgaType.ADMINISTRATION,
+          ).catch((err) => {
+            throw new ApiError('Failed to resolve target user administrations', {
+              statusCode: StatusCodes.INTERNAL_SERVER_ERROR,
+              code: ApiErrorCode.EXTERNAL_SERVICE_FAILED,
+              context: { userId, targetUserId },
+              cause: err,
+            });
+          }),
+          authorizationService.listAccessibleObjects(
+            userId,
+            FgaRelation.CAN_LIST,
+            FgaType.ADMINISTRATION,
+          ).catch((err) => {
+            throw new ApiError('Failed to resolve requester administrations', {
+              statusCode: StatusCodes.INTERNAL_SERVER_ERROR,
+              code: ApiErrorCode.EXTERNAL_SERVICE_FAILED,
+              context: { userId, targetUserId },
+              cause: err,
+            });
+          }),
+        ]);
+
+        const targetIds = new Set(targetObjects.map(extractFgaObjectId));
+        const requesterIds = new Set(requesterObjects.map(extractFgaObjectId));
+
+        // Intersection: only administrations both users can access
+        const intersectedIds = [...targetIds].filter((id) => requesterIds.has(id));
+        if (intersectedIds.length === 0) {
+          return { items: [], totalItems: 0 };
+        }
+
+        result = await administrationRepository.getByIds(intersectedIds, queryParams);
+      }
+
+      // Resolve embeds (reuse existing logic)
+      const embedOptions = options.embed ?? [];
+      if (embedOptions.length === 0 || result.items.length === 0) {
+        return result;
+      }
+
+      const administrationIds = result.items.map((admin) => admin.id);
+      const shouldEmbedStats = isSuperAdmin && embedOptions.includes(AdministrationEmbedOption.STATS);
+      const shouldEmbedTasks = embedOptions.includes(AdministrationEmbedOption.TASKS);
+
+      const statsMap = shouldEmbedStats ? await fetchStatsEmbed(administrationIds, userId) : null;
+      const tasksMap = shouldEmbedTasks ? await fetchTasksEmbed(administrationIds, userId) : null;
+
+      const itemsWithEmbeds: AdministrationWithEmbeds[] = result.items.map((admin) => {
+        const adminWithEmbeds: AdministrationWithEmbeds = { ...admin };
+
+        if (statsMap) {
+          adminWithEmbeds.stats = statsMap.get(admin.id) ?? { assigned: 0, started: 0, completed: 0 };
+        }
+
+        if (tasksMap) {
+          adminWithEmbeds.tasks = tasksMap.get(admin.id) ?? [];
+        }
+
+        return adminWithEmbeds;
+      });
+
+      return {
+        items: itemsWithEmbeds,
+        totalItems: result.totalItems,
+      };
+    } catch (error) {
+      if (error instanceof ApiError) throw error;
+
+      logger.error(
+        { err: error, context: { userId, targetUserId } },
+        'Failed to list user administrations',
+      );
+
+      throw new ApiError('Failed to retrieve user administrations', {
+        statusCode: StatusCodes.INTERNAL_SERVER_ERROR,
+        code: ApiErrorCode.DATABASE_QUERY_FAILED,
+        context: { userId, targetUserId },
+        cause: error,
+      });
+    }
+  }
+
   return {
     verifyAdministrationAccess,
     list,
@@ -996,5 +1150,6 @@ export function AdministrationService({
     listTaskVariants,
     listAgreements,
     deleteById,
+    listUserAdministrations,
   };
 }

--- a/apps/backend/src/test-support/services/administration.service.ts
+++ b/apps/backend/src/test-support/services/administration.service.ts
@@ -18,6 +18,7 @@ export function createMockAdministrationService(): MockedObject<ReturnType<typeo
     listTaskVariants: vi.fn(),
     listAgreements: vi.fn(),
     deleteById: vi.fn(),
+    listUserAdministrations: vi.fn(),
   } as MockedObject<ReturnType<typeof AdministrationService>>;
 }
 

--- a/packages/api-contract/src/v1/users/contract.ts
+++ b/packages/api-contract/src/v1/users/contract.ts
@@ -7,10 +7,7 @@ import {
   RecordUserAgreementRequestBodySchema,
   RecordUserAgreementResponseSchema,
 } from './schema';
-import {
-  AdministrationsListQuerySchema,
-  AdministrationsListResponseSchema,
-} from '../administrations/schema';
+import { AdministrationsListQuerySchema, AdministrationsListResponseSchema } from '../administrations/schema';
 
 const c = initContract();
 
@@ -118,7 +115,7 @@ export const UsersContract = c.router(
         'Returns a paginated list of administrations assigned to the specified user. ' +
         'Super admins see all administrations for the user. ' +
         'The user themselves sees their own administrations. ' +
-        'Supervisory users see the intersection of the target user\'s and their own accessible administrations. ' +
+        "Supervisory users see the intersection of the target user's and their own accessible administrations. " +
         'Supervised roles receive 403. ' +
         'Returns 404 if the target user does not exist.',
     },

--- a/packages/api-contract/src/v1/users/contract.ts
+++ b/packages/api-contract/src/v1/users/contract.ts
@@ -7,6 +7,10 @@ import {
   RecordUserAgreementRequestBodySchema,
   RecordUserAgreementResponseSchema,
 } from './schema';
+import {
+  AdministrationsListQuerySchema,
+  AdministrationsListResponseSchema,
+} from '../administrations/schema';
 
 const c = initContract();
 
@@ -95,6 +99,28 @@ export const UsersContract = c.router(
         'Returns 404 if the user or agreement version does not exist. ' +
         'Returns 409 if the user has already consented to the given agreement version. ' +
         'Returns 500 if an internal server error occurs.',
+    },
+    listUserAdministrations: {
+      method: 'GET',
+      path: '/:userId/administrations',
+      pathParams: z.object({ userId: z.string().uuid() }),
+      query: AdministrationsListQuerySchema,
+      responses: {
+        200: SuccessEnvelopeSchema(AdministrationsListResponseSchema),
+        401: ErrorEnvelopeSchema,
+        403: ErrorEnvelopeSchema,
+        404: ErrorEnvelopeSchema,
+        500: ErrorEnvelopeSchema,
+      },
+      strictStatusCodes: true,
+      summary: 'List administrations for a user',
+      description:
+        'Returns a paginated list of administrations assigned to the specified user. ' +
+        'Super admins see all administrations for the user. ' +
+        'The user themselves sees their own administrations. ' +
+        'Supervisory users see the intersection of the target user\'s and their own accessible administrations. ' +
+        'Supervised roles receive 403. ' +
+        'Returns 404 if the target user does not exist.',
     },
   },
   { pathPrefix: '/users' },


### PR DESCRIPTION
## Summary

This PR adds a sub-resource endpoint that returns a paginated list of administrations assigned to a specific user. Authorization uses OpenFGA rather than SQL-based access control joins. Reuses the existing administrations query/response schemas. Implemented across all 5 layers.

### Contract

`GET /users/:userId/administrations` reuses `AdministrationsListQuerySchema` and `AdministrationsListResponseSchema` from the administrations contract — the response shape is identical to `GET /administrations`.

### Service — authorization flow

`listUserAdministrations(authContext, targetUserId, options)`:

1. **Target user exists** — 404 if not found
2. **Self-access** (`userId === targetUserId`) — delegates to existing `list()`, which handles its own authorization (single FGA call)
3. **Super admin** — `authorizationService.listAccessibleObjects(targetUserId, CAN_LIST, ADMINISTRATION)` → `extractFgaObjectId()` → `repository.getByIds()`
4. **Non-super-admin** — parallel FGA calls for both target and requester, then Set intersection of accessible administration IDs → `repository.getByIds()` on the intersected set
5. **Embed resolution** — reuses existing `fetchStatsEmbed` / `fetchTasksEmbed` helpers

Empty ID sets short-circuit to `{ items: [], totalItems: 0 }` without hitting the database.

### Repository

No new repository methods. The service uses `getByIds()` (inherited from `BaseRepository`) to fetch paginated results filtered to the FGA-resolved ID set. The old SQL-based `listByUserId()` and `listByUserIdAuthorized()` methods (which used `buildUserAdministrationIdsQuery` INNER JOINs) were removed — FGA replaces them.

### Controller

Shared transform helpers extracted to `controllers/utils/administration.transform.ts` for reuse:

- `transformAdministrationBase` — DB entity → API base schema (dates → ISO strings, `namePublic` → `publicName`)
- `transformAdministration` — extends base with optional embeds

### Route

Registered with `AuthGuardMiddleware`. Passes `user!`, `userId`, and `query` to controller.

## Review focus

- **FGA intersection logic:** Non-super-admin path computes Set intersection of target and requester's `listAccessibleObjects` results. Verify empty-set short-circuits are correct and that the parallel `.catch()` wraps errors in `ApiError` with `EXTERNAL_SERVICE_FAILED`.
- **Self-access delegation:** When `userId === targetUserId`, it delegates to `list()`. Verify this doesn't create privilege escalation for supervised users.
- **Stats embed restriction:** `shouldEmbedStats` requires `isSuperAdmin`, matching existing list behavior.

Resolves [1740](https://github.com/yeatmanlab/roar-project-management/issues/1740)

## Types of changes

What types of changes does this pull request introduce?

<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (non-breaking change that does not add functionality but makes code cleaner or more efficient)
- [ ] Documentation Update
- [x] Tests (new or updated tests)
- [ ] Style (changes to code styling)
- [ ] CI (continuous integration changes)
- [ ] Repository Maintenance
- [ ] Other (please describe below)

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask.  We're here
to help! This is simply a reminder of what we are going to look for before
merging your code.
-->

- [x] I have read the [guidelines for contributing](https://github.com/yeatmanlab/roar-dashboard/blob/main/.github/CONTRIBUTING.md).
- [x] The changes in this PR are as small as they can be. They represent one and only one fix or enhancement.
- [x] Linting checks pass with my changes.
- [x] Any existing unit tests pass with my changes.
- [x] Any existing end-to-end tests pass with my changes.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] If this PR fixes an existing issue, I have added a unit or end-to-end test that will detect if this issue reoccurs.
- [x] I have added JSDoc comments as appropriate.
- [ ] I have added the necessary documentation to the [roar-docs repository](https://github.com/yeatmanlab/roar-docs).
- [x] I have shared this PR on the roar-pr-reviews channel (if I have access)
- [x] I have linked relevant issues (if any)