### PR TITLE
Add `GET /v1/users/:userId/administrations/:administrationId` endpoint

### DIFF
--- a/apps/backend/src/controllers/users.controller.test.ts
+++ b/apps/backend/src/controllers/users.controller.test.ts
@@ -48,6 +48,7 @@ describe('UsersController', () => {
   const mockUpdate = vi.fn();
   const mockRecordUserAgreement = vi.fn();
   const mockListUserAdministrations = vi.fn();
+  const mockGetUserAdministration = vi.fn();
   const mockAuthContext = AuthContextFactory.build({ userId: 'user-123', isSuperAdmin: false });
 
   beforeEach(() => {
@@ -73,6 +74,7 @@ describe('UsersController', () => {
       listAgreements: vi.fn(),
       deleteById: vi.fn(),
       listUserAdministrations: mockListUserAdministrations,
+      getUserAdministration: mockGetUserAdministration,
     });
   });
 
@@ -862,6 +864,131 @@ describe('UsersController', () => {
       const { UsersController: Controller } = await import('./users.controller');
 
       await expect(Controller.listUserAdministrations(mockAuthContext, targetUserId, defaultQuery)).rejects.toThrow(
+        'Unexpected error',
+      );
+    });
+  });
+
+  describe('getUserAdministration', () => {
+    const targetUserId = 'target-user-456';
+    const administrationId = 'admin-uuid-789';
+
+    it('should return 200 with transformed administration base', async () => {
+      const mockAdmin = AdministrationFactory.build({ id: administrationId });
+      mockGetUserAdministration.mockResolvedValue(mockAdmin);
+
+      const { UsersController: Controller } = await import('./users.controller');
+
+      const result = await Controller.getUserAdministration(mockAuthContext, targetUserId, administrationId);
+
+      const data = expectOkResponse(result);
+      expect(data).toHaveProperty('id', administrationId);
+      expect(data).toHaveProperty('publicName', mockAdmin.namePublic);
+      expect(data).toHaveProperty('dates');
+      expect(data).toHaveProperty('isOrdered', mockAdmin.isOrdered);
+    });
+
+    it('should transform date fields to ISO strings and rename fields', async () => {
+      const mockAdmin = AdministrationFactory.build({
+        id: administrationId,
+        namePublic: 'Public Test',
+        dateStart: new Date('2025-09-01T00:00:00.000Z'),
+        dateEnd: new Date('2025-12-31T23:59:59.000Z'),
+        createdAt: new Date('2025-08-15T10:30:00.000Z'),
+      });
+      mockGetUserAdministration.mockResolvedValue(mockAdmin);
+
+      const { UsersController: Controller } = await import('./users.controller');
+
+      const result = await Controller.getUserAdministration(mockAuthContext, targetUserId, administrationId);
+
+      const data = expectOkResponse(result);
+      expect(data.publicName).toBe('Public Test');
+      expect(data.dates.start).toBe('2025-09-01T00:00:00.000Z');
+      expect(data.dates.end).toBe('2025-12-31T23:59:59.000Z');
+      expect(data.dates.created).toBe('2025-08-15T10:30:00.000Z');
+    });
+
+    it('should pass authContext, userId, and administrationId to the service', async () => {
+      mockGetUserAdministration.mockResolvedValue(AdministrationFactory.build());
+
+      const { UsersController: Controller } = await import('./users.controller');
+
+      await Controller.getUserAdministration(mockAuthContext, targetUserId, administrationId);
+
+      expect(mockGetUserAdministration).toHaveBeenCalledWith(mockAuthContext, targetUserId, administrationId);
+    });
+
+    it('should return 401 for unauthenticated requests', async () => {
+      mockGetUserAdministration.mockRejectedValue(
+        new ApiError(ApiErrorMessage.UNAUTHORIZED, {
+          statusCode: StatusCodes.UNAUTHORIZED,
+          code: ApiErrorCode.AUTH_UNAUTHENTICATED,
+        }),
+      );
+
+      const { UsersController: Controller } = await import('./users.controller');
+
+      const result = await Controller.getUserAdministration(mockAuthContext, targetUserId, administrationId);
+
+      const error = expectErrorResponse(result, StatusCodes.UNAUTHORIZED);
+      expect(error.message).toBe(ApiErrorMessage.UNAUTHORIZED);
+    });
+
+    it('should return 403 when requester lacks permission', async () => {
+      mockGetUserAdministration.mockRejectedValue(
+        new ApiError(ApiErrorMessage.FORBIDDEN, {
+          statusCode: StatusCodes.FORBIDDEN,
+          code: ApiErrorCode.AUTH_FORBIDDEN,
+        }),
+      );
+
+      const { UsersController: Controller } = await import('./users.controller');
+
+      const result = await Controller.getUserAdministration(mockAuthContext, targetUserId, administrationId);
+
+      const error = expectErrorResponse(result, StatusCodes.FORBIDDEN);
+      expect(error.message).toBe(ApiErrorMessage.FORBIDDEN);
+    });
+
+    it('should return 404 when user or administration not found', async () => {
+      mockGetUserAdministration.mockRejectedValue(
+        new ApiError(ApiErrorMessage.NOT_FOUND, {
+          statusCode: StatusCodes.NOT_FOUND,
+          code: ApiErrorCode.RESOURCE_NOT_FOUND,
+        }),
+      );
+
+      const { UsersController: Controller } = await import('./users.controller');
+
+      const result = await Controller.getUserAdministration(mockAuthContext, targetUserId, administrationId);
+
+      const error = expectErrorResponse(result, StatusCodes.NOT_FOUND);
+      expect(error.message).toBe(ApiErrorMessage.NOT_FOUND);
+    });
+
+    it('should return 500 for internal server errors', async () => {
+      mockGetUserAdministration.mockRejectedValue(
+        new ApiError(ApiErrorMessage.INTERNAL_SERVER_ERROR, {
+          statusCode: StatusCodes.INTERNAL_SERVER_ERROR,
+          code: ApiErrorCode.DATABASE_QUERY_FAILED,
+        }),
+      );
+
+      const { UsersController: Controller } = await import('./users.controller');
+
+      const result = await Controller.getUserAdministration(mockAuthContext, targetUserId, administrationId);
+
+      const error = expectErrorResponse(result, StatusCodes.INTERNAL_SERVER_ERROR);
+      expect(error.message).toBe(ApiErrorMessage.INTERNAL_SERVER_ERROR);
+    });
+
+    it('should rethrow non-ApiError exceptions', async () => {
+      mockGetUserAdministration.mockRejectedValue(new Error('Unexpected error'));
+
+      const { UsersController: Controller } = await import('./users.controller');
+
+      await expect(Controller.getUserAdministration(mockAuthContext, targetUserId, administrationId)).rejects.toThrow(
         'Unexpected error',
       );
     });

--- a/apps/backend/src/controllers/users.controller.ts
+++ b/apps/backend/src/controllers/users.controller.ts
@@ -11,7 +11,7 @@ import { UserService } from '../services/user';
 import { AdministrationService } from '../services/administration/administration.service';
 import { ApiError } from '../errors/api-error';
 import { toErrorResponse } from '../utils/to-error-response.util';
-import { transformAdministration } from './utils/administration.transform';
+import { transformAdministration, transformAdministrationBase } from './utils/administration.transform';
 
 const userService = UserService();
 const administrationService = AdministrationService();
@@ -206,6 +206,38 @@ export const UsersController = {
               totalPages: Math.ceil(result.totalItems / query.perPage),
             },
           },
+        },
+      };
+    } catch (error) {
+      if (error instanceof ApiError) {
+        return toErrorResponse(error, [
+          StatusCodes.UNAUTHORIZED,
+          StatusCodes.FORBIDDEN,
+          StatusCodes.NOT_FOUND,
+          StatusCodes.INTERNAL_SERVER_ERROR,
+        ]);
+      }
+      throw error;
+    }
+  },
+
+  /**
+   * Get a single administration for a specific user.
+   *
+   * Delegates to AdministrationService for authorization and retrieval.
+   * Returns the base administration schema (no embeds).
+   *
+   * @param authContext - Requesting user's authentication context.
+   * @param userId - UUID of the target user.
+   * @param administrationId - UUID of the administration to retrieve.
+   */
+  getUserAdministration: async (authContext: AuthContext, userId: string, administrationId: string) => {
+    try {
+      const administration = await administrationService.getUserAdministration(authContext, userId, administrationId);
+      return {
+        status: StatusCodes.OK as const,
+        body: {
+          data: transformAdministrationBase(administration),
         },
       };
     } catch (error) {

--- a/apps/backend/src/routes/users.ts
+++ b/apps/backend/src/routes/users.ts
@@ -36,6 +36,12 @@ export function registerUserRoutes(routerInstance: Router) {
       handler: async ({ req: { user }, params: { userId }, query }) =>
         UsersController.listUserAdministrations(user!, userId, query),
     },
+    getUserAdministration: {
+      // @ts-expect-error - Express v4/v5 types mismatch in monorepo
+      middleware: [AuthGuardMiddleware],
+      handler: async ({ req: { user }, params: { userId, administrationId } }) =>
+        UsersController.getUserAdministration(user!, userId, administrationId),
+    },
   });
 
   // @ts-expect-error - Express v4/v5 types mismatch in monorepo

--- a/apps/backend/src/services/administration/administration.service.test.ts
+++ b/apps/backend/src/services/administration/administration.service.test.ts
@@ -3967,4 +3967,216 @@ describe('AdministrationService', () => {
       });
     });
   });
+
+  describe('getUserAdministration', () => {
+    const targetUserId = 'target-user-123';
+    const administrationId = 'admin-uuid-123';
+    const mockUser = UserFactory.build({ id: targetUserId });
+    const mockAdmin = AdministrationFactory.build({ id: administrationId });
+
+    function createService() {
+      return AdministrationService({
+        administrationRepository: mockAdministrationRepository,
+        userRepository: mockUserRepository,
+        authorizationService: mockAuthorizationService,
+      });
+    }
+
+    describe('target user validation', () => {
+      it('should throw NOT_FOUND when target user does not exist', async () => {
+        mockUserRepository.getById.mockResolvedValue(null);
+
+        const service = createService();
+
+        await expect(
+          service.getUserAdministration(
+            { userId: 'requester-123', isSuperAdmin: false },
+            targetUserId,
+            administrationId,
+          ),
+        ).rejects.toMatchObject({
+          statusCode: StatusCodes.NOT_FOUND,
+          code: ApiErrorCode.RESOURCE_NOT_FOUND,
+        });
+
+        expect(mockAdministrationRepository.getById).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('administration validation', () => {
+      it('should throw NOT_FOUND when administration does not exist', async () => {
+        mockUserRepository.getById.mockResolvedValue(mockUser);
+        mockAdministrationRepository.getById.mockResolvedValue(null);
+
+        const service = createService();
+
+        await expect(
+          service.getUserAdministration(
+            { userId: 'requester-123', isSuperAdmin: false },
+            targetUserId,
+            administrationId,
+          ),
+        ).rejects.toMatchObject({
+          statusCode: StatusCodes.NOT_FOUND,
+          code: ApiErrorCode.RESOURCE_NOT_FOUND,
+        });
+
+        expect(mockAuthorizationService.hasPermission).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('target user access check', () => {
+      it('should throw NOT_FOUND when target user does not have access to the administration', async () => {
+        mockUserRepository.getById.mockResolvedValue(mockUser);
+        mockAdministrationRepository.getById.mockResolvedValue(mockAdmin);
+        mockAuthorizationService.hasPermission.mockResolvedValue(false);
+
+        const service = createService();
+
+        await expect(
+          service.getUserAdministration(
+            { userId: 'requester-123', isSuperAdmin: false },
+            targetUserId,
+            administrationId,
+          ),
+        ).rejects.toMatchObject({
+          statusCode: StatusCodes.NOT_FOUND,
+          code: ApiErrorCode.RESOURCE_NOT_FOUND,
+        });
+
+        expect(mockAuthorizationService.hasPermission).toHaveBeenCalledWith(
+          targetUserId,
+          'can_list',
+          `administration:${administrationId}`,
+        );
+        expect(mockAuthorizationService.requirePermission).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('self-access', () => {
+      it('should return administration when requester is the target user', async () => {
+        mockUserRepository.getById.mockResolvedValue(mockUser);
+        mockAdministrationRepository.getById.mockResolvedValue(mockAdmin);
+        mockAuthorizationService.hasPermission.mockResolvedValue(true);
+
+        const service = createService();
+
+        const result = await service.getUserAdministration(
+          { userId: targetUserId, isSuperAdmin: false },
+          targetUserId,
+          administrationId,
+        );
+
+        expect(result).toEqual(mockAdmin);
+        // Self-access skips requester permission check
+        expect(mockAuthorizationService.requirePermission).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('super admin access', () => {
+      it('should return administration for super admin without requester permission check', async () => {
+        mockUserRepository.getById.mockResolvedValue(mockUser);
+        mockAdministrationRepository.getById.mockResolvedValue(mockAdmin);
+        mockAuthorizationService.hasPermission.mockResolvedValue(true);
+
+        const service = createService();
+
+        const result = await service.getUserAdministration(
+          { userId: 'super-admin-123', isSuperAdmin: true },
+          targetUserId,
+          administrationId,
+        );
+
+        expect(result).toEqual(mockAdmin);
+        expect(mockAuthorizationService.requirePermission).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('requester authorization', () => {
+      it('should return administration when requester has FGA access', async () => {
+        mockUserRepository.getById.mockResolvedValue(mockUser);
+        mockAdministrationRepository.getById.mockResolvedValue(mockAdmin);
+        mockAuthorizationService.hasPermission.mockResolvedValue(true);
+        mockAuthorizationService.requirePermission.mockResolvedValue(undefined);
+
+        const service = createService();
+
+        const result = await service.getUserAdministration(
+          { userId: 'requester-123', isSuperAdmin: false },
+          targetUserId,
+          administrationId,
+        );
+
+        expect(result).toEqual(mockAdmin);
+        expect(mockAuthorizationService.requirePermission).toHaveBeenCalledWith(
+          'requester-123',
+          'can_read',
+          `administration:${administrationId}`,
+        );
+      });
+
+      it('should throw FORBIDDEN when requester lacks FGA access', async () => {
+        mockUserRepository.getById.mockResolvedValue(mockUser);
+        mockAdministrationRepository.getById.mockResolvedValue(mockAdmin);
+        mockAuthorizationService.hasPermission.mockResolvedValue(true);
+        mockAuthorizationService.requirePermission.mockRejectedValue(
+          new ApiError(ApiErrorMessage.FORBIDDEN, {
+            statusCode: StatusCodes.FORBIDDEN,
+            code: ApiErrorCode.AUTH_FORBIDDEN,
+          }),
+        );
+
+        const service = createService();
+
+        await expect(
+          service.getUserAdministration(
+            { userId: 'requester-123', isSuperAdmin: false },
+            targetUserId,
+            administrationId,
+          ),
+        ).rejects.toMatchObject({
+          statusCode: StatusCodes.FORBIDDEN,
+          code: ApiErrorCode.AUTH_FORBIDDEN,
+        });
+      });
+    });
+
+    describe('error handling', () => {
+      it('should re-throw ApiError instances', async () => {
+        const notFoundError = new ApiError(ApiErrorMessage.NOT_FOUND, {
+          statusCode: StatusCodes.NOT_FOUND,
+          code: ApiErrorCode.RESOURCE_NOT_FOUND,
+        });
+        mockUserRepository.getById.mockRejectedValue(notFoundError);
+
+        const service = createService();
+
+        await expect(
+          service.getUserAdministration(
+            { userId: 'requester-123', isSuperAdmin: false },
+            targetUserId,
+            administrationId,
+          ),
+        ).rejects.toThrow(notFoundError);
+      });
+
+      it('should wrap unexpected errors in ApiError', async () => {
+        mockUserRepository.getById.mockResolvedValue(mockUser);
+        mockAdministrationRepository.getById.mockRejectedValue(new Error('DB connection failed'));
+
+        const service = createService();
+
+        await expect(
+          service.getUserAdministration(
+            { userId: 'requester-123', isSuperAdmin: false },
+            targetUserId,
+            administrationId,
+          ),
+        ).rejects.toMatchObject({
+          statusCode: StatusCodes.INTERNAL_SERVER_ERROR,
+          code: ApiErrorCode.DATABASE_QUERY_FAILED,
+        });
+      });
+    });
+  });
 });

--- a/apps/backend/src/services/administration/administration.service.ts
+++ b/apps/backend/src/services/administration/administration.service.ts
@@ -1132,6 +1132,95 @@ export function AdministrationService({
     }
   }
 
+  /**
+   * Get a single administration for a specific user.
+   *
+   * Authorization flow:
+   * 1. Verify target user exists (404 if not)
+   * 2. Verify administration exists (404 if not)
+   * 3. Verify target user has access to the administration via FGA (404 if not)
+   * 4. If requester is super admin or same user → return administration
+   * 5. Verify requester has FGA access to the administration (403 if not)
+   *
+   * @param authContext - Requesting user's auth context
+   * @param targetUserId - UUID of the user whose administration to retrieve
+   * @param administrationId - UUID of the administration to retrieve
+   * @returns The administration if found and accessible
+   * @throws {ApiError} NOT_FOUND if user, administration, or assignment doesn't exist
+   * @throws {ApiError} FORBIDDEN if requester lacks permission
+   */
+  async function getUserAdministration(
+    authContext: AuthContext,
+    targetUserId: string,
+    administrationId: string,
+  ): Promise<Administration> {
+    const { userId, isSuperAdmin } = authContext;
+
+    try {
+      // 1. Verify target user exists
+      const targetUser = await userRepository.getById({ id: targetUserId });
+      if (!targetUser) {
+        throw new ApiError(ApiErrorMessage.NOT_FOUND, {
+          statusCode: StatusCodes.NOT_FOUND,
+          code: ApiErrorCode.RESOURCE_NOT_FOUND,
+          context: { userId, targetUserId },
+        });
+      }
+
+      // 2. Verify administration exists
+      const administration = await administrationRepository.getById({ id: administrationId });
+      if (!administration) {
+        throw new ApiError(ApiErrorMessage.NOT_FOUND, {
+          statusCode: StatusCodes.NOT_FOUND,
+          code: ApiErrorCode.RESOURCE_NOT_FOUND,
+          context: { userId, targetUserId, administrationId },
+        });
+      }
+
+      // 3. Verify target user has access to this administration
+      const targetHasAccess = await authorizationService.hasPermission(
+        targetUserId,
+        FgaRelation.CAN_LIST,
+        `${FgaType.ADMINISTRATION}:${administrationId}`,
+      );
+      if (!targetHasAccess) {
+        throw new ApiError(ApiErrorMessage.NOT_FOUND, {
+          statusCode: StatusCodes.NOT_FOUND,
+          code: ApiErrorCode.RESOURCE_NOT_FOUND,
+          context: { userId, targetUserId, administrationId },
+        });
+      }
+
+      // 4. Super admin or self-access → return immediately
+      if (isSuperAdmin || userId === targetUserId) {
+        return administration;
+      }
+
+      // 5. Verify requester has access to the administration
+      await authorizationService.requirePermission(
+        userId,
+        FgaRelation.CAN_READ,
+        `${FgaType.ADMINISTRATION}:${administrationId}`,
+      );
+
+      return administration;
+    } catch (error) {
+      if (error instanceof ApiError) throw error;
+
+      logger.error(
+        { err: error, context: { userId, targetUserId, administrationId } },
+        'Failed to get user administration',
+      );
+
+      throw new ApiError('Failed to retrieve user administration', {
+        statusCode: StatusCodes.INTERNAL_SERVER_ERROR,
+        code: ApiErrorCode.DATABASE_QUERY_FAILED,
+        context: { userId, targetUserId, administrationId },
+        cause: error,
+      });
+    }
+  }
+
   return {
     verifyAdministrationAccess,
     list,
@@ -1144,5 +1233,6 @@ export function AdministrationService({
     listAgreements,
     deleteById,
     listUserAdministrations,
+    getUserAdministration,
   };
 }

--- a/apps/backend/src/test-support/services/administration.service.ts
+++ b/apps/backend/src/test-support/services/administration.service.ts
@@ -19,6 +19,7 @@ export function createMockAdministrationService(): MockedObject<ReturnType<typeo
     listAgreements: vi.fn(),
     deleteById: vi.fn(),
     listUserAdministrations: vi.fn(),
+    getUserAdministration: vi.fn(),
   } as MockedObject<ReturnType<typeof AdministrationService>>;
 }
 

--- a/packages/api-contract/src/v1/users/contract.ts
+++ b/packages/api-contract/src/v1/users/contract.ts
@@ -7,7 +7,11 @@ import {
   RecordUserAgreementRequestBodySchema,
   RecordUserAgreementResponseSchema,
 } from './schema';
-import { AdministrationsListQuerySchema, AdministrationsListResponseSchema } from '../administrations/schema';
+import {
+  AdministrationBaseSchema,
+  AdministrationsListQuerySchema,
+  AdministrationsListResponseSchema,
+} from '../administrations/schema';
 
 const c = initContract();
 
@@ -118,6 +122,29 @@ export const UsersContract = c.router(
         "Supervisory users see the intersection of the target user's and their own accessible administrations. " +
         'Supervised roles receive 403. ' +
         'Returns 404 if the target user does not exist.',
+    },
+    getUserAdministration: {
+      method: 'GET',
+      path: '/:userId/administrations/:administrationId',
+      pathParams: z.object({
+        userId: z.string().uuid(),
+        administrationId: z.string().uuid(),
+      }),
+      responses: {
+        200: SuccessEnvelopeSchema(AdministrationBaseSchema),
+        401: ErrorEnvelopeSchema,
+        403: ErrorEnvelopeSchema,
+        404: ErrorEnvelopeSchema,
+        500: ErrorEnvelopeSchema,
+      },
+      strictStatusCodes: true,
+      summary: 'Get a single administration for a user',
+      description:
+        "Returns a single administration's details for the specified user. " +
+        'Verifies that the target user has access to the administration and ' +
+        'that the requester is authorized to view it. ' +
+        'Returns 404 if the user, administration, or user-administration assignment does not exist. ' +
+        'Returns 403 if the requester lacks permission.',
     },
   },
   { pathPrefix: '/users' },


### PR DESCRIPTION
## Summary

This PR adds the detail counterpart to the list endpoint in #1691. It returns a single administration's details for a specific user, verifying that both the target user has access to the administration and the requester is authorized to view it. Authorization uses OpenFGA. Implemented across all 5 layers.

### Contract

Adds `getUserAdministration` to the users contract:

- `GET /users/:userId/administrations/:administrationId`
- Path params: `userId` (UUID) + `administrationId` (UUID)
- Response: `SuccessEnvelopeSchema(AdministrationBaseSchema)` — same shape as `GET /administrations/:id`
- Includes 401, 403, 404, 500 error responses with `strictStatusCodes: true`

### Service — authorization flow

`getUserAdministration(authContext, targetUserId, administrationId)`:

1. **Target user exists** — 404 if not found
2. **Administration exists** — 404 if not found
3. **Target user has FGA access** — `authorizationService.hasPermission(targetUserId, CAN_LIST, administration:{id})` → 404 if false
4. **Super admin or self-access** — return immediately, no requester check
5. **Requester authorization** — `authorizationService.requirePermission(userId, CAN_READ, administration:{id})` → 403 if denied

### Repository

No new repository methods. The service uses `getById()` (inherited from `BaseRepository`) for existence checks, and FGA handles all authorization externally.

### Controller

Reuses `transformAdministrationBase` from `controllers/utils/administration.transform.ts` for the response transform. Returns the base schema (no embeds).

### Route

Registered with `AuthGuardMiddleware`. Passes `user!`, `userId`, and `administrationId` to controller.

## Review focus

- **404-before-403 ordering:** The service checks existence (user, administration) and target user access before checking requester authorization. A missing resource always returns 404, never 403.
- **`hasPermission` vs `requirePermission`:** Target user access uses `hasPermission` (returns boolean, mapped to 404). Requester access uses `requirePermission` (throws 403 directly).
- **Self-access shortcut:** When `userId === targetUserId`, the requester permission check is skipped since the target access check already confirmed the user can see the administration.

Resolves [1741](https://github.com/yeatmanlab/roar-project-management/issues/1741)

## Types of changes

What types of changes does this pull request introduce?

<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (non-breaking change that does not add functionality but makes code cleaner or more efficient)
- [ ] Documentation Update
- [x] Tests (new or updated tests)
- [ ] Style (changes to code styling)
- [ ] CI (continuous integration changes)
- [ ] Repository Maintenance
- [ ] Other (please describe below)

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask.  We're here
to help! This is simply a reminder of what we are going to look for before
merging your code.
-->

- [x] I have read the [guidelines for contributing](https://github.com/yeatmanlab/roar-dashboard/blob/main/.github/CONTRIBUTING.md).
- [x] The changes in this PR are as small as they can be. They represent one and only one fix or enhancement.
- [x] Linting checks pass with my changes.
- [x] Any existing unit tests pass with my changes.
- [x] Any existing end-to-end tests pass with my changes.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] If this PR fixes an existing issue, I have added a unit or end-to-end test that will detect if this issue reoccurs.
- [x] I have added JSDoc comments as appropriate.
- [ ] I have added the necessary documentation to the [roar-docs repository](https://github.com/yeatmanlab/roar-docs).
- [x] I have shared this PR on the roar-pr-reviews channel (if I have access)
- [x] I have linked relevant issues (if any)