### PR TITLE
Add `GET /administrations/:administrationId/reports/scores/overview`

### DIFF
--- a/apps/backend/src/controllers/administrations.controller.test.ts
+++ b/apps/backend/src/controllers/administrations.controller.test.ts
@@ -6,7 +6,12 @@ import {
 } from '../test-support/factories/administration.factory';
 import { AgreementFactory } from '../test-support/factories/agreement.factory';
 import { AgreementVersionFactory } from '../test-support/factories/agreement-version.factory';
-import type { ProgressStudentsQuery, ReportTaskMetadata, ProgressStudent } from '@roar-dashboard/api-contract';
+import type {
+  ProgressStudentsQuery,
+  ReportTaskMetadata,
+  ProgressStudent,
+  ScoreOverviewQuery,
+} from '@roar-dashboard/api-contract';
 import { ApiError } from '../errors/api-error';
 import { ApiErrorCode } from '../enums/api-error-code.enum';
 
@@ -1447,6 +1452,108 @@ describe('AdministrationsController', () => {
       await Controller.getProgressOverview(mockAuthContext, testAdminId, testQuery);
 
       expect(mockGetProgressOverview).toHaveBeenCalledWith(mockAuthContext, testAdminId, testQuery);
+    });
+  });
+
+  describe('getScoreOverview', () => {
+    const testAdminId = 'admin-uuid-1';
+
+    const scoreQuery: ScoreOverviewQuery = {
+      scopeType: 'district',
+      scopeId: 'district-uuid-1',
+      filter: [],
+    };
+
+    const testScoreResult = {
+      totalStudents: 100,
+      tasks: [
+        {
+          taskId: 'task-1',
+          taskSlug: 'swr',
+          taskName: 'ROAR - Word',
+          orderIndex: 0,
+          totalAssessed: 80,
+          totalNotAssessed: { required: 15, optional: 5 },
+          supportLevels: {
+            achievedSkill: { count: 40, percentage: 50.0 },
+            developingSkill: { count: 25, percentage: 31.3 },
+            needsExtraSupport: { count: 15, percentage: 18.8 },
+          },
+        },
+      ],
+      computedAt: '2025-09-16T12:00:00.000Z',
+    };
+
+    it('returns 200 with score overview data', async () => {
+      mockGetScoreOverview.mockResolvedValue(testScoreResult);
+
+      const { AdministrationsController: Controller } = await import('./administrations.controller');
+      const result = await Controller.getScoreOverview(mockAuthContext, testAdminId, scoreQuery);
+
+      const data = expectOkResponse(result);
+      expect(data.totalStudents).toBe(100);
+      expect(data.tasks).toHaveLength(1);
+      expect(data.tasks[0]!.supportLevels.achievedSkill.count).toBe(40);
+      expect(data.computedAt).toBe('2025-09-16T12:00:00.000Z');
+    });
+
+    it('maps ApiError to typed error response for 404', async () => {
+      mockGetScoreOverview.mockRejectedValue(
+        new ApiError('Not found', {
+          statusCode: StatusCodes.NOT_FOUND,
+          code: ApiErrorCode.RESOURCE_NOT_FOUND,
+        }),
+      );
+
+      const { AdministrationsController: Controller } = await import('./administrations.controller');
+      const result = await Controller.getScoreOverview(mockAuthContext, testAdminId, scoreQuery);
+
+      expect(result.status).toBe(StatusCodes.NOT_FOUND);
+    });
+
+    it('maps ApiError to typed error response for 403', async () => {
+      mockGetScoreOverview.mockRejectedValue(
+        new ApiError('Forbidden', {
+          statusCode: StatusCodes.FORBIDDEN,
+          code: ApiErrorCode.AUTH_FORBIDDEN,
+        }),
+      );
+
+      const { AdministrationsController: Controller } = await import('./administrations.controller');
+      const result = await Controller.getScoreOverview(mockAuthContext, testAdminId, scoreQuery);
+
+      expect(result.status).toBe(StatusCodes.FORBIDDEN);
+    });
+
+    it('maps ApiError to typed error response for 400', async () => {
+      mockGetScoreOverview.mockRejectedValue(
+        new ApiError('Bad request', {
+          statusCode: StatusCodes.BAD_REQUEST,
+          code: ApiErrorCode.REQUEST_VALIDATION_FAILED,
+        }),
+      );
+
+      const { AdministrationsController: Controller } = await import('./administrations.controller');
+      const result = await Controller.getScoreOverview(mockAuthContext, testAdminId, scoreQuery);
+
+      expect(result.status).toBe(StatusCodes.BAD_REQUEST);
+    });
+
+    it('re-throws non-ApiError errors', async () => {
+      mockGetScoreOverview.mockRejectedValue(new Error('unexpected'));
+
+      const { AdministrationsController: Controller } = await import('./administrations.controller');
+
+      await expect(Controller.getScoreOverview(mockAuthContext, testAdminId, scoreQuery)).rejects.toThrow('unexpected');
+    });
+
+    it('passes authContext, administrationId, and query to service', async () => {
+      mockGetScoreOverview.mockResolvedValue(testScoreResult);
+
+      const { AdministrationsController: Controller } = await import('./administrations.controller');
+      await Controller.getScoreOverview(mockAuthContext, testAdminId, scoreQuery);
+
+      expect(mockGetScoreOverview).toHaveBeenCalledWith(mockAuthContext, testAdminId, scoreQuery);
     });
   });
 });

--- a/apps/backend/src/controllers/administrations.controller.test.ts
+++ b/apps/backend/src/controllers/administrations.controller.test.ts
@@ -1911,9 +1911,9 @@ describe('AdministrationsController', () => {
           totalAssessed: 80,
           totalNotAssessed: { required: 15, optional: 5 },
           supportLevels: {
-            achievedSkill: { count: 40, percentage: 50.0 },
-            developingSkill: { count: 25, percentage: 31.3 },
-            needsExtraSupport: { count: 15, percentage: 18.8 },
+            achievedSkill: { count: 40 },
+            developingSkill: { count: 25 },
+            needsExtraSupport: { count: 15 },
           },
         },
       ],

--- a/apps/backend/src/controllers/administrations.controller.test.ts
+++ b/apps/backend/src/controllers/administrations.controller.test.ts
@@ -43,6 +43,7 @@ describe('AdministrationsController', () => {
   const mockDeleteById = vi.fn();
   const mockListProgressStudents = vi.fn();
   const mockGetProgressOverview = vi.fn();
+  const mockGetScoreOverview = vi.fn();
   const mockAuthContext = { userId: 'user-123', isSuperAdmin: false };
 
   beforeEach(() => {
@@ -62,6 +63,7 @@ describe('AdministrationsController', () => {
     vi.mocked(ReportService).mockReturnValue({
       listProgressStudents: mockListProgressStudents,
       getProgressOverview: mockGetProgressOverview,
+      getScoreOverview: mockGetScoreOverview,
     });
   });
   describe('list', () => {

--- a/apps/backend/src/controllers/administrations.controller.test.ts
+++ b/apps/backend/src/controllers/administrations.controller.test.ts
@@ -1539,6 +1539,20 @@ describe('AdministrationsController', () => {
       expect(result.status).toBe(StatusCodes.BAD_REQUEST);
     });
 
+    it('maps ApiError to typed error response for 500', async () => {
+      mockGetScoreOverview.mockRejectedValue(
+        new ApiError('Internal server error', {
+          statusCode: StatusCodes.INTERNAL_SERVER_ERROR,
+          code: ApiErrorCode.DATABASE_QUERY_FAILED,
+        }),
+      );
+
+      const { AdministrationsController: Controller } = await import('./administrations.controller');
+      const result = await Controller.getScoreOverview(mockAuthContext, testAdminId, scoreQuery);
+
+      expect(result.status).toBe(StatusCodes.INTERNAL_SERVER_ERROR);
+    });
+
     it('re-throws non-ApiError errors', async () => {
       mockGetScoreOverview.mockRejectedValue(new Error('unexpected'));
 

--- a/apps/backend/src/controllers/administrations.controller.ts
+++ b/apps/backend/src/controllers/administrations.controller.ts
@@ -17,6 +17,7 @@ import type {
   ProgressOverviewQuery,
   ReportTaskMetadata,
   ProgressStudent,
+  ScoreOverviewQuery,
 } from '@roar-dashboard/api-contract';
 import type { Administration } from '../db/schema';
 import type {
@@ -437,6 +438,40 @@ export const AdministrationsController = {
   getProgressOverview: async (authContext: AuthContext, administrationId: string, query: ProgressOverviewQuery) => {
     try {
       const result = await reportService.getProgressOverview(authContext, administrationId, query);
+
+      return {
+        status: StatusCodes.OK as const,
+        body: {
+          data: result,
+        },
+      };
+    } catch (error) {
+      if (error instanceof ApiError) {
+        return toErrorResponse(error, [
+          StatusCodes.BAD_REQUEST,
+          StatusCodes.FORBIDDEN,
+          StatusCodes.NOT_FOUND,
+          StatusCodes.INTERNAL_SERVER_ERROR,
+        ]);
+      }
+      throw error;
+    }
+  },
+
+  /**
+   * Get aggregated score overview for an administration.
+   *
+   * Delegates to ReportService for authorization and aggregation.
+   * Service and contract types are structurally identical, so the result is
+   * returned directly with no transformation.
+   *
+   * @param authContext - User's auth context
+   * @param administrationId - The administration to report on
+   * @param query - Query parameters (scopeType, scopeId, optional filter)
+   */
+  getScoreOverview: async (authContext: AuthContext, administrationId: string, query: ScoreOverviewQuery) => {
+    try {
+      const result = await reportService.getScoreOverview(authContext, administrationId, query);
 
       return {
         status: StatusCodes.OK as const,

--- a/apps/backend/src/controllers/administrations.controller.ts
+++ b/apps/backend/src/controllers/administrations.controller.ts
@@ -462,8 +462,12 @@ export const AdministrationsController = {
    * Get aggregated score overview for an administration.
    *
    * Delegates to ReportService for authorization and aggregation.
-   * Service and contract types are structurally identical, so the result is
-   * returned directly with no transformation.
+   * The service's `ScoreOverviewResult` and the contract's `ScoreOverviewResponseSchema`
+   * are kept structurally equivalent (same field names and types: totalStudents,
+   * tasks[], computedAt) so the result can be returned directly without an explicit
+   * transform. Type compatibility is enforced at compile time via TypeScript's
+   * structural typing — see `report.types.ts` and the contract schema for the
+   * source of truth on each side.
    *
    * @param authContext - User's auth context
    * @param administrationId - The administration to report on

--- a/apps/backend/src/repositories/report.repository.ts
+++ b/apps/backend/src/repositories/report.repository.ts
@@ -19,6 +19,7 @@ import {
 import type * as CoreDbSchema from '../db/schema/core';
 import { CoreDbClient } from '../db/clients';
 import { fdwRuns } from '../db/schema/assessment-fdw/runs';
+import { fdwRunScores } from '../db/schema/assessment-fdw/run-scores';
 import { SortOrder } from '@roar-dashboard/api-contract';
 import type { ScopeType } from '../services/report/report.types';
 import { conditionToSql } from '../utils/condition-to-sql';
@@ -146,6 +147,35 @@ export interface StudentAssignmentLevelCounts {
   studentsAssigned: number;
   studentsStarted: number;
   studentsCompleted: number;
+}
+
+/**
+ * Raw student data for score overview aggregation.
+ * Includes demographic fields for condition evaluation and grade for scoring.
+ */
+export interface StudentOverviewRow {
+  userId: string;
+  grade: string | null;
+  statusEll: string | null;
+  statusIep: string | null;
+  statusFrl: string | null;
+  dob: string | null;
+  gender: string | null;
+  race: string | null;
+  hispanicEthnicity: boolean | null;
+  homeLanguage: string | null;
+}
+
+/**
+ * Raw run score row from the FDW run_scores table.
+ * The service layer resolves these into percentile/rawScore values via the
+ * scoring service's task-specific field mappings.
+ */
+export interface RunScoreRow {
+  userId: string;
+  taskVariantId: string;
+  scoreName: string;
+  scoreValue: string;
 }
 
 /**
@@ -1229,5 +1259,97 @@ export class ReportRepository {
       WHEN (${assignmentSql}) THEN 1
       ELSE -1
     END`;
+  }
+
+  /**
+   * Get all students in scope with demographic fields for score overview aggregation.
+   * Returns all students (no pagination) so the overview can aggregate across the full population.
+   *
+   * @param scope - The scope to query students within
+   * @param filterCondition - Optional SQL filter condition (must reference users table columns only)
+   * @returns Total student count and all student rows with demographic data
+   */
+  async getAllStudentsInScope(
+    scope: ReportScope,
+    filterCondition?: SQL,
+  ): Promise<{ totalStudents: number; students: StudentOverviewRow[] }> {
+    const studentsInScope = this.buildStudentInScopeQuery(scope).as('students_in_scope');
+
+    const [countRow] = await this.db
+      .select({ total: countDistinct(users.id) })
+      .from(users)
+      .innerJoin(studentsInScope, eq(users.id, studentsInScope.userId))
+      .where(filterCondition);
+
+    const totalStudents = countRow?.total ?? 0;
+
+    if (totalStudents === 0) {
+      return { totalStudents: 0, students: [] };
+    }
+
+    const studentRows = await this.db
+      .selectDistinct({
+        userId: users.id,
+        grade: users.grade,
+        statusEll: users.statusEll,
+        statusIep: users.statusIep,
+        statusFrl: users.statusFrl,
+        dob: users.dob,
+        gender: users.gender,
+        race: users.race,
+        hispanicEthnicity: users.hispanicEthnicity,
+        homeLanguage: users.homeLanguage,
+      })
+      .from(users)
+      .innerJoin(studentsInScope, eq(users.id, studentsInScope.userId))
+      .where(filterCondition);
+
+    return { totalStudents, students: studentRows };
+  }
+
+  /**
+   * Bulk fetch completed run scores for a set of students and task variants.
+   * Returns raw score rows (scoreName + scoreValue) that the service layer
+   * resolves into percentile/rawScore using task-specific field mappings.
+   *
+   * Filters: completed runs only (completedAt IS NOT NULL), non-aborted, non-deleted,
+   * reporting-eligible. Mirrors the run filters used in `getProgressStudents`.
+   *
+   * @param administrationId - The administration ID
+   * @param studentIds - Student user IDs to fetch scores for
+   * @param taskVariantIds - Task variant IDs to fetch scores for
+   * @returns Array of raw score rows
+   */
+  async getCompletedRunScores(
+    administrationId: string,
+    studentIds: string[],
+    taskVariantIds: string[],
+  ): Promise<RunScoreRow[]> {
+    if (studentIds.length === 0 || taskVariantIds.length === 0) {
+      return [];
+    }
+
+    const rows = await this.db
+      .select({
+        userId: fdwRuns.userId,
+        taskVariantId: fdwRuns.taskVariantId,
+        scoreName: fdwRunScores.name,
+        scoreValue: fdwRunScores.value,
+      })
+      .from(fdwRuns)
+      .innerJoin(fdwRunScores, eq(fdwRuns.id, fdwRunScores.runId))
+      .where(
+        and(
+          eq(fdwRuns.administrationId, administrationId),
+          inArray(fdwRuns.userId, studentIds),
+          inArray(fdwRuns.taskVariantId, taskVariantIds),
+          isNull(fdwRuns.deletedAt),
+          isNull(fdwRuns.abortedAt),
+          eq(fdwRuns.useForReporting, true),
+          isNotNull(fdwRuns.completedAt),
+        ),
+      );
+
+    return rows;
   }
 }

--- a/apps/backend/src/repositories/report.repository.ts
+++ b/apps/backend/src/repositories/report.repository.ts
@@ -1315,6 +1315,16 @@ export class ReportRepository {
    * Filters: completed runs only (completedAt IS NOT NULL), non-aborted, non-deleted,
    * reporting-eligible. Mirrors the run filters used in `getProgressStudents`.
    *
+   * Run-level dedup: this query does not de-duplicate at the run level — it returns
+   * every score row for every matching run. The caller (`buildScoreLookup`) folds
+   * scores into a `userId → taskVariantId → scoreName → value` map, with last-row-wins
+   * on duplicate `(userId, taskVariantId, scoreName)` triples. That is correct only
+   * if the assessment side guarantees at most one `useForReporting=true`,
+   * non-aborted, non-deleted completed run per (user, variant). If that invariant
+   * is ever broken, multi-run scoring will silently pick the last-fetched row's
+   * value rather than e.g. the most recent one — surface this assumption here so
+   * any future change to assessment-side run lifecycle gets reviewed against it.
+   *
    * @param administrationId - The administration ID
    * @param studentIds - Student user IDs to fetch scores for
    * @param taskVariantIds - Task variant IDs to fetch scores for

--- a/apps/backend/src/repositories/report.repository.ts
+++ b/apps/backend/src/repositories/report.repository.ts
@@ -1265,6 +1265,16 @@ export class ReportRepository {
    * Get all students in scope with demographic fields for score overview aggregation.
    * Returns all students (no pagination) so the overview can aggregate across the full population.
    *
+   * Implementation note: this method runs two queries — a `COUNT DISTINCT` for
+   * `totalStudents` followed by a `SELECT DISTINCT` for the row data. Between
+   * the two calls the underlying population could change (a roster sync, a
+   * `rosteringEnded` update, or a concurrent admin-assignment edit), which
+   * would let the returned `totalStudents` diverge from `students.length` by
+   * a small amount. The window is very short and the worst case is an off-by-N
+   * on the count for one request — acceptable for an aggregation endpoint that
+   * already presents instantaneous snapshots. Wrap in a transaction with
+   * `REPEATABLE READ` if precision tightens.
+   *
    * @param scope - The scope to query students within
    * @param filterCondition - Optional SQL filter condition (must reference users table columns only)
    * @returns Total student count and all student rows with demographic data

--- a/apps/backend/src/routes/administrations.ts
+++ b/apps/backend/src/routes/administrations.ts
@@ -60,6 +60,14 @@ export function registerAdministrationsRoutes(routerInstance: Router) {
           AdministrationsController.getProgressOverview(user!, id, query),
       },
     },
+    scoreReports: {
+      getOverview: {
+        // @ts-expect-error - Express v4/v5 types mismatch in monorepo
+        middleware: [AuthGuardMiddleware],
+        handler: async ({ req: { user }, params: { id }, query }) =>
+          AdministrationsController.getScoreOverview(user!, id, query),
+      },
+    },
   });
 
   // @ts-expect-error - Express v4/v5 types mismatch in monorepo

--- a/apps/backend/src/routes/reports.integration.test.ts
+++ b/apps/backend/src/routes/reports.integration.test.ts
@@ -1538,6 +1538,22 @@ describe('GET /v1/administrations/:id/reports/scores/overview', () => {
 
       expect(res.status).toBe(StatusCodes.FORBIDDEN);
     });
+
+    it('returns 403 when class teacher requests school scope', async () => {
+      // FGA can_read_scores at the school level requires school_admin_tier or higher.
+      // A class teacher's tuples don't propagate up to the school, so the request is denied.
+      authenticateAs(baseFixture.classATeacher);
+      const res = await request(app)
+        .get(scoreOverviewPath(baseFixture.administrationAssignedToSchoolA.id))
+        .query({
+          scopeType: 'school',
+          scopeId: baseFixture.schoolA.id,
+        })
+        .set('Authorization', 'Bearer token');
+
+      expect(res.status).toBe(StatusCodes.FORBIDDEN);
+      expect(res.body.error.code).toBe(ApiErrorCode.AUTH_FORBIDDEN);
+    });
   });
 
   describe('scope validation', () => {
@@ -1693,6 +1709,62 @@ describe('GET /v1/administrations/:id/reports/scores/overview', () => {
       expect(typeof data.totalStudents).toBe('number');
       expect(data.totalStudents).toBeGreaterThanOrEqual(0);
     });
+
+    it('deduplicates multi-variant tasks into one entry per taskId', async () => {
+      // The fixture assigns 4 variants of `task` (variantForAllGrades, variantForGrade5,
+      // variantForGrade3, variantOptionalForEll) and 2 variants of `task2` to
+      // administrationAssignedToDistrict. Without dedup we would see 6 entries; with
+      // dedup we expect exactly 2 (one per unique taskId).
+      authenticateAs(tiers.superAdmin);
+      const res = await request(app)
+        .get(scoreOverviewPath(baseFixture.administrationAssignedToDistrict.id))
+        .query(scoreOverviewQuery())
+        .set('Authorization', 'Bearer token');
+
+      expect(res.status).toBe(StatusCodes.OK);
+
+      const { data } = res.body;
+      const uniqueTaskIds = new Set(data.tasks.map((t: { taskId: string }) => t.taskId));
+      expect(uniqueTaskIds.size).toBe(data.tasks.length);
+      expect(uniqueTaskIds).toEqual(new Set([baseFixture.task.id, baseFixture.task2.id]));
+    });
+
+    it('returns 200 for class scope', async () => {
+      authenticateAs(tiers.superAdmin);
+      const res = await request(app)
+        .get(scoreOverviewPath(baseFixture.administrationAssignedToClassA.id))
+        .query({
+          scopeType: 'class',
+          scopeId: baseFixture.classInSchoolA.id,
+        })
+        .set('Authorization', 'Bearer token');
+
+      expect(res.status).toBe(StatusCodes.OK);
+
+      const { data } = res.body;
+      expect(data).toHaveProperty('totalStudents');
+      expect(data).toHaveProperty('tasks');
+      expect(data).toHaveProperty('computedAt');
+    });
+
+    it('returns 200 for group scope', async () => {
+      authenticateAs(tiers.superAdmin);
+      const res = await request(app)
+        .get(scoreOverviewPath(baseFixture.administrationAssignedToGroup.id))
+        .query({
+          scopeType: 'group',
+          scopeId: baseFixture.group.id,
+        })
+        .set('Authorization', 'Bearer token');
+
+      expect(res.status).toBe(StatusCodes.OK);
+
+      const { data } = res.body;
+      expect(data).toHaveProperty('totalStudents');
+      expect(data).toHaveProperty('tasks');
+      // The group administration has no task variants assigned — tasks should be empty
+      expect(data.tasks).toHaveLength(0);
+    });
   });
 
   describe('FDW-backed aggregation', () => {
@@ -1731,6 +1803,28 @@ describe('GET /v1/administrations/:id/reports/scores/overview', () => {
       expect(taskOverview).toBeDefined();
       // At least the seeded student should be assessed
       expect(taskOverview!.totalAssessed).toBeGreaterThanOrEqual(1);
+    });
+
+    it('counts students without completed runs in totalNotAssessed', async () => {
+      // The district contains more students than the single seeded grade5Student.
+      // Every other student has no completed run with scores for `task`, so they
+      // should appear in totalNotAssessed (required or optional, depending on
+      // condition evaluation).
+      authenticateAs(tiers.superAdmin);
+      const res = await request(app)
+        .get(scoreOverviewPath(baseFixture.administrationAssignedToDistrict.id))
+        .query(scoreOverviewQuery())
+        .set('Authorization', 'Bearer token');
+
+      expect(res.status).toBe(StatusCodes.OK);
+
+      const { data } = res.body;
+      const taskOverview = data.tasks.find((t: { taskId: string }) => t.taskId === baseFixture.task.id);
+      expect(taskOverview).toBeDefined();
+      const notAssessedTotal = taskOverview!.totalNotAssessed.required + taskOverview!.totalNotAssessed.optional;
+      expect(notAssessedTotal).toBeGreaterThan(0);
+      // Every assigned student is either assessed or not-assessed — never both.
+      expect(taskOverview!.totalAssessed + notAssessedTotal).toBeLessThanOrEqual(data.totalStudents);
     });
   });
 });

--- a/apps/backend/src/routes/reports.integration.test.ts
+++ b/apps/backend/src/routes/reports.integration.test.ts
@@ -1647,7 +1647,6 @@ describe('GET /v1/administrations/:id/reports/scores/overview', () => {
       expect(firstTask.supportLevels).toHaveProperty('developingSkill');
       expect(firstTask.supportLevels).toHaveProperty('needsExtraSupport');
       expect(firstTask.supportLevels.achievedSkill).toHaveProperty('count');
-      expect(firstTask.supportLevels.achievedSkill).toHaveProperty('percentage');
     });
 
     it('per-task counts are internally consistent', async () => {
@@ -1671,15 +1670,6 @@ describe('GET /v1/administrations/:id/reports/scores/overview', () => {
         // Total students engaged with the task cannot exceed totalStudents
         const totalEngaged = task.totalAssessed + task.totalNotAssessed.required + task.totalNotAssessed.optional;
         expect(totalEngaged).toBeLessThanOrEqual(data.totalStudents);
-
-        // Percentages are 0-100 with at most 1 decimal place
-        for (const level of ['achievedSkill', 'developingSkill', 'needsExtraSupport'] as const) {
-          const pct = task.supportLevels[level].percentage;
-          expect(pct).toBeGreaterThanOrEqual(0);
-          expect(pct).toBeLessThanOrEqual(100);
-          // Round to 1 decimal: pct * 10 should be an integer
-          expect(Math.round(pct * 10)).toBeCloseTo(pct * 10);
-        }
       }
     });
 

--- a/apps/backend/src/routes/reports.integration.test.ts
+++ b/apps/backend/src/routes/reports.integration.test.ts
@@ -16,6 +16,7 @@ import type { TierUsers } from '../test-support/route-test.helper';
 import { baseFixture } from '../test-support/fixtures';
 import { ApiErrorCode } from '../enums/api-error-code.enum';
 import { RunFactory } from '../test-support/factories/run.factory';
+import { RunScoreFactory } from '../test-support/factories/run-score.factory';
 
 // ═══════════════════════════════════════════════════════════════════════════
 // Test setup
@@ -33,6 +34,11 @@ function progressStudentsPath(administrationId: string) {
 /** Builds the progress overview endpoint path for the given administration. */
 function progressOverviewPath(administrationId: string) {
   return `/v1/administrations/${administrationId}/reports/progress/overview`;
+}
+
+/** Builds the score overview endpoint path for the given administration. */
+function scoreOverviewPath(administrationId: string) {
+  return `/v1/administrations/${administrationId}/reports/scores/overview`;
 }
 
 /** Default query params for a valid request. */
@@ -1415,6 +1421,316 @@ describe('GET /v1/administrations/:id/reports/progress/overview', () => {
       expect(data).toHaveProperty('byTask');
       // Group administration has no task variants — byTask is empty but query succeeds
       expect(data.byTask).toHaveLength(0);
+    });
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// GET /v1/administrations/:id/reports/scores/overview
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('GET /v1/administrations/:id/reports/scores/overview', () => {
+  /** Default query params for a valid score overview request. */
+  function scoreOverviewQuery() {
+    return {
+      scopeType: 'district',
+      scopeId: baseFixture.district.id,
+    };
+  }
+
+  describe('authorization', () => {
+    it('returns 401 without auth', async () => {
+      const res = await expectRoute('GET', scoreOverviewPath(baseFixture.administrationAssignedToDistrict.id))
+        .unauthenticated()
+        .toReturn(401);
+
+      expect(res.body.error.code).toBe(ApiErrorCode.AUTH_REQUIRED);
+    });
+
+    it('super admin can access', async () => {
+      authenticateAs(tiers.superAdmin);
+      const res = await request(app)
+        .get(scoreOverviewPath(baseFixture.administrationAssignedToDistrict.id))
+        .query(scoreOverviewQuery())
+        .set('Authorization', 'Bearer token');
+
+      expect(res.status).toBe(StatusCodes.OK);
+      expect(res.body.data).toBeDefined();
+    });
+
+    it('admin (administrator role) at district can access', async () => {
+      authenticateAs(tiers.admin);
+      const res = await request(app)
+        .get(scoreOverviewPath(baseFixture.administrationAssignedToDistrict.id))
+        .query(scoreOverviewQuery())
+        .set('Authorization', 'Bearer token');
+
+      expect(res.status).toBe(StatusCodes.OK);
+      expect(res.body.data).toBeDefined();
+    });
+
+    it('educator (teacher role) at district is forbidden from reading scores at district scope', async () => {
+      // District can_read_scores is restricted to admin_tier only.
+      authenticateAs(tiers.educator);
+      const res = await request(app)
+        .get(scoreOverviewPath(baseFixture.administrationAssignedToDistrict.id))
+        .query(scoreOverviewQuery())
+        .set('Authorization', 'Bearer token');
+
+      expect(res.status).toBe(StatusCodes.FORBIDDEN);
+    });
+
+    it('principal at school A can read score overview at school scope', async () => {
+      authenticateAs(baseFixture.schoolAPrincipal);
+      const res = await request(app)
+        .get(scoreOverviewPath(baseFixture.administrationAssignedToSchoolA.id))
+        .query({
+          scopeType: 'school',
+          scopeId: baseFixture.schoolA.id,
+        })
+        .set('Authorization', 'Bearer token');
+
+      expect(res.status).toBe(StatusCodes.OK);
+      expect(res.body.data).toBeDefined();
+    });
+
+    it('principal at school A is forbidden from reading score overview at district scope', async () => {
+      authenticateAs(baseFixture.schoolAPrincipal);
+      const res = await request(app)
+        .get(scoreOverviewPath(baseFixture.administrationAssignedToDistrict.id))
+        .query(scoreOverviewQuery())
+        .set('Authorization', 'Bearer token');
+
+      expect(res.status).toBe(StatusCodes.FORBIDDEN);
+    });
+
+    it('student tier returns 403', async () => {
+      authenticateAs(tiers.student);
+      const res = await request(app)
+        .get(scoreOverviewPath(baseFixture.administrationAssignedToDistrict.id))
+        .query(scoreOverviewQuery())
+        .set('Authorization', 'Bearer token');
+
+      expect(res.status).toBe(StatusCodes.FORBIDDEN);
+      expect(res.body.error.code).toBe(ApiErrorCode.AUTH_FORBIDDEN);
+    });
+
+    it('caregiver tier returns 403', async () => {
+      authenticateAs(tiers.caregiver);
+      const res = await request(app)
+        .get(scoreOverviewPath(baseFixture.administrationAssignedToDistrict.id))
+        .query(scoreOverviewQuery())
+        .set('Authorization', 'Bearer token');
+
+      expect(res.status).toBe(StatusCodes.FORBIDDEN);
+      expect(res.body.error.code).toBe(ApiErrorCode.AUTH_FORBIDDEN);
+    });
+
+    it('returns 403 for admin in a different district', async () => {
+      authenticateAs(baseFixture.districtBAdmin);
+      const res = await request(app)
+        .get(scoreOverviewPath(baseFixture.administrationAssignedToSchoolA.id))
+        .query({
+          scopeType: 'school',
+          scopeId: baseFixture.schoolA.id,
+        })
+        .set('Authorization', 'Bearer token');
+
+      expect(res.status).toBe(StatusCodes.FORBIDDEN);
+    });
+  });
+
+  describe('scope validation', () => {
+    it('returns 400 for scope not assigned to administration', async () => {
+      authenticateAs(tiers.superAdmin);
+      const res = await request(app)
+        .get(scoreOverviewPath(baseFixture.administrationAssignedToSchoolA.id))
+        .query({
+          scopeType: 'school',
+          scopeId: baseFixture.schoolB.id,
+        })
+        .set('Authorization', 'Bearer token');
+
+      expect(res.status).toBe(StatusCodes.BAD_REQUEST);
+      expect(res.body.error.code).toBe(ApiErrorCode.REQUEST_VALIDATION_FAILED);
+    });
+
+    it('returns 400 when scopeType is missing', async () => {
+      authenticateAs(tiers.superAdmin);
+      const res = await request(app)
+        .get(scoreOverviewPath(baseFixture.administrationAssignedToDistrict.id))
+        .query({ scopeId: baseFixture.district.id })
+        .set('Authorization', 'Bearer token');
+
+      expect(res.status).toBe(StatusCodes.BAD_REQUEST);
+    });
+
+    it('returns 400 when scopeId is missing', async () => {
+      authenticateAs(tiers.superAdmin);
+      const res = await request(app)
+        .get(scoreOverviewPath(baseFixture.administrationAssignedToDistrict.id))
+        .query({ scopeType: 'district' })
+        .set('Authorization', 'Bearer token');
+
+      expect(res.status).toBe(StatusCodes.BAD_REQUEST);
+    });
+
+    it('returns 404 for non-existent administration', async () => {
+      authenticateAs(tiers.superAdmin);
+      const res = await request(app)
+        .get(scoreOverviewPath('00000000-0000-0000-0000-000000000000'))
+        .query(scoreOverviewQuery())
+        .set('Authorization', 'Bearer token');
+
+      expect(res.status).toBe(StatusCodes.NOT_FOUND);
+      expect(res.body.error.code).toBe(ApiErrorCode.RESOURCE_NOT_FOUND);
+    });
+  });
+
+  describe('response shape', () => {
+    it('returns 200 with correct response structure', async () => {
+      authenticateAs(tiers.superAdmin);
+      const res = await request(app)
+        .get(scoreOverviewPath(baseFixture.administrationAssignedToDistrict.id))
+        .query(scoreOverviewQuery())
+        .set('Authorization', 'Bearer token');
+
+      expect(res.status).toBe(StatusCodes.OK);
+
+      const { data } = res.body;
+      expect(data).toHaveProperty('totalStudents');
+      expect(data).toHaveProperty('tasks');
+      expect(data).toHaveProperty('computedAt');
+      expect(typeof data.totalStudents).toBe('number');
+      expect(typeof data.computedAt).toBe('string');
+      expect(data.tasks).toBeInstanceOf(Array);
+      expect(data.tasks.length).toBeGreaterThan(0);
+
+      const firstTask = data.tasks[0];
+      expect(firstTask).toHaveProperty('taskId');
+      expect(firstTask).toHaveProperty('taskSlug');
+      expect(firstTask).toHaveProperty('taskName');
+      expect(firstTask).toHaveProperty('orderIndex');
+      expect(firstTask).toHaveProperty('totalAssessed');
+      expect(firstTask).toHaveProperty('totalNotAssessed');
+      expect(firstTask.totalNotAssessed).toHaveProperty('required');
+      expect(firstTask.totalNotAssessed).toHaveProperty('optional');
+      expect(firstTask).toHaveProperty('supportLevels');
+      expect(firstTask.supportLevels).toHaveProperty('achievedSkill');
+      expect(firstTask.supportLevels).toHaveProperty('developingSkill');
+      expect(firstTask.supportLevels).toHaveProperty('needsExtraSupport');
+      expect(firstTask.supportLevels.achievedSkill).toHaveProperty('count');
+      expect(firstTask.supportLevels.achievedSkill).toHaveProperty('percentage');
+    });
+
+    it('per-task counts are internally consistent', async () => {
+      authenticateAs(tiers.superAdmin);
+      const res = await request(app)
+        .get(scoreOverviewPath(baseFixture.administrationAssignedToDistrict.id))
+        .query(scoreOverviewQuery())
+        .set('Authorization', 'Bearer token');
+
+      expect(res.status).toBe(StatusCodes.OK);
+
+      const { data } = res.body;
+      for (const task of data.tasks) {
+        // Sum of bucketed assessed students cannot exceed totalAssessed
+        const bucketedAssessed =
+          task.supportLevels.achievedSkill.count +
+          task.supportLevels.developingSkill.count +
+          task.supportLevels.needsExtraSupport.count;
+        expect(bucketedAssessed).toBeLessThanOrEqual(task.totalAssessed);
+
+        // Total students engaged with the task cannot exceed totalStudents
+        const totalEngaged = task.totalAssessed + task.totalNotAssessed.required + task.totalNotAssessed.optional;
+        expect(totalEngaged).toBeLessThanOrEqual(data.totalStudents);
+
+        // Percentages are 0-100 with at most 1 decimal place
+        for (const level of ['achievedSkill', 'developingSkill', 'needsExtraSupport'] as const) {
+          const pct = task.supportLevels[level].percentage;
+          expect(pct).toBeGreaterThanOrEqual(0);
+          expect(pct).toBeLessThanOrEqual(100);
+          // Round to 1 decimal: pct * 10 should be an integer
+          expect(Math.round(pct * 10)).toBeCloseTo(pct * 10);
+        }
+      }
+    });
+
+    it('filters tasks via taskId filter', async () => {
+      authenticateAs(tiers.superAdmin);
+      const res = await request(app)
+        .get(scoreOverviewPath(baseFixture.administrationAssignedToDistrict.id))
+        .query({
+          ...scoreOverviewQuery(),
+          filter: `taskId:in:${baseFixture.task.id}`,
+        })
+        .set('Authorization', 'Bearer token');
+
+      expect(res.status).toBe(StatusCodes.OK);
+
+      const { data } = res.body;
+      // All returned tasks share the filtered taskId (the fixture defines a single task,
+      // so this confirms the filter doesn't accidentally widen the set)
+      for (const task of data.tasks) {
+        expect(task.taskId).toBe(baseFixture.task.id);
+      }
+    });
+
+    it('filters student population via user.grade filter', async () => {
+      authenticateAs(tiers.superAdmin);
+      const res = await request(app)
+        .get(scoreOverviewPath(baseFixture.administrationAssignedToDistrict.id))
+        .query({
+          ...scoreOverviewQuery(),
+          filter: 'user.grade:eq:5',
+        })
+        .set('Authorization', 'Bearer token');
+
+      expect(res.status).toBe(StatusCodes.OK);
+
+      const { data } = res.body;
+      // grade-filtered population should be smaller than the unfiltered district set
+      expect(typeof data.totalStudents).toBe('number');
+      expect(data.totalStudents).toBeGreaterThanOrEqual(0);
+    });
+  });
+
+  describe('FDW-backed aggregation', () => {
+    // Seed a completed run + scores for grade5Student so totalAssessed is non-zero.
+    beforeAll(async () => {
+      const run = await RunFactory.create({
+        userId: baseFixture.grade5Student.id,
+        taskId: baseFixture.task.id,
+        taskVariantId: baseFixture.variantForAllGrades.id,
+        administrationId: baseFixture.administrationAssignedToDistrict.id,
+        useForReporting: true,
+        completedAt: new Date('2025-08-01T10:00:00Z'),
+      });
+
+      // Seed a percentile score so getSupportLevel can classify the student.
+      await RunScoreFactory.create({
+        runId: run.id,
+        type: 'computed',
+        domain: 'default',
+        name: 'percentile',
+        value: '90',
+      });
+    });
+
+    it('counts the seeded completed run in totalAssessed', async () => {
+      authenticateAs(tiers.superAdmin);
+      const res = await request(app)
+        .get(scoreOverviewPath(baseFixture.administrationAssignedToDistrict.id))
+        .query(scoreOverviewQuery())
+        .set('Authorization', 'Bearer token');
+
+      expect(res.status).toBe(StatusCodes.OK);
+
+      const { data } = res.body;
+      const taskOverview = data.tasks.find((t: { taskId: string }) => t.taskId === baseFixture.task.id);
+      expect(taskOverview).toBeDefined();
+      // At least the seeded student should be assessed
+      expect(taskOverview!.totalAssessed).toBeGreaterThanOrEqual(1);
     });
   });
 });

--- a/apps/backend/src/routes/reports.integration.test.ts
+++ b/apps/backend/src/routes/reports.integration.test.ts
@@ -1469,6 +1469,17 @@ describe('GET /v1/administrations/:id/reports/scores/overview', () => {
       expect(res.body.data).toBeDefined();
     });
 
+    it('site admin (site_administrator role) at district can access', async () => {
+      authenticateAs(tiers.siteAdmin);
+      const res = await request(app)
+        .get(scoreOverviewPath(baseFixture.administrationAssignedToDistrict.id))
+        .query(scoreOverviewQuery())
+        .set('Authorization', 'Bearer token');
+
+      expect(res.status).toBe(StatusCodes.OK);
+      expect(res.body.data).toBeDefined();
+    });
+
     it('educator (teacher role) at district is forbidden from reading scores at district scope', async () => {
       // District can_read_scores is restricted to admin_tier only.
       authenticateAs(tiers.educator);

--- a/apps/backend/src/services/report/report.service.test.ts
+++ b/apps/backend/src/services/report/report.service.test.ts
@@ -1377,7 +1377,7 @@ describe('ReportService', () => {
       for (const task of result.tasks) {
         expect(task.totalAssessed).toBe(0);
         expect(task.totalNotAssessed).toEqual({ required: 0, optional: 0 });
-        expect(task.supportLevels.achievedSkill).toEqual({ count: 0, percentage: 0 });
+        expect(task.supportLevels.achievedSkill).toEqual({ count: 0 });
       }
       expect(result.computedAt).toBeDefined();
     });
@@ -1478,28 +1478,6 @@ describe('ReportService', () => {
       expect(swrTask!.totalAssessed).toBe(0);
       expect(swrTask!.totalNotAssessed.required).toBe(0);
       expect(swrTask!.totalNotAssessed.optional).toBe(0);
-    });
-
-    it('rounds support level percentages to 1 decimal place', async () => {
-      const students = [
-        buildOverviewStudent({ userId: 's1', grade: '3' }),
-        buildOverviewStudent({ userId: 's2', grade: '3' }),
-        buildOverviewStudent({ userId: 's3', grade: '3' }),
-      ];
-
-      // All students get high percentile → all in achievedSkill (100%)
-      const scoreRows = students.map((s) => buildScoreRow(s.userId, VARIANT_ID_1, 'percentile', '90'));
-
-      setupDefaultScoreOverviewMocks(students, scoreRows);
-
-      const service = createService();
-      const result = await service.getScoreOverview(superAdminAuth, testAdministrationId, scoreQuery);
-
-      const swrTask = result.tasks.find((t) => t.taskId === TASK_ID_1);
-      expect(swrTask).toBeDefined();
-      expect(swrTask!.supportLevels.achievedSkill.percentage).toBe(100);
-      expect(swrTask!.supportLevels.developingSkill.percentage).toBe(0);
-      expect(swrTask!.supportLevels.needsExtraSupport.percentage).toBe(0);
     });
 
     // --- Multi-variant deduplication ---

--- a/apps/backend/src/services/report/report.service.test.ts
+++ b/apps/backend/src/services/report/report.service.test.ts
@@ -1729,7 +1729,9 @@ describe('ReportService', () => {
 
     it('returns empty tasks array when taskId filter excludes every task', async () => {
       // Filter targets a UUID not present in testTaskMetas — taskMetas becomes []
-      // and taskGroups.length === 0 triggers the short-circuit.
+      // and taskGroups.length === 0 triggers the short-circuit. Because the short-circuit
+      // is evaluated BEFORE the student-fetch DB call, getAllStudentsInScope is also skipped
+      // and the response carries totalStudents: 0 by definition (no tasks → no aggregation).
       const students = [buildOverviewStudent({ userId: 'student-1' })];
       setupDefaultScoreOverviewMocks(students, []);
 
@@ -1742,11 +1744,33 @@ describe('ReportService', () => {
       const result = await service.getScoreOverview(superAdminAuth, testAdministrationId, filteredQuery);
 
       expect(result.tasks).toHaveLength(0);
-      expect(result.totalStudents).toBe(1);
+      expect(result.totalStudents).toBe(0);
       expect(typeof result.computedAt).toBe('string');
-      // Short-circuit means we don't fetch scoring versions or run scores
+      // Short-circuit means we don't touch the student-fetch path or downstream queries
+      expect(mockReportRepository.getAllStudentsInScope).not.toHaveBeenCalled();
       expect(mockTaskVariantParameterRepository.getByTaskVariantIds).not.toHaveBeenCalled();
       expect(mockReportRepository.getCompletedRunScores).not.toHaveBeenCalled();
+    });
+
+    it('merges multiple taskId filter entries into a single allow-list', async () => {
+      // Two `taskId:in:...` filter entries should be unioned (not silently truncated to the first).
+      // The fixture has TASK_ID_1, TASK_ID_2, TASK_ID_3, TASK_ID_4 in testTaskMetas; we ask for
+      // ID_1 in the first entry and ID_3 in the second, expecting both back.
+      setupDefaultScoreOverviewMocks([buildOverviewStudent({ userId: 'student-1' })], []);
+
+      const filteredQuery: ScoreOverviewInput = {
+        ...scoreQuery,
+        filter: [
+          { field: 'taskId', operator: 'in', value: TASK_ID_1 },
+          { field: 'taskId', operator: 'in', value: TASK_ID_3 },
+        ],
+      };
+
+      const service = createService();
+      const result = await service.getScoreOverview(superAdminAuth, testAdministrationId, filteredQuery);
+
+      const returnedIds = new Set(result.tasks.map((t) => t.taskId));
+      expect(returnedIds).toEqual(new Set([TASK_ID_1, TASK_ID_3]));
     });
 
     // --- Multi-variant: any required → required (not optional) ---

--- a/apps/backend/src/services/report/report.service.test.ts
+++ b/apps/backend/src/services/report/report.service.test.ts
@@ -2,15 +2,25 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { StatusCodes } from 'http-status-codes';
 import { ReportService, buildProgressMap } from './report.service';
 import { AdministrationFactory } from '../../test-support/factories/administration.factory';
-import { createMockAdministrationRepository, createMockReportRepository } from '../../test-support/repositories';
+import {
+  createMockAdministrationRepository,
+  createMockReportRepository,
+  createMockTaskVariantParameterRepository,
+} from '../../test-support/repositories';
 import { createMockAuthorizationService, createMockTaskService } from '../../test-support/services';
 import type { MockAuthorizationService } from '../../test-support/services';
 import { ApiErrorCode } from '../../enums/api-error-code.enum';
 import { ApiErrorMessage } from '../../enums/api-error-message.enum';
 import { ApiError } from '../../errors/api-error';
 import { FgaType, FgaRelation } from '../authorization/fga-constants';
-import type { ProgressStudentsInput, ProgressOverviewInput } from './report.types';
-import type { ReportTaskMeta, StudentProgressRow, TaskStatusCount } from '../../repositories/report.repository';
+import type { ProgressStudentsInput, ProgressOverviewInput, ScoreOverviewInput } from './report.types';
+import type {
+  ReportTaskMeta,
+  StudentProgressRow,
+  StudentOverviewRow,
+  RunScoreRow,
+  TaskStatusCount,
+} from '../../repositories/report.repository';
 import { Operator } from '../../types/condition';
 
 /** Default demographic fields for test StudentProgressRow objects */
@@ -30,6 +40,7 @@ describe('ReportService', () => {
   let mockReportRepository: ReturnType<typeof createMockReportRepository>;
   let mockTaskService: ReturnType<typeof createMockTaskService>;
   let mockAuthorizationService: MockAuthorizationService;
+  let mockTaskVariantParameterRepository: ReturnType<typeof createMockTaskVariantParameterRepository>;
 
   const superAdminAuth = { userId: 'super-admin-id', isSuperAdmin: true };
   const teacherAuth = { userId: 'teacher-id', isSuperAdmin: false };
@@ -100,6 +111,7 @@ describe('ReportService', () => {
       reportRepository: mockReportRepository,
       taskService: mockTaskService,
       authorizationService: mockAuthorizationService,
+      taskVariantParameterRepository: mockTaskVariantParameterRepository,
     });
   }
 
@@ -109,6 +121,7 @@ describe('ReportService', () => {
     mockReportRepository = createMockReportRepository();
     mockTaskService = createMockTaskService();
     mockAuthorizationService = createMockAuthorizationService();
+    mockTaskVariantParameterRepository = createMockTaskVariantParameterRepository();
 
     // Default: administration exists
     mockAdministrationRepository.getById.mockResolvedValue(AdministrationFactory.build({ id: testAdministrationId }));
@@ -1216,6 +1229,500 @@ describe('ReportService', () => {
         { scopeType: 'district', scopeId: 'district-uuid-1' },
         testTaskMetas,
       );
+    });
+  });
+
+  describe('getScoreOverview', () => {
+    const scoreQuery: ScoreOverviewInput = {
+      scopeType: 'district',
+      scopeId: 'district-uuid-1',
+      filter: [],
+    };
+
+    /** Helper to build a StudentOverviewRow with default demographics. */
+    function buildOverviewStudent(overrides: Partial<StudentOverviewRow> & { userId: string }): StudentOverviewRow {
+      return {
+        grade: '3',
+        statusEll: null,
+        statusIep: null,
+        statusFrl: null,
+        dob: null,
+        gender: null,
+        race: null,
+        hispanicEthnicity: null,
+        homeLanguage: null,
+        ...overrides,
+      };
+    }
+
+    /** Helper to build a RunScoreRow. */
+    function buildScoreRow(userId: string, taskVariantId: string, scoreName: string, scoreValue: string): RunScoreRow {
+      return { userId, taskVariantId, scoreName, scoreValue };
+    }
+
+    /** Set up default mocks for a successful getScoreOverview call. */
+    function setupDefaultScoreOverviewMocks(
+      students: StudentOverviewRow[] = [buildOverviewStudent({ userId: 'student-1' })],
+      scoreRows: RunScoreRow[] = [],
+    ) {
+      mockReportRepository.getAllStudentsInScope.mockResolvedValue({
+        totalStudents: students.length,
+        students,
+      });
+      mockReportRepository.getCompletedRunScores.mockResolvedValue(scoreRows);
+      mockTaskVariantParameterRepository.getByTaskVariantIds.mockResolvedValue([]);
+    }
+
+    // --- Authorization (same shape as getProgressOverview, but checks CAN_READ_SCORES) ---
+
+    it('returns 404 when administration does not exist', async () => {
+      mockAdministrationRepository.getById.mockResolvedValue(null);
+
+      const service = createService();
+
+      await expect(service.getScoreOverview(teacherAuth, testAdministrationId, scoreQuery)).rejects.toMatchObject({
+        statusCode: StatusCodes.NOT_FOUND,
+        code: ApiErrorCode.RESOURCE_NOT_FOUND,
+      });
+    });
+
+    it('returns 403 when FGA denies can_read_scores on administration', async () => {
+      mockAuthorizationService.requirePermission.mockRejectedValue(
+        new ApiError(ApiErrorMessage.FORBIDDEN, {
+          statusCode: StatusCodes.FORBIDDEN,
+          code: ApiErrorCode.AUTH_FORBIDDEN,
+        }),
+      );
+
+      const service = createService();
+
+      await expect(service.getScoreOverview(teacherAuth, testAdministrationId, scoreQuery)).rejects.toMatchObject({
+        statusCode: StatusCodes.FORBIDDEN,
+        code: ApiErrorCode.AUTH_FORBIDDEN,
+      });
+
+      expect(mockAuthorizationService.requirePermission).toHaveBeenCalledWith(
+        teacherAuth.userId,
+        FgaRelation.CAN_READ_SCORES,
+        `${FgaType.ADMINISTRATION}:${testAdministrationId}`,
+      );
+    });
+
+    it('returns 400 when scope is not assigned to administration', async () => {
+      mockReportRepository.isScopeAssignedToAdministration.mockResolvedValue(false);
+
+      const service = createService();
+
+      await expect(service.getScoreOverview(teacherAuth, testAdministrationId, scoreQuery)).rejects.toMatchObject({
+        statusCode: StatusCodes.BAD_REQUEST,
+        code: ApiErrorCode.REQUEST_VALIDATION_FAILED,
+      });
+    });
+
+    it('returns 403 when FGA denies can_read_scores at scope level', async () => {
+      // First check (administration) passes, second check (scope) fails
+      mockAuthorizationService.requirePermission.mockResolvedValueOnce(undefined).mockRejectedValueOnce(
+        new ApiError(ApiErrorMessage.FORBIDDEN, {
+          statusCode: StatusCodes.FORBIDDEN,
+          code: ApiErrorCode.AUTH_FORBIDDEN,
+        }),
+      );
+
+      const service = createService();
+
+      await expect(service.getScoreOverview(teacherAuth, testAdministrationId, scoreQuery)).rejects.toMatchObject({
+        statusCode: StatusCodes.FORBIDDEN,
+        code: ApiErrorCode.AUTH_FORBIDDEN,
+      });
+
+      // Second call targets the scope entity with CAN_READ_SCORES
+      expect(mockAuthorizationService.requirePermission).toHaveBeenNthCalledWith(
+        2,
+        teacherAuth.userId,
+        FgaRelation.CAN_READ_SCORES,
+        `${FgaType.DISTRICT}:district-uuid-1`,
+      );
+    });
+
+    it('super admin bypasses FGA checks', async () => {
+      setupDefaultScoreOverviewMocks();
+
+      const service = createService();
+      await service.getScoreOverview(superAdminAuth, testAdministrationId, scoreQuery);
+
+      expect(mockAuthorizationService.requirePermission).not.toHaveBeenCalled();
+    });
+
+    // --- Empty results ---
+
+    it('returns empty task overviews when no students in scope', async () => {
+      setupDefaultScoreOverviewMocks([]);
+
+      const service = createService();
+      const result = await service.getScoreOverview(superAdminAuth, testAdministrationId, scoreQuery);
+
+      expect(result.totalStudents).toBe(0);
+      expect(result.tasks).toHaveLength(testTaskMetas.length);
+      for (const task of result.tasks) {
+        expect(task.totalAssessed).toBe(0);
+        expect(task.totalNotAssessed).toEqual({ required: 0, optional: 0 });
+        expect(task.supportLevels.achievedSkill).toEqual({ count: 0, percentage: 0 });
+      }
+      expect(result.computedAt).toBeDefined();
+    });
+
+    it('returns computedAt as a parseable ISO datetime', async () => {
+      setupDefaultScoreOverviewMocks();
+
+      const service = createService();
+      const result = await service.getScoreOverview(superAdminAuth, testAdministrationId, scoreQuery);
+
+      const parsed = new Date(result.computedAt);
+      expect(parsed.getTime()).not.toBeNaN();
+    });
+
+    // --- Aggregation logic ---
+
+    it('counts assessed students with classifiable scores', async () => {
+      const students = [
+        buildOverviewStudent({ userId: 'student-1', grade: '3' }),
+        buildOverviewStudent({ userId: 'student-2', grade: '3' }),
+        buildOverviewStudent({ userId: 'student-3', grade: '3' }),
+      ];
+
+      // All 3 students have completed scores for swr (task-1).
+      const scoreRows = [
+        buildScoreRow('student-1', VARIANT_ID_1, 'percentile', '90'),
+        buildScoreRow('student-2', VARIANT_ID_1, 'percentile', '50'),
+        buildScoreRow('student-3', VARIANT_ID_1, 'percentile', '10'),
+      ];
+
+      setupDefaultScoreOverviewMocks(students, scoreRows);
+
+      const service = createService();
+      const result = await service.getScoreOverview(superAdminAuth, testAdministrationId, scoreQuery);
+
+      const swrTask = result.tasks.find((t) => t.taskId === TASK_ID_1);
+      expect(swrTask).toBeDefined();
+      expect(swrTask!.totalAssessed).toBe(3);
+      // Sum of bucketed students cannot exceed totalAssessed (some tasks may
+      // produce null support levels for unknown classifications)
+      const totalClassified =
+        swrTask!.supportLevels.achievedSkill.count +
+        swrTask!.supportLevels.developingSkill.count +
+        swrTask!.supportLevels.needsExtraSupport.count;
+      expect(totalClassified).toBeLessThanOrEqual(3);
+    });
+
+    it('counts not-assessed students as required when no run exists', async () => {
+      const students = [
+        buildOverviewStudent({ userId: 'student-1', grade: '3' }),
+        buildOverviewStudent({ userId: 'student-2', grade: '3' }),
+      ];
+
+      // Only student-1 has scores; student-2 has no run.
+      const scoreRows = [buildScoreRow('student-1', VARIANT_ID_1, 'percentile', '50')];
+
+      setupDefaultScoreOverviewMocks(students, scoreRows);
+
+      const service = createService();
+      const result = await service.getScoreOverview(superAdminAuth, testAdministrationId, scoreQuery);
+
+      const swrTask = result.tasks.find((t) => t.taskId === TASK_ID_1);
+      expect(swrTask).toBeDefined();
+      expect(swrTask!.totalAssessed).toBe(1);
+      expect(swrTask!.totalNotAssessed.required).toBe(1);
+      expect(swrTask!.totalNotAssessed.optional).toBe(0);
+    });
+
+    it('counts not-assessed students as optional when evaluator returns optional', async () => {
+      const students = [buildOverviewStudent({ userId: 'student-no-run', grade: '3' })];
+
+      setupDefaultScoreOverviewMocks(students, []);
+      // Override default: task is optional for this student
+      mockTaskService.evaluateTaskVariantEligibility.mockReturnValue({ isAssigned: true, isOptional: true });
+
+      const service = createService();
+      const result = await service.getScoreOverview(superAdminAuth, testAdministrationId, scoreQuery);
+
+      const swrTask = result.tasks.find((t) => t.taskId === TASK_ID_1);
+      expect(swrTask).toBeDefined();
+      expect(swrTask!.totalAssessed).toBe(0);
+      expect(swrTask!.totalNotAssessed.optional).toBe(1);
+      expect(swrTask!.totalNotAssessed.required).toBe(0);
+    });
+
+    it('excludes unassigned students from not-assessed counts', async () => {
+      const students = [buildOverviewStudent({ userId: 'student-excluded', grade: '3' })];
+
+      setupDefaultScoreOverviewMocks(students, []);
+      // Student is not assigned to this task at all
+      mockTaskService.evaluateTaskVariantEligibility.mockReturnValue({ isAssigned: false, isOptional: false });
+
+      const service = createService();
+      const result = await service.getScoreOverview(superAdminAuth, testAdministrationId, scoreQuery);
+
+      const swrTask = result.tasks.find((t) => t.taskId === TASK_ID_1);
+      expect(swrTask).toBeDefined();
+      expect(swrTask!.totalAssessed).toBe(0);
+      expect(swrTask!.totalNotAssessed.required).toBe(0);
+      expect(swrTask!.totalNotAssessed.optional).toBe(0);
+    });
+
+    it('rounds support level percentages to 1 decimal place', async () => {
+      const students = [
+        buildOverviewStudent({ userId: 's1', grade: '3' }),
+        buildOverviewStudent({ userId: 's2', grade: '3' }),
+        buildOverviewStudent({ userId: 's3', grade: '3' }),
+      ];
+
+      // All students get high percentile → all in achievedSkill (100%)
+      const scoreRows = students.map((s) => buildScoreRow(s.userId, VARIANT_ID_1, 'percentile', '90'));
+
+      setupDefaultScoreOverviewMocks(students, scoreRows);
+
+      const service = createService();
+      const result = await service.getScoreOverview(superAdminAuth, testAdministrationId, scoreQuery);
+
+      const swrTask = result.tasks.find((t) => t.taskId === TASK_ID_1);
+      expect(swrTask).toBeDefined();
+      expect(swrTask!.supportLevels.achievedSkill.percentage).toBe(100);
+      expect(swrTask!.supportLevels.developingSkill.percentage).toBe(0);
+      expect(swrTask!.supportLevels.needsExtraSupport.percentage).toBe(0);
+    });
+
+    // --- Multi-variant deduplication ---
+
+    it('deduplicates across variants of the same task', async () => {
+      // Two variants for the same taskId
+      const SHARED_TASK = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
+      const variantA: ReportTaskMeta = {
+        taskId: SHARED_TASK,
+        taskVariantId: 'var-a',
+        taskSlug: 'swr',
+        taskName: 'ROAR - Word',
+        orderIndex: 0,
+        conditionsAssignment: null,
+        conditionsRequirements: null,
+      };
+      const variantB: ReportTaskMeta = {
+        taskId: SHARED_TASK,
+        taskVariantId: 'var-b',
+        taskSlug: 'swr',
+        taskName: 'ROAR - Word',
+        orderIndex: 1,
+        conditionsAssignment: null,
+        conditionsRequirements: null,
+      };
+
+      mockReportRepository.getTaskMetadata.mockResolvedValue([variantA, variantB]);
+
+      const students = [buildOverviewStudent({ userId: 'student-1', grade: '3' })];
+
+      // Student has scores on variant A only
+      const scoreRows = [buildScoreRow('student-1', 'var-a', 'percentile', '50')];
+
+      setupDefaultScoreOverviewMocks(students, scoreRows);
+
+      const service = createService();
+      const result = await service.getScoreOverview(superAdminAuth, testAdministrationId, scoreQuery);
+
+      // Should produce exactly 1 task (both variants grouped)
+      expect(result.tasks).toHaveLength(1);
+      expect(result.tasks[0]!.taskId).toBe(SHARED_TASK);
+      // Student counted once (not twice)
+      expect(result.tasks[0]!.totalAssessed).toBe(1);
+    });
+
+    it('uses the first variant with scores for a multi-variant student', async () => {
+      const SHARED_TASK = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
+      const variantA: ReportTaskMeta = {
+        taskId: SHARED_TASK,
+        taskVariantId: 'var-a',
+        taskSlug: 'swr',
+        taskName: 'ROAR - Word',
+        orderIndex: 0,
+        conditionsAssignment: null,
+        conditionsRequirements: null,
+      };
+      const variantB: ReportTaskMeta = {
+        taskId: SHARED_TASK,
+        taskVariantId: 'var-b',
+        taskSlug: 'swr',
+        taskName: 'ROAR - Word',
+        orderIndex: 1,
+        conditionsAssignment: null,
+        conditionsRequirements: null,
+      };
+
+      mockReportRepository.getTaskMetadata.mockResolvedValue([variantA, variantB]);
+
+      const students = [buildOverviewStudent({ userId: 'student-1', grade: '3' })];
+
+      // Student has scores on both variants — should use variant A (first in order)
+      // Variant A has high percentile (achievedSkill); variant B has low (would be needsExtraSupport)
+      const scoreRows = [
+        buildScoreRow('student-1', 'var-a', 'percentile', '90'),
+        buildScoreRow('student-1', 'var-b', 'percentile', '10'),
+      ];
+
+      setupDefaultScoreOverviewMocks(students, scoreRows);
+
+      const service = createService();
+      const result = await service.getScoreOverview(superAdminAuth, testAdministrationId, scoreQuery);
+
+      expect(result.tasks[0]!.totalAssessed).toBe(1);
+      // Variant A wins → achievedSkill, not needsExtraSupport from variant B
+      expect(result.tasks[0]!.supportLevels.achievedSkill.count).toBe(1);
+      expect(result.tasks[0]!.supportLevels.needsExtraSupport.count).toBe(0);
+    });
+
+    it('evaluates eligibility across all variants when no run exists', async () => {
+      const SHARED_TASK = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
+      const variantA: ReportTaskMeta = {
+        taskId: SHARED_TASK,
+        taskVariantId: 'var-a',
+        taskSlug: 'swr',
+        taskName: 'ROAR - Word',
+        orderIndex: 0,
+        conditionsAssignment: null,
+        conditionsRequirements: null,
+      };
+      const variantB: ReportTaskMeta = {
+        taskId: SHARED_TASK,
+        taskVariantId: 'var-b',
+        taskSlug: 'swr',
+        taskName: 'ROAR - Word',
+        orderIndex: 1,
+        conditionsAssignment: null,
+        conditionsRequirements: null,
+      };
+
+      mockReportRepository.getTaskMetadata.mockResolvedValue([variantA, variantB]);
+
+      const students = [buildOverviewStudent({ userId: 'student-1', grade: '3' })];
+      setupDefaultScoreOverviewMocks(students, []);
+
+      // Variant A: not assigned. Variant B: assigned and required.
+      // Student should be counted as not-assessed required (ANY variant assigning → assigned).
+      let callCount = 0;
+      mockTaskService.evaluateTaskVariantEligibility.mockImplementation(() => {
+        callCount++;
+        if (callCount === 1) return { isAssigned: false, isOptional: false };
+        return { isAssigned: true, isOptional: false };
+      });
+
+      const service = createService();
+      const result = await service.getScoreOverview(superAdminAuth, testAdministrationId, scoreQuery);
+
+      expect(result.tasks[0]!.totalNotAssessed.required).toBe(1);
+      expect(result.tasks[0]!.totalNotAssessed.optional).toBe(0);
+    });
+
+    // --- taskId filter ---
+
+    it('filters tasks by taskId when filter includes the taskId field', async () => {
+      const students = [buildOverviewStudent({ userId: 'student-1', grade: '3' })];
+      const scoreRows = [buildScoreRow('student-1', VARIANT_ID_1, 'percentile', '50')];
+
+      setupDefaultScoreOverviewMocks(students, scoreRows);
+
+      const filteredQuery: ScoreOverviewInput = {
+        ...scoreQuery,
+        filter: [{ field: 'taskId', operator: 'in', value: TASK_ID_1 }],
+      };
+
+      const service = createService();
+      const result = await service.getScoreOverview(superAdminAuth, testAdministrationId, filteredQuery);
+
+      // Only the filtered task should be in the result
+      expect(result.tasks).toHaveLength(1);
+      expect(result.tasks[0]!.taskId).toBe(TASK_ID_1);
+    });
+
+    // --- Scoring version ---
+
+    it('passes scoring version from task variant parameters into scoring logic', async () => {
+      const students = [buildOverviewStudent({ userId: 'student-1', grade: '3' })];
+      const scoreRows = [buildScoreRow('student-1', VARIANT_ID_1, 'percentile', '50')];
+
+      setupDefaultScoreOverviewMocks(students, scoreRows);
+      mockTaskVariantParameterRepository.getByTaskVariantIds.mockResolvedValue([
+        {
+          taskVariantId: VARIANT_ID_1,
+          name: 'scoringVersion',
+          value: 2,
+          createdAt: new Date(),
+          updatedAt: null,
+        },
+      ]);
+
+      const service = createService();
+      const result = await service.getScoreOverview(superAdminAuth, testAdministrationId, scoreQuery);
+
+      // Repository is consulted for scoring versions
+      expect(mockTaskVariantParameterRepository.getByTaskVariantIds).toHaveBeenCalledWith(
+        testTaskMetas.map((t) => t.taskVariantId),
+      );
+      // And the call completes successfully
+      expect(result.tasks).toHaveLength(testTaskMetas.length);
+    });
+
+    // --- Error handling ---
+
+    it('wraps unexpected repository errors in a 500 ApiError', async () => {
+      mockReportRepository.getAllStudentsInScope.mockRejectedValue(new Error('connection reset'));
+
+      const service = createService();
+
+      await expect(service.getScoreOverview(superAdminAuth, testAdministrationId, scoreQuery)).rejects.toMatchObject({
+        statusCode: StatusCodes.INTERNAL_SERVER_ERROR,
+        code: ApiErrorCode.DATABASE_QUERY_FAILED,
+      });
+    });
+
+    it('re-throws ApiError without wrapping', async () => {
+      // The 404 from verifyAdministrationScoreReadAccess should propagate as-is
+      mockAdministrationRepository.getById.mockResolvedValue(null);
+
+      const service = createService();
+
+      await expect(service.getScoreOverview(superAdminAuth, testAdministrationId, scoreQuery)).rejects.toMatchObject({
+        statusCode: StatusCodes.NOT_FOUND,
+        code: ApiErrorCode.RESOURCE_NOT_FOUND,
+      });
+    });
+
+    // --- user.grade filter ---
+
+    it('passes user-level filters to getAllStudentsInScope', async () => {
+      setupDefaultScoreOverviewMocks();
+
+      const filteredQuery: ScoreOverviewInput = {
+        ...scoreQuery,
+        filter: [{ field: 'user.grade', operator: 'eq', value: '3' }],
+      };
+
+      const service = createService();
+      await service.getScoreOverview(superAdminAuth, testAdministrationId, filteredQuery);
+
+      // getAllStudentsInScope should be called with a non-undefined filter condition
+      expect(mockReportRepository.getAllStudentsInScope).toHaveBeenCalledWith(
+        { scopeType: 'district', scopeId: 'district-uuid-1' },
+        expect.anything(),
+      );
+    });
+
+    it('returns per-task metadata in results', async () => {
+      setupDefaultScoreOverviewMocks([], []);
+
+      const service = createService();
+      const result = await service.getScoreOverview(superAdminAuth, testAdministrationId, scoreQuery);
+
+      expect(result.tasks[0]!.taskId).toBe(TASK_ID_1);
+      expect(result.tasks[0]!.taskSlug).toBe('swr');
+      expect(result.tasks[0]!.taskName).toBe('ROAR - Word');
+      expect(result.tasks[0]!.orderIndex).toBe(0);
     });
   });
 });

--- a/apps/backend/src/services/report/report.service.test.ts
+++ b/apps/backend/src/services/report/report.service.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { StatusCodes } from 'http-status-codes';
 import { ReportService, buildProgressMap, groupVariantsByTaskId } from './report.service';
+import { AdministrationService } from '../administration/administration.service';
 import { AdministrationFactory } from '../../test-support/factories/administration.factory';
 import {
   createMockAdministrationRepository,
@@ -106,8 +107,18 @@ describe('ReportService', () => {
   ];
 
   function createService() {
-    return ReportService({
+    // Inject a real AdministrationService backed by the same mocks the
+    // ReportService used to consume directly. This preserves test assertions
+    // on `mockAdministrationRepository.getById` and
+    // `mockAuthorizationService.requirePermission` while routing access
+    // checks through the canonical helper.
+    const administrationService = AdministrationService({
       administrationRepository: mockAdministrationRepository,
+      authorizationService: mockAuthorizationService,
+    });
+
+    return ReportService({
+      administrationService,
       reportRepository: mockReportRepository,
       taskService: mockTaskService,
       authorizationService: mockAuthorizationService,
@@ -1682,7 +1693,7 @@ describe('ReportService', () => {
     });
 
     it('re-throws ApiError without wrapping', async () => {
-      // The 404 from verifyAdministrationScoreReadAccess should propagate as-is
+      // The 404 from AdministrationService.verifyAdministrationAccess should propagate as-is
       mockAdministrationRepository.getById.mockResolvedValue(null);
 
       const service = createService();

--- a/apps/backend/src/services/report/report.service.test.ts
+++ b/apps/backend/src/services/report/report.service.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { StatusCodes } from 'http-status-codes';
-import { ReportService, buildProgressMap } from './report.service';
+import { ReportService, buildProgressMap, groupVariantsByTaskId } from './report.service';
 import { AdministrationFactory } from '../../test-support/factories/administration.factory';
 import {
   createMockAdministrationRepository,
@@ -1723,6 +1723,261 @@ describe('ReportService', () => {
       expect(result.tasks[0]!.taskSlug).toBe('swr');
       expect(result.tasks[0]!.taskName).toBe('ROAR - Word');
       expect(result.tasks[0]!.orderIndex).toBe(0);
+    });
+
+    // --- Empty-result short-circuit when taskId filter excludes all tasks ---
+
+    it('returns empty tasks array when taskId filter excludes every task', async () => {
+      // Filter targets a UUID not present in testTaskMetas — taskMetas becomes []
+      // and taskGroups.length === 0 triggers the short-circuit.
+      const students = [buildOverviewStudent({ userId: 'student-1' })];
+      setupDefaultScoreOverviewMocks(students, []);
+
+      const filteredQuery: ScoreOverviewInput = {
+        ...scoreQuery,
+        filter: [{ field: 'taskId', operator: 'in', value: '00000000-0000-0000-0000-000000000000' }],
+      };
+
+      const service = createService();
+      const result = await service.getScoreOverview(superAdminAuth, testAdministrationId, filteredQuery);
+
+      expect(result.tasks).toHaveLength(0);
+      expect(result.totalStudents).toBe(1);
+      expect(typeof result.computedAt).toBe('string');
+      // Short-circuit means we don't fetch scoring versions or run scores
+      expect(mockTaskVariantParameterRepository.getByTaskVariantIds).not.toHaveBeenCalled();
+      expect(mockReportRepository.getCompletedRunScores).not.toHaveBeenCalled();
+    });
+
+    // --- Multi-variant: any required → required (not optional) ---
+
+    it('counts a not-assessed student as required when any variant is required', async () => {
+      // Variant A assigns the student as required. Variant B assigns them as optional.
+      // Per evaluateEligibilityAcrossVariants, the student should be counted as
+      // not-assessed REQUIRED because at least one variant marks them required.
+      const SHARED_TASK = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
+      const variantA: ReportTaskMeta = {
+        taskId: SHARED_TASK,
+        taskVariantId: 'var-a',
+        taskSlug: 'swr',
+        taskName: 'ROAR - Word',
+        orderIndex: 0,
+        conditionsAssignment: null,
+        conditionsRequirements: null,
+      };
+      const variantB: ReportTaskMeta = {
+        taskId: SHARED_TASK,
+        taskVariantId: 'var-b',
+        taskSlug: 'swr',
+        taskName: 'ROAR - Word',
+        orderIndex: 1,
+        conditionsAssignment: null,
+        conditionsRequirements: null,
+      };
+
+      mockReportRepository.getTaskMetadata.mockResolvedValue([variantA, variantB]);
+
+      const students = [buildOverviewStudent({ userId: 'student-1' })];
+      setupDefaultScoreOverviewMocks(students, []);
+
+      // Variant A: assigned + required. Variant B: assigned + optional.
+      let callCount = 0;
+      mockTaskService.evaluateTaskVariantEligibility.mockImplementation(() => {
+        callCount++;
+        if (callCount === 1) return { isAssigned: true, isOptional: false };
+        return { isAssigned: true, isOptional: true };
+      });
+
+      const service = createService();
+      const result = await service.getScoreOverview(superAdminAuth, testAdministrationId, scoreQuery);
+
+      expect(result.tasks[0]!.totalNotAssessed.required).toBe(1);
+      expect(result.tasks[0]!.totalNotAssessed.optional).toBe(0);
+    });
+
+    // --- Scoring version edge cases ---
+    //
+    // The scoring service's swr config exposes different percentile cutoffs by version:
+    //   v0 (legacy): achievedSkill >= 50, developingSkill >= 25
+    //   v7+:         achievedSkill >= 40, developingSkill >= 20
+    // A percentile of 45 lets us observe which version's cutoffs were applied:
+    //   v0 → developingSkill (45 < 50)
+    //   v7 → achievedSkill   (45 >= 40)
+
+    it('ignores task variant parameters whose name is not scoringVersion', async () => {
+      const students = [buildOverviewStudent({ userId: 'student-1', grade: '3' })];
+      const scoreRows = [buildScoreRow('student-1', VARIANT_ID_1, 'percentile', '45')];
+
+      setupDefaultScoreOverviewMocks(students, scoreRows);
+      // Param has the wrong name — should be ignored, leaving version=null (treated as 0)
+      mockTaskVariantParameterRepository.getByTaskVariantIds.mockResolvedValue([
+        { taskVariantId: VARIANT_ID_1, name: 'difficulty', value: 7, createdAt: new Date(), updatedAt: null },
+      ]);
+
+      const service = createService();
+      const result = await service.getScoreOverview(superAdminAuth, testAdministrationId, scoreQuery);
+
+      const swrTask = result.tasks.find((t) => t.taskId === TASK_ID_1)!;
+      // v0 cutoffs were applied: 45 < 50 → developingSkill, NOT achievedSkill
+      expect(swrTask.supportLevels.developingSkill.count).toBe(1);
+      expect(swrTask.supportLevels.achievedSkill.count).toBe(0);
+    });
+
+    it('ignores scoringVersion values that cannot be parsed as a number', async () => {
+      const students = [buildOverviewStudent({ userId: 'student-1', grade: '3' })];
+      const scoreRows = [buildScoreRow('student-1', VARIANT_ID_1, 'percentile', '45')];
+
+      setupDefaultScoreOverviewMocks(students, scoreRows);
+      // Non-numeric string → Number('foo') is NaN → skipped → version stays null/0
+      mockTaskVariantParameterRepository.getByTaskVariantIds.mockResolvedValue([
+        { taskVariantId: VARIANT_ID_1, name: 'scoringVersion', value: 'foo', createdAt: new Date(), updatedAt: null },
+      ]);
+
+      const service = createService();
+      const result = await service.getScoreOverview(superAdminAuth, testAdministrationId, scoreQuery);
+
+      const swrTask = result.tasks.find((t) => t.taskId === TASK_ID_1)!;
+      expect(swrTask.supportLevels.developingSkill.count).toBe(1);
+      expect(swrTask.supportLevels.achievedSkill.count).toBe(0);
+    });
+
+    it('accepts string-numeric scoringVersion values', async () => {
+      const students = [buildOverviewStudent({ userId: 'student-1', grade: '3' })];
+      const scoreRows = [buildScoreRow('student-1', VARIANT_ID_1, 'percentile', '45')];
+
+      setupDefaultScoreOverviewMocks(students, scoreRows);
+      // String '7' → Number('7') = 7 → v7 cutoffs applied
+      mockTaskVariantParameterRepository.getByTaskVariantIds.mockResolvedValue([
+        { taskVariantId: VARIANT_ID_1, name: 'scoringVersion', value: '7', createdAt: new Date(), updatedAt: null },
+      ]);
+
+      const service = createService();
+      const result = await service.getScoreOverview(superAdminAuth, testAdministrationId, scoreQuery);
+
+      const swrTask = result.tasks.find((t) => t.taskId === TASK_ID_1)!;
+      // v7 cutoffs applied: 45 >= 40 → achievedSkill
+      expect(swrTask.supportLevels.achievedSkill.count).toBe(1);
+      expect(swrTask.supportLevels.developingSkill.count).toBe(0);
+    });
+
+    // --- Assessment-computed support level (roam-alpaca) ---
+
+    it('classifies assessment-computed tasks via the supportLevel score field', async () => {
+      // roam-alpaca uses classification.type = 'assessment-computed' — the support level
+      // comes from the assessment, not from percentile/rawScore cutoffs.
+      const ROAM_ALPACA_TASK = 'cccccccc-aaaa-bbbb-dddd-eeeeeeeeeeee';
+      const ROAM_VARIANT = 'roam-variant-1';
+      const roamMeta: ReportTaskMeta = {
+        taskId: ROAM_ALPACA_TASK,
+        taskVariantId: ROAM_VARIANT,
+        taskSlug: 'roam-alpaca',
+        taskName: 'ROAM - Alpaca',
+        orderIndex: 0,
+        conditionsAssignment: null,
+        conditionsRequirements: null,
+      };
+      mockReportRepository.getTaskMetadata.mockResolvedValue([roamMeta]);
+
+      const students = [buildOverviewStudent({ userId: 'student-1', grade: '3' })];
+      const scoreRows = [buildScoreRow('student-1', ROAM_VARIANT, 'supportLevel', 'achievedSkill')];
+
+      setupDefaultScoreOverviewMocks(students, scoreRows);
+
+      const service = createService();
+      const result = await service.getScoreOverview(superAdminAuth, testAdministrationId, scoreQuery);
+
+      const roamTask = result.tasks.find((t) => t.taskId === ROAM_ALPACA_TASK)!;
+      expect(roamTask.totalAssessed).toBe(1);
+      expect(roamTask.supportLevels.achievedSkill.count).toBe(1);
+      expect(roamTask.supportLevels.developingSkill.count).toBe(0);
+      expect(roamTask.supportLevels.needsExtraSupport.count).toBe(0);
+    });
+
+    // --- parseScoreValue angle-bracket handling ---
+
+    it('classifies angle-bracket percentile strings (e.g., ">99")', async () => {
+      // Newer norming tables encode extreme values as ">99" or "<1". parseScoreValue
+      // strips the brackets so the score is still classifiable.
+      const students = [buildOverviewStudent({ userId: 'student-1', grade: '3' })];
+      const scoreRows = [buildScoreRow('student-1', VARIANT_ID_1, 'percentile', '>99')];
+
+      setupDefaultScoreOverviewMocks(students, scoreRows);
+
+      const service = createService();
+      const result = await service.getScoreOverview(superAdminAuth, testAdministrationId, scoreQuery);
+
+      const swrTask = result.tasks.find((t) => t.taskId === TASK_ID_1)!;
+      expect(swrTask.totalAssessed).toBe(1);
+      // 99 (after bracket strip) >= 50 (v0 swr achieved cutoff) → achievedSkill
+      expect(swrTask.supportLevels.achievedSkill.count).toBe(1);
+    });
+
+    // --- No resolvable score path ---
+
+    it('counts a student in totalAssessed but no support-level bucket when scores are unresolvable', async () => {
+      // The student's run has score rows, but none match the swr field names
+      // (e.g., 'percentile', 'wjPercentile', 'roarScore'). getSupportLevel
+      // returns null → counted in totalAssessed but no bucket increments.
+      const students = [buildOverviewStudent({ userId: 'student-1', grade: '3' })];
+      const scoreRows = [buildScoreRow('student-1', VARIANT_ID_1, 'irrelevant', '42')];
+
+      setupDefaultScoreOverviewMocks(students, scoreRows);
+
+      const service = createService();
+      const result = await service.getScoreOverview(superAdminAuth, testAdministrationId, scoreQuery);
+
+      const swrTask = result.tasks.find((t) => t.taskId === TASK_ID_1)!;
+      expect(swrTask.totalAssessed).toBe(1);
+      expect(swrTask.supportLevels.achievedSkill.count).toBe(0);
+      expect(swrTask.supportLevels.developingSkill.count).toBe(0);
+      expect(swrTask.supportLevels.needsExtraSupport.count).toBe(0);
+      // Not-assessed should NOT be incremented either — the student is "assessed"
+      // (has a completed run with scores), they just lack a classifiable result.
+      expect(swrTask.totalNotAssessed.required).toBe(0);
+      expect(swrTask.totalNotAssessed.optional).toBe(0);
+    });
+  });
+
+  // --- groupVariantsByTaskId helper unit test ---
+
+  describe('groupVariantsByTaskId', () => {
+    function buildMeta(overrides: Partial<ReportTaskMeta> & { taskId: string; taskVariantId: string }): ReportTaskMeta {
+      return {
+        taskSlug: 'swr',
+        taskName: 'ROAR - Word',
+        orderIndex: 0,
+        conditionsAssignment: null,
+        conditionsRequirements: null,
+        ...overrides,
+      };
+    }
+
+    it('returns an empty array for empty input', () => {
+      expect(groupVariantsByTaskId([])).toEqual([]);
+    });
+
+    it('groups variants sharing a taskId and uses the first occurrence as the representative', () => {
+      const a = buildMeta({ taskId: 'task-1', taskVariantId: 'v-1', orderIndex: 0 });
+      const b = buildMeta({ taskId: 'task-1', taskVariantId: 'v-2', orderIndex: 1 });
+      const c = buildMeta({ taskId: 'task-2', taskVariantId: 'v-3', orderIndex: 2 });
+
+      const groups = groupVariantsByTaskId([a, b, c]);
+
+      expect(groups).toHaveLength(2);
+      expect(groups[0]!.representative).toBe(a);
+      expect(groups[0]!.variants).toEqual([a, b]);
+      expect(groups[1]!.representative).toBe(c);
+      expect(groups[1]!.variants).toEqual([c]);
+    });
+
+    it('preserves the input order across taskIds (does not sort by taskId)', () => {
+      // First-seen wins for ordering — taskId 'z' before 'a' in input → 'z' first in output.
+      const z = buildMeta({ taskId: 'z-task', taskVariantId: 'v-z', orderIndex: 0 });
+      const a = buildMeta({ taskId: 'a-task', taskVariantId: 'v-a', orderIndex: 1 });
+
+      const groups = groupVariantsByTaskId([z, a]);
+
+      expect(groups.map((g) => g.representative.taskId)).toEqual(['z-task', 'a-task']);
     });
   });
 });

--- a/apps/backend/src/services/report/report.service.ts
+++ b/apps/backend/src/services/report/report.service.ts
@@ -431,7 +431,7 @@ export function ReportService({
    * Get aggregated score overview for an administration.
    *
    * Returns per-task support level distributions (achievedSkill, developingSkill,
-   * needsExtraSupport) with counts and percentages, plus totalAssessed and
+   * needsExtraSupport) with counts, plus totalAssessed and
    * totalNotAssessed (required/optional) counts.
    *
    * Authorization (two FGA checks, in order):
@@ -879,9 +879,9 @@ function buildEmptyTaskOverview(task: ReportTaskMeta): ServiceTaskScoreOverview 
     totalAssessed: 0,
     totalNotAssessed: { required: 0, optional: 0 },
     supportLevels: {
-      achievedSkill: { count: 0, percentage: 0 },
-      developingSkill: { count: 0, percentage: 0 },
-      needsExtraSupport: { count: 0, percentage: 0 },
+      achievedSkill: { count: 0 },
+      developingSkill: { count: 0 },
+      needsExtraSupport: { count: 0 },
     },
   };
 }
@@ -1031,9 +1031,6 @@ function aggregateTaskGroup(
     }
   }
 
-  // Round percentages to 1 decimal place
-  const pct = (count: number) => (totalAssessed > 0 ? Math.round((count / totalAssessed) * 1000) / 10 : 0);
-
   return {
     taskId: representative.taskId,
     taskSlug: representative.taskSlug,
@@ -1042,9 +1039,9 @@ function aggregateTaskGroup(
     totalAssessed,
     totalNotAssessed: { required: notAssessedRequired, optional: notAssessedOptional },
     supportLevels: {
-      achievedSkill: { count: achievedCount, percentage: pct(achievedCount) },
-      developingSkill: { count: developingCount, percentage: pct(developingCount) },
-      needsExtraSupport: { count: needsSupportCount, percentage: pct(needsSupportCount) },
+      achievedSkill: { count: achievedCount },
+      developingSkill: { count: developingCount },
+      needsExtraSupport: { count: needsSupportCount },
     },
   };
 }

--- a/apps/backend/src/services/report/report.service.ts
+++ b/apps/backend/src/services/report/report.service.ts
@@ -13,6 +13,9 @@ import type {
   ProgressOverviewInput,
   ProgressOverviewResult,
   ServiceTaskOverview,
+  ScoreOverviewInput,
+  ScoreOverviewResult,
+  ServiceTaskScoreOverview,
   ParsedFilter,
 } from './report.types';
 import { PROGRESS_TASK_STATUS_PATTERN } from '@roar-dashboard/api-contract';
@@ -28,12 +31,17 @@ import { ReportRepository, REPORT_CONDITION_FIELD_MAP } from '../../repositories
 import type {
   ReportTaskMeta,
   StudentProgressRow,
+  StudentOverviewRow,
+  RunScoreRow,
   ProgressStatusSortParam,
   ProgressStatusFilterParam,
 } from '../../repositories/report.repository';
 import { TaskService } from '../task/task.service';
 import { AuthorizationService } from '../authorization/authorization.service';
 import { FgaType, FgaRelation } from '../authorization/fga-constants';
+import { TaskVariantParameterRepository } from '../../repositories/task-variant-parameter.repository';
+import { getSupportLevel, parseScoreValue, resolveScoreFieldNames } from '../scoring';
+import { getGradeAsNumber } from '../../utils/get-grade-as-number.util';
 import { conditionToSql } from '../../utils/condition-to-sql';
 import type { Condition, ConditionEvaluationUser } from '../../types/condition';
 import type { AuthContext } from '../../types/auth-context';
@@ -57,6 +65,16 @@ const PROGRESS_FILTER_FIELDS: Record<ProgressStudentsFilterField, PgColumn> = {
 
 /** Fields that use grade-aware numeric ordering for gte/lte comparisons. */
 const GRADE_AWARE_FIELDS: ReadonlySet<string> = new Set(['user.grade']);
+
+/**
+ * Map filter field strings to Drizzle column references for score overview.
+ * Only includes user-level fields that can be applied as SQL WHERE conditions.
+ * `taskId` is handled separately in the service layer (it filters task metadata,
+ * not student rows).
+ */
+const SCORE_OVERVIEW_USER_FILTER_FIELDS: Record<string, PgColumn> = {
+  'user.grade': users.grade,
+};
 
 /** Per-task status counters for progress overview aggregation (7-level). */
 interface TaskStatusCounter {
@@ -82,11 +100,13 @@ export function ReportService({
   reportRepository = new ReportRepository(),
   taskService = TaskService(),
   authorizationService = AuthorizationService(),
+  taskVariantParameterRepository = new TaskVariantParameterRepository(),
 }: {
   administrationRepository?: AdministrationRepository;
   reportRepository?: ReportRepository;
   taskService?: ReturnType<typeof TaskService>;
   authorizationService?: ReturnType<typeof AuthorizationService>;
+  taskVariantParameterRepository?: TaskVariantParameterRepository;
 } = {}) {
   /**
    * Verify that an administration exists and the user has progress-read access.
@@ -127,6 +147,45 @@ export function ReportService({
     );
   }
 
+  /**
+   * Verify that an administration exists and the user has score-read access.
+   *
+   * Mirrors `verifyAdministrationProgressAccess` but checks the FGA
+   * `can_read_scores` relation instead of `can_read_progress`. The FGA model
+   * defines both as `supervisory_tier_group` on the administration type, so the
+   * set of permitted users is the same shape (admin-tier or educator-tier roles
+   * on an assigned entity), but the permissions are distinct so they can diverge
+   * in the future without changing this code.
+   *
+   * Follows the 404-before-403 pattern: checks existence first so a missing
+   * administration returns 404, not a misleading 403.
+   *
+   * @param authContext - User's auth context
+   * @param administrationId - The administration ID to verify
+   * @throws {ApiError} NOT_FOUND if administration doesn't exist
+   * @throws {ApiError} FORBIDDEN if user lacks can_read_scores on the administration
+   */
+  async function verifyAdministrationScoreReadAccess(authContext: AuthContext, administrationId: string) {
+    const { userId, isSuperAdmin } = authContext;
+
+    const administration = await administrationRepository.getById({ id: administrationId });
+    if (!administration) {
+      throw new ApiError('Administration not found', {
+        statusCode: StatusCodes.NOT_FOUND,
+        code: ApiErrorCode.RESOURCE_NOT_FOUND,
+        context: { userId, administrationId },
+      });
+    }
+
+    if (isSuperAdmin) return;
+
+    await authorizationService.requirePermission(
+      userId,
+      FgaRelation.CAN_READ_SCORES,
+      `${FgaType.ADMINISTRATION}:${administrationId}`,
+    );
+  }
+
   /** Map report scope types to FGA object type prefixes. */
   const SCOPE_TO_FGA_TYPE: Record<ScopeType, FgaType> = {
     [EntityType.DISTRICT]: FgaType.DISTRICT,
@@ -140,27 +199,29 @@ export function ReportService({
    *
    * Checks:
    * 1. The scope entity is assigned to the administration (business rule)
-   * 2. FGA grants can_read_progress on the scope entity
+   * 2. FGA grants the requested relation on the scope entity (default: can_read_progress)
    *
-   * The FGA model defines `can_read_progress: supervisory_tier_group` on all scope
-   * types (district, school, class, group). This replaces the old ltree-based
-   * `getUserRolesAtOrAboveScope` + `hasSupervisoryRole` check. FGA's hierarchy
-   * relations handle ancestor visibility: a district admin's membership propagates
-   * to child schools and classes, so a `can_read_progress` check on a school
-   * passes if the user has a supervisory role at the school's parent district.
+   * The FGA model defines `can_read_progress` and `can_read_scores` as
+   * `supervisory_tier_group` on all scope types (district, school, class, group).
+   * FGA's hierarchy relations handle ancestor visibility: a district admin's
+   * membership propagates to child schools and classes, so a permission check
+   * on a school passes if the user has a supervisory role at the school's
+   * parent district.
    *
    * @param authContext - User's auth context
    * @param administrationId - The administration ID
    * @param scopeType - The scope type (district, school, class, group)
    * @param scopeId - The scope entity ID
+   * @param relation - The FGA relation to check (defaults to CAN_READ_PROGRESS)
    * @throws {ApiError} BAD_REQUEST if scope is not assigned to the administration
-   * @throws {ApiError} FORBIDDEN if user lacks can_read_progress on the scope entity
+   * @throws {ApiError} FORBIDDEN if user lacks the requested relation on the scope entity
    */
   async function authorizeScopeAccess(
     authContext: AuthContext,
     administrationId: string,
     scopeType: ScopeType,
     scopeId: string,
+    relation: FgaRelation = FgaRelation.CAN_READ_PROGRESS,
   ) {
     const { userId, isSuperAdmin } = authContext;
 
@@ -180,9 +241,9 @@ export function ReportService({
     // Super admins bypass scope authorization
     if (isSuperAdmin) return;
 
-    // Verify user has can_read_progress on the scope entity via FGA
+    // Verify user has the requested permission on the scope entity via FGA
     const fgaType = SCOPE_TO_FGA_TYPE[scopeType];
-    await authorizationService.requirePermission(userId, FgaRelation.CAN_READ_PROGRESS, `${fgaType}:${scopeId}`);
+    await authorizationService.requirePermission(userId, relation, `${fgaType}:${scopeId}`);
   }
 
   /**
@@ -435,7 +496,143 @@ export function ReportService({
     }
   }
 
-  return { listProgressStudents, getProgressOverview };
+  /**
+   * Get aggregated score overview for an administration.
+   *
+   * Returns per-task support level distributions (achievedSkill, developingSkill,
+   * needsExtraSupport) with counts and percentages, plus totalAssessed and
+   * totalNotAssessed (required/optional) counts.
+   *
+   * Authorization (two FGA checks, in order):
+   *
+   * 1. **Administration score-read access** (verifyAdministrationScoreReadAccess):
+   *    Checks existence (404 before 403) then verifies `can_read_scores` on the
+   *    administration via FGA. The FGA model grants this only to admin-tier and
+   *    educator-tier roles, denying students and caregivers.
+   *
+   * 2. **Scope-level authorization** (authorizeScopeAccess with CAN_READ_SCORES):
+   *    Validates the scope is assigned to the administration (business rule), then
+   *    checks `can_read_scores` on the scope entity. This prevents e.g., a teacher
+   *    at School A from viewing School B's score report within a shared district
+   *    administration.
+   *
+   * Multi-variant dedup: when multiple variants share a taskId, each student is
+   * counted once at the first variant that has completed run scores. Eligibility
+   * for not-assessed counts is evaluated across all variants — a student is
+   * "assigned" if ANY variant assigns them, "optional" only if ALL assigning
+   * variants are optional.
+   *
+   * @param authContext - User's auth context
+   * @param administrationId - The administration to report on
+   * @param query - Query parameters (scope, filters)
+   * @returns Score overview with per-task distributions
+   * @throws {ApiError} NOT_FOUND if administration doesn't exist
+   * @throws {ApiError} FORBIDDEN if user lacks can_read_scores
+   * @throws {ApiError} BAD_REQUEST if scope is invalid
+   */
+  async function getScoreOverview(
+    authContext: AuthContext,
+    administrationId: string,
+    query: ScoreOverviewInput,
+  ): Promise<ScoreOverviewResult> {
+    const { userId } = authContext;
+    const { scopeType, scopeId, filter } = query;
+
+    try {
+      // 1. Verify administration exists and user has can_read_scores
+      await verifyAdministrationScoreReadAccess(authContext, administrationId);
+
+      // 2. Validate scope and authorize can_read_scores on the scope entity
+      await authorizeScopeAccess(authContext, administrationId, scopeType, scopeId, FgaRelation.CAN_READ_SCORES);
+
+      // 3. Get task metadata
+      let taskMetas = await reportRepository.getTaskMetadata(administrationId);
+
+      // 4. Extract taskId filter (if any) and user-level filters separately
+      const taskIdFilter = filter.find((f) => f.field === 'taskId');
+      if (taskIdFilter) {
+        const allowedTaskIds = new Set(taskIdFilter.value.split(',').map((v) => v.trim()));
+        taskMetas = taskMetas.filter((t) => allowedTaskIds.has(t.taskId));
+      }
+
+      const userFilters = filter.filter((f) => f.field !== 'taskId');
+      const filterCondition =
+        userFilters.length > 0
+          ? buildFilterConditions(userFilters, SCORE_OVERVIEW_USER_FILTER_FIELDS, {
+              gradeAwareFields: GRADE_AWARE_FIELDS,
+            })
+          : undefined;
+
+      // 5. Get all students in scope (no pagination — overview aggregates the full population)
+      const { totalStudents, students } = await reportRepository.getAllStudentsInScope(
+        { scopeType, scopeId },
+        filterCondition,
+      );
+
+      // 6. Group variants by taskId for multi-variant deduplication.
+      // Multiple variants can share a taskId (e.g., grade-specific variants).
+      // Each student should be counted once per task at their best variant's score.
+      const taskGroups = groupVariantsByTaskId(taskMetas);
+
+      if (totalStudents === 0 || taskGroups.length === 0) {
+        return {
+          totalStudents,
+          tasks: taskGroups.map(({ representative }) => buildEmptyTaskOverview(representative)),
+          computedAt: new Date().toISOString(),
+        };
+      }
+
+      // 7. Fetch scoring versions from task_variant_parameters
+      const taskVariantIds = taskMetas.map((t) => t.taskVariantId);
+      const allParams = await taskVariantParameterRepository.getByTaskVariantIds(taskVariantIds);
+      const scoringVersionByVariant = new Map<string, number>();
+      for (const param of allParams) {
+        if (param.name === 'scoringVersion') {
+          const version = typeof param.value === 'number' ? param.value : Number(param.value);
+          if (!isNaN(version)) {
+            scoringVersionByVariant.set(param.taskVariantId, version);
+          }
+        }
+      }
+
+      // 8. Bulk fetch completed run scores
+      const studentIds = students.map((s) => s.userId);
+      const scoreRows = await reportRepository.getCompletedRunScores(administrationId, studentIds, taskVariantIds);
+
+      // Build a lookup: userId → taskVariantId → Map<scoreName, scoreValue>
+      const scoresByStudentTask = buildScoreLookup(scoreRows);
+
+      // 9. Aggregate per task (deduplicated across variants)
+      const tasks: ServiceTaskScoreOverview[] = taskGroups.map(({ representative, variants }) =>
+        aggregateTaskGroup(
+          representative,
+          variants,
+          students,
+          scoresByStudentTask,
+          scoringVersionByVariant,
+          taskService.evaluateTaskVariantEligibility,
+        ),
+      );
+
+      return { totalStudents, tasks, computedAt: new Date().toISOString() };
+    } catch (error) {
+      if (error instanceof ApiError) throw error;
+
+      logger.error(
+        { err: error, context: { userId, administrationId, scopeType, scopeId } },
+        'Failed to retrieve score overview',
+      );
+
+      throw new ApiError('Failed to retrieve score overview', {
+        statusCode: StatusCodes.INTERNAL_SERVER_ERROR,
+        code: ApiErrorCode.DATABASE_QUERY_FAILED,
+        context: { userId, administrationId },
+        cause: error,
+      });
+    }
+  }
+
+  return { listProgressStudents, getProgressOverview, getScoreOverview };
 }
 
 // --- Progress sort/filter resolution helpers ---
@@ -651,4 +848,248 @@ export function buildProgressMap(
   }
 
   return progress;
+}
+
+// --- Score overview helpers ---
+
+/** Nested lookup: userId → taskVariantId → scoreName → scoreValue (raw string from FDW). */
+type ScoreLookup = Map<string, Map<string, Map<string, string>>>;
+
+/** A group of task variants sharing the same taskId. */
+interface TaskGroup {
+  /** First variant in orderIndex order — used for taskId, taskSlug, taskName, orderIndex */
+  representative: ReportTaskMeta;
+  /** All variants for this taskId, in orderIndex order */
+  variants: ReportTaskMeta[];
+}
+
+/**
+ * Group task variants by taskId, preserving the orderIndex ordering of the input.
+ * Returns one TaskGroup per unique taskId, using the lowest-orderIndex variant
+ * as the representative (for metadata in the response).
+ *
+ * Exported for independent testing.
+ */
+export function groupVariantsByTaskId(taskMetas: ReportTaskMeta[]): TaskGroup[] {
+  const groups = new Map<string, ReportTaskMeta[]>();
+  const orderedTaskIds: string[] = [];
+  for (const meta of taskMetas) {
+    const existing = groups.get(meta.taskId);
+    if (existing) {
+      existing.push(meta);
+    } else {
+      groups.set(meta.taskId, [meta]);
+      orderedTaskIds.push(meta.taskId);
+    }
+  }
+
+  return orderedTaskIds.map((taskId) => {
+    const variants = groups.get(taskId)!;
+    return { representative: variants[0]!, variants };
+  });
+}
+
+/**
+ * Build a nested lookup: userId → taskVariantId → Map<scoreName, scoreValue>.
+ * For duplicate score names within the same user-task-variant, the last value wins.
+ */
+function buildScoreLookup(scoreRows: RunScoreRow[]): ScoreLookup {
+  const lookup: ScoreLookup = new Map();
+  for (const row of scoreRows) {
+    if (!lookup.has(row.userId)) {
+      lookup.set(row.userId, new Map());
+    }
+    const userScores = lookup.get(row.userId)!;
+    if (!userScores.has(row.taskVariantId)) {
+      userScores.set(row.taskVariantId, new Map());
+    }
+    userScores.get(row.taskVariantId)!.set(row.scoreName, row.scoreValue);
+  }
+  return lookup;
+}
+
+/**
+ * Build an empty task overview (all zeros) for when there are no students or
+ * no variants are in scope after filtering.
+ */
+function buildEmptyTaskOverview(task: ReportTaskMeta): ServiceTaskScoreOverview {
+  return {
+    taskId: task.taskId,
+    taskSlug: task.taskSlug,
+    taskName: task.taskName,
+    orderIndex: task.orderIndex,
+    totalAssessed: 0,
+    totalNotAssessed: { required: 0, optional: 0 },
+    supportLevels: {
+      achievedSkill: { count: 0, percentage: 0 },
+      developingSkill: { count: 0, percentage: 0 },
+      needsExtraSupport: { count: 0, percentage: 0 },
+    },
+  };
+}
+
+/**
+ * Find the first variant (in orderIndex order) with completed run scores for a student.
+ * Returns the variant and its score map, or null if no variant has scores.
+ */
+function findScoredVariant(
+  userId: string,
+  variants: ReportTaskMeta[],
+  scoresByStudentTask: ScoreLookup,
+): { variant: ReportTaskMeta; scores: Map<string, string> } | null {
+  const userScores = scoresByStudentTask.get(userId);
+  if (!userScores) return null;
+
+  for (const variant of variants) {
+    const scores = userScores.get(variant.taskVariantId);
+    if (scores && scores.size > 0) {
+      return { variant, scores };
+    }
+  }
+  return null;
+}
+
+/**
+ * Evaluate eligibility across all variants of a task for a student.
+ *
+ * A student is "assigned" if ANY variant assigns them. They are "optional" only
+ * if every assigning variant marks them as optional. This mirrors the priority
+ * logic in `buildProgressMap`: a student's effective status is their best across
+ * all variants of the same task.
+ */
+function evaluateEligibilityAcrossVariants(
+  student: StudentOverviewRow,
+  variants: ReportTaskMeta[],
+  evaluateEligibility: EligibilityEvaluator,
+): { isAssigned: boolean; isOptional: boolean } {
+  let anyAssigned = false;
+  let anyRequired = false;
+
+  for (const variant of variants) {
+    const { isAssigned, isOptional } = evaluateEligibility(
+      student,
+      variant.conditionsAssignment,
+      variant.conditionsRequirements,
+    );
+    if (isAssigned) {
+      anyAssigned = true;
+      if (!isOptional) anyRequired = true;
+    }
+  }
+
+  return { isAssigned: anyAssigned, isOptional: anyAssigned && !anyRequired };
+}
+
+/**
+ * Resolve a numeric score from the score map by trying each field name in order.
+ * Uses parseScoreValue from the scoring service to handle angle-bracket strings
+ * like ">99" or "<1" found in newer norming tables.
+ *
+ * Returns the first valid numeric value found, or null if none match.
+ */
+function resolveNumericScore(scores: Map<string, string>, fieldNames: string[]): number | null {
+  for (const name of fieldNames) {
+    const raw = scores.get(name);
+    if (raw !== undefined) {
+      const parsed = parseScoreValue(raw);
+      if (parsed !== null) return parsed;
+    }
+  }
+  return null;
+}
+
+/**
+ * Resolve a string score (e.g., assessment-computed support level for roam-alpaca)
+ * from the score map by trying each field name in order.
+ */
+function resolveStringScore(scores: Map<string, string>, fieldNames: string[]): string | null {
+  for (const name of fieldNames) {
+    const raw = scores.get(name);
+    if (raw !== undefined) return raw;
+  }
+  return null;
+}
+
+/**
+ * Aggregate support level distributions for a task across all its variants.
+ *
+ * Multi-variant deduplication: when a task has multiple variants (e.g., grade-specific),
+ * each student is counted once at the first variant that has completed run scores.
+ * For students with no completed runs on any variant, condition evaluation checks
+ * all variants — the student is "assigned" if ANY variant assigns them, and "optional"
+ * only if all matching variants are optional.
+ */
+function aggregateTaskGroup(
+  representative: ReportTaskMeta,
+  variants: ReportTaskMeta[],
+  students: StudentOverviewRow[],
+  scoresByStudentTask: ScoreLookup,
+  scoringVersionByVariant: Map<string, number>,
+  evaluateEligibility: EligibilityEvaluator,
+): ServiceTaskScoreOverview {
+  let totalAssessed = 0;
+  let notAssessedRequired = 0;
+  let notAssessedOptional = 0;
+  let achievedCount = 0;
+  let developingCount = 0;
+  let needsSupportCount = 0;
+
+  // Conventional score names used by assessment-computed tasks (e.g., roam-alpaca)
+  const ASSESSMENT_SUPPORT_LEVEL_FIELDS = ['supportLevel', 'support_level'];
+
+  for (const student of students) {
+    // Check all variants for this task — use the first with completed scores
+    const scored = findScoredVariant(student.userId, variants, scoresByStudentTask);
+
+    if (scored) {
+      totalAssessed++;
+
+      const scoringVersion = scoringVersionByVariant.get(scored.variant.taskVariantId) ?? null;
+      const gradeLevel = getGradeAsNumber(student.grade);
+      const fieldNames = resolveScoreFieldNames(scored.variant.taskSlug, gradeLevel);
+
+      const percentile = resolveNumericScore(scored.scores, fieldNames.percentileFieldNames);
+      const rawScore = resolveNumericScore(scored.scores, fieldNames.rawScoreFieldNames);
+      const assessmentSupportLevel = resolveStringScore(scored.scores, ASSESSMENT_SUPPORT_LEVEL_FIELDS);
+
+      const supportLevel = getSupportLevel({
+        grade: student.grade,
+        percentile,
+        rawScore,
+        taskSlug: scored.variant.taskSlug,
+        scoringVersion,
+        assessmentSupportLevel,
+      });
+
+      if (supportLevel === 'achievedSkill') achievedCount++;
+      else if (supportLevel === 'developingSkill') developingCount++;
+      else if (supportLevel === 'needsExtraSupport') needsSupportCount++;
+      // null support level (raw-score-only tasks, unknown tasks) → counted in
+      // totalAssessed but not in any bucket
+    } else {
+      // No completed run on any variant — evaluate conditions across all variants.
+      const eligibility = evaluateEligibilityAcrossVariants(student, variants, evaluateEligibility);
+
+      if (!eligibility.isAssigned) continue;
+      if (eligibility.isOptional) notAssessedOptional++;
+      else notAssessedRequired++;
+    }
+  }
+
+  // Round percentages to 1 decimal place
+  const pct = (count: number) => (totalAssessed > 0 ? Math.round((count / totalAssessed) * 1000) / 10 : 0);
+
+  return {
+    taskId: representative.taskId,
+    taskSlug: representative.taskSlug,
+    taskName: representative.taskName,
+    orderIndex: representative.orderIndex,
+    totalAssessed,
+    totalNotAssessed: { required: notAssessedRequired, optional: notAssessedOptional },
+    supportLevels: {
+      achievedSkill: { count: achievedCount, percentage: pct(achievedCount) },
+      developingSkill: { count: developingCount, percentage: pct(developingCount) },
+      needsExtraSupport: { count: needsSupportCount, percentage: pct(needsSupportCount) },
+    },
+  };
 }

--- a/apps/backend/src/services/report/report.service.ts
+++ b/apps/backend/src/services/report/report.service.ts
@@ -548,10 +548,13 @@ export function ReportService({
       // 3. Get task metadata
       let taskMetas = await reportRepository.getTaskMetadata(administrationId);
 
-      // 4. Extract taskId filter (if any) and user-level filters separately
-      const taskIdFilter = filter.find((f) => f.field === 'taskId');
-      if (taskIdFilter) {
-        const allowedTaskIds = new Set(taskIdFilter.value.split(',').map((v) => v.trim()));
+      // 4. Extract taskId filters (if any) and user-level filters separately.
+      // Multiple `taskId:in:...` filter entries are merged into a single allow-list —
+      // a client passing `?filter=taskId:in:a,b&filter=taskId:in:c` should see all three.
+      // Using filter().flatMap() rather than find() to avoid silently dropping later entries.
+      const taskIdFilters = filter.filter((f) => f.field === 'taskId');
+      if (taskIdFilters.length > 0) {
+        const allowedTaskIds = new Set(taskIdFilters.flatMap((f) => f.value.split(',').map((v) => v.trim())));
         taskMetas = taskMetas.filter((t) => allowedTaskIds.has(t.taskId));
       }
 
@@ -563,18 +566,28 @@ export function ReportService({
             })
           : undefined;
 
-      // 5. Get all students in scope (no pagination — overview aggregates the full population)
+      // 5. Group variants by taskId for multi-variant deduplication.
+      // Multiple variants can share a taskId (e.g., grade-specific variants).
+      // Each student should be counted once per task at their best variant's score.
+      // This is pure (no I/O), so derive it before any DB calls — when a taskId
+      // filter eliminates every task we can short-circuit without touching the DB.
+      const taskGroups = groupVariantsByTaskId(taskMetas);
+
+      if (taskGroups.length === 0) {
+        return {
+          totalStudents: 0,
+          tasks: [],
+          computedAt: new Date().toISOString(),
+        };
+      }
+
+      // 6. Get all students in scope (no pagination — overview aggregates the full population)
       const { totalStudents, students } = await reportRepository.getAllStudentsInScope(
         { scopeType, scopeId },
         filterCondition,
       );
 
-      // 6. Group variants by taskId for multi-variant deduplication.
-      // Multiple variants can share a taskId (e.g., grade-specific variants).
-      // Each student should be counted once per task at their best variant's score.
-      const taskGroups = groupVariantsByTaskId(taskMetas);
-
-      if (totalStudents === 0 || taskGroups.length === 0) {
+      if (totalStudents === 0) {
         return {
           totalStudents,
           tasks: taskGroups.map(({ representative }) => buildEmptyTaskOverview(representative)),
@@ -626,7 +639,7 @@ export function ReportService({
       throw new ApiError('Failed to retrieve score overview', {
         statusCode: StatusCodes.INTERNAL_SERVER_ERROR,
         code: ApiErrorCode.DATABASE_QUERY_FAILED,
-        context: { userId, administrationId },
+        context: { userId, administrationId, scopeType, scopeId },
         cause: error,
       });
     }

--- a/apps/backend/src/services/report/report.service.ts
+++ b/apps/backend/src/services/report/report.service.ts
@@ -865,6 +865,15 @@ export function buildProgressMap(
 
 // --- Score overview helpers ---
 
+/**
+ * Conventional score names that hold the assessment-computed support level
+ * for tasks like `roam-alpaca`. The scoring service's
+ * `getSupportLevelFieldName(taskSlug)` is the source of truth per slug; this
+ * list is the order in which we probe `run_scores` if the slug-specific name
+ * isn't in the score map (handles the `support_level` snake_case alias too).
+ */
+const ASSESSMENT_SUPPORT_LEVEL_FIELDS: ReadonlyArray<string> = ['supportLevel', 'support_level'];
+
 /** Nested lookup: userId → taskVariantId → scoreName → scoreValue (raw string from FDW). */
 type ScoreLookup = Map<string, Map<string, Map<string, string>>>;
 
@@ -1015,7 +1024,7 @@ function resolveNumericScore(scores: Map<string, string>, fieldNames: string[]):
  * Resolve a string score (e.g., assessment-computed support level for roam-alpaca)
  * from the score map by trying each field name in order.
  */
-function resolveStringScore(scores: Map<string, string>, fieldNames: string[]): string | null {
+function resolveStringScore(scores: Map<string, string>, fieldNames: ReadonlyArray<string>): string | null {
   for (const name of fieldNames) {
     const raw = scores.get(name);
     if (raw !== undefined) return raw;
@@ -1046,9 +1055,6 @@ function aggregateTaskGroup(
   let achievedCount = 0;
   let developingCount = 0;
   let needsSupportCount = 0;
-
-  // Conventional score names used by assessment-computed tasks (e.g., roam-alpaca)
-  const ASSESSMENT_SUPPORT_LEVEL_FIELDS = ['supportLevel', 'support_level'];
 
   for (const student of students) {
     // Check all variants for this task — use the first with completed scores

--- a/apps/backend/src/services/report/report.service.ts
+++ b/apps/backend/src/services/report/report.service.ts
@@ -26,7 +26,7 @@ import { ApiError } from '../../errors/api-error';
 import { logger } from '../../logger';
 import { users } from '../../db/schema';
 import { EntityType } from '../../types/entity-type';
-import { AdministrationRepository } from '../../repositories/administration.repository';
+import { AdministrationService } from '../administration/administration.service';
 import { ReportRepository, REPORT_CONDITION_FIELD_MAP } from '../../repositories/report.repository';
 import type {
   ReportTaskMeta,
@@ -96,96 +96,18 @@ interface TaskStatusCounter {
  * @returns ReportService methods
  */
 export function ReportService({
-  administrationRepository = new AdministrationRepository(),
+  administrationService = AdministrationService(),
   reportRepository = new ReportRepository(),
   taskService = TaskService(),
   authorizationService = AuthorizationService(),
   taskVariantParameterRepository = new TaskVariantParameterRepository(),
 }: {
-  administrationRepository?: AdministrationRepository;
+  administrationService?: ReturnType<typeof AdministrationService>;
   reportRepository?: ReportRepository;
   taskService?: ReturnType<typeof TaskService>;
   authorizationService?: ReturnType<typeof AuthorizationService>;
   taskVariantParameterRepository?: TaskVariantParameterRepository;
 } = {}) {
-  /**
-   * Verify that an administration exists and the user has progress-read access.
-   *
-   * Combines the old 3-step check (administration access → Reports.Progress.READ
-   * permission → supervisory role) into a single FGA call. The FGA model defines
-   * `can_read_progress: supervisory_tier_group` on the administration type, which
-   * grants access only to users with admin-tier or educator-tier roles on the
-   * administration's assigned entities — exactly the same set that previously
-   * passed both the permission and supervisory role checks.
-   *
-   * Follows the 404-before-403 pattern: checks existence first so a missing
-   * administration returns 404, not a misleading 403.
-   *
-   * @param authContext - User's auth context
-   * @param administrationId - The administration ID to verify
-   * @throws {ApiError} NOT_FOUND if administration doesn't exist
-   * @throws {ApiError} FORBIDDEN if user lacks can_read_progress on the administration
-   */
-  async function verifyAdministrationProgressAccess(authContext: AuthContext, administrationId: string) {
-    const { userId, isSuperAdmin } = authContext;
-
-    const administration = await administrationRepository.getById({ id: administrationId });
-    if (!administration) {
-      throw new ApiError('Administration not found', {
-        statusCode: StatusCodes.NOT_FOUND,
-        code: ApiErrorCode.RESOURCE_NOT_FOUND,
-        context: { userId, administrationId },
-      });
-    }
-
-    if (isSuperAdmin) return;
-
-    await authorizationService.requirePermission(
-      userId,
-      FgaRelation.CAN_READ_PROGRESS,
-      `${FgaType.ADMINISTRATION}:${administrationId}`,
-    );
-  }
-
-  /**
-   * Verify that an administration exists and the user has score-read access.
-   *
-   * Mirrors `verifyAdministrationProgressAccess` but checks the FGA
-   * `can_read_scores` relation instead of `can_read_progress`. The FGA model
-   * defines both as `supervisory_tier_group` on the administration type, so the
-   * set of permitted users is the same shape (admin-tier or educator-tier roles
-   * on an assigned entity), but the permissions are distinct so they can diverge
-   * in the future without changing this code.
-   *
-   * Follows the 404-before-403 pattern: checks existence first so a missing
-   * administration returns 404, not a misleading 403.
-   *
-   * @param authContext - User's auth context
-   * @param administrationId - The administration ID to verify
-   * @throws {ApiError} NOT_FOUND if administration doesn't exist
-   * @throws {ApiError} FORBIDDEN if user lacks can_read_scores on the administration
-   */
-  async function verifyAdministrationScoreReadAccess(authContext: AuthContext, administrationId: string) {
-    const { userId, isSuperAdmin } = authContext;
-
-    const administration = await administrationRepository.getById({ id: administrationId });
-    if (!administration) {
-      throw new ApiError('Administration not found', {
-        statusCode: StatusCodes.NOT_FOUND,
-        code: ApiErrorCode.RESOURCE_NOT_FOUND,
-        context: { userId, administrationId },
-      });
-    }
-
-    if (isSuperAdmin) return;
-
-    await authorizationService.requirePermission(
-      userId,
-      FgaRelation.CAN_READ_SCORES,
-      `${FgaType.ADMINISTRATION}:${administrationId}`,
-    );
-  }
-
   /** Map report scope types to FGA object type prefixes. */
   const SCOPE_TO_FGA_TYPE: Record<ScopeType, FgaType> = {
     [EntityType.DISTRICT]: FgaType.DISTRICT,
@@ -251,7 +173,8 @@ export function ReportService({
    *
    * Authorization flow (two FGA checks, in order):
    *
-   * 1. **Administration progress access** (verifyAdministrationProgressAccess):
+   * 1. **Administration progress access** (AdministrationService.verifyAdministrationAccess
+   *    with `CAN_READ_PROGRESS`):
    *    Checks existence (404 before 403) then verifies `can_read_progress` on the
    *    administration via FGA. This replaces the old 3-step pattern (administration
    *    access → Reports.Progress.READ → hasSupervisoryRole) with a single call.
@@ -282,7 +205,11 @@ export function ReportService({
 
     try {
       // 1. Verify administration exists and user has can_read_progress
-      await verifyAdministrationProgressAccess(authContext, administrationId);
+      await administrationService.verifyAdministrationAccess(
+        authContext,
+        administrationId,
+        FgaRelation.CAN_READ_PROGRESS,
+      );
 
       // 2. Validate scope and authorize can_read_progress on the scope entity
       await authorizeScopeAccess(authContext, administrationId, scopeType, scopeId);
@@ -388,7 +315,11 @@ export function ReportService({
 
     try {
       // 1. Verify administration exists and user has can_read_progress
-      await verifyAdministrationProgressAccess(authContext, administrationId);
+      await administrationService.verifyAdministrationAccess(
+        authContext,
+        administrationId,
+        FgaRelation.CAN_READ_PROGRESS,
+      );
 
       // 2. Validate scope and authorize can_read_progress on the scope entity
       await authorizeScopeAccess(authContext, administrationId, scopeType, scopeId);
@@ -505,7 +436,8 @@ export function ReportService({
    *
    * Authorization (two FGA checks, in order):
    *
-   * 1. **Administration score-read access** (verifyAdministrationScoreReadAccess):
+   * 1. **Administration score-read access** (AdministrationService.verifyAdministrationAccess
+   *    with `CAN_READ_SCORES`):
    *    Checks existence (404 before 403) then verifies `can_read_scores` on the
    *    administration via FGA. The FGA model grants this only to admin-tier and
    *    educator-tier roles, denying students and caregivers.
@@ -540,7 +472,11 @@ export function ReportService({
 
     try {
       // 1. Verify administration exists and user has can_read_scores
-      await verifyAdministrationScoreReadAccess(authContext, administrationId);
+      await administrationService.verifyAdministrationAccess(
+        authContext,
+        administrationId,
+        FgaRelation.CAN_READ_SCORES,
+      );
 
       // 2. Validate scope and authorize can_read_scores on the scope entity
       await authorizeScopeAccess(authContext, administrationId, scopeType, scopeId, FgaRelation.CAN_READ_SCORES);

--- a/apps/backend/src/services/report/report.types.ts
+++ b/apps/backend/src/services/report/report.types.ts
@@ -129,11 +129,9 @@ export interface ScoreOverviewInput {
   filter: ParsedFilter[];
 }
 
-/** Support level distribution counts and percentages for a single category. */
+/** Support level distribution counts for a single category. */
 export interface ServiceSupportLevelEntry {
   count: number;
-  /** Percentage of totalAssessed (0-100), rounded to 1 decimal place */
-  percentage: number;
 }
 
 /** Per-task score overview with support level distribution. */

--- a/apps/backend/src/services/report/report.types.ts
+++ b/apps/backend/src/services/report/report.types.ts
@@ -121,3 +121,46 @@ export interface ProgressOverviewResult {
   byTask: ServiceTaskOverview[];
   computedAt: string;
 }
+
+/** Query input for getScoreOverview. */
+export interface ScoreOverviewInput {
+  scopeType: ScopeType;
+  scopeId: string;
+  filter: ParsedFilter[];
+}
+
+/** Support level distribution counts and percentages for a single category. */
+export interface ServiceSupportLevelEntry {
+  count: number;
+  /** Percentage of totalAssessed (0-100), rounded to 1 decimal place */
+  percentage: number;
+}
+
+/** Per-task score overview with support level distribution. */
+export interface ServiceTaskScoreOverview {
+  taskId: string;
+  taskSlug: string;
+  taskName: string;
+  orderIndex: number;
+  /** Number of students with a completed run and classifiable scores */
+  totalAssessed: number;
+  /** Students with no completed run, split by assignment status */
+  totalNotAssessed: {
+    required: number;
+    optional: number;
+  };
+  /** Support level distribution (only for assessed students) */
+  supportLevels: {
+    achievedSkill: ServiceSupportLevelEntry;
+    developingSkill: ServiceSupportLevelEntry;
+    needsExtraSupport: ServiceSupportLevelEntry;
+  };
+}
+
+/** Return type for getScoreOverview. */
+export interface ScoreOverviewResult {
+  totalStudents: number;
+  tasks: ServiceTaskScoreOverview[];
+  /** ISO 8601 timestamp when the aggregation was computed */
+  computedAt: string;
+}

--- a/apps/backend/src/test-support/repositories/report.repository.ts
+++ b/apps/backend/src/test-support/repositories/report.repository.ts
@@ -15,6 +15,8 @@ export function createMockReportRepository(): MockedObject<ReportRepository> {
     getUserRolesAtOrAboveScope: vi.fn(),
     getProgressStudents: vi.fn(),
     getProgressOverviewCounts: vi.fn(),
+    getAllStudentsInScope: vi.fn(),
+    getCompletedRunScores: vi.fn(),
   } as unknown as MockedObject<ReportRepository>;
 }
 

--- a/packages/api-contract/src/v1/administrations/contract.ts
+++ b/packages/api-contract/src/v1/administrations/contract.ts
@@ -12,6 +12,7 @@ import {
 } from './schema';
 import { ErrorEnvelopeSchema, SuccessEnvelopeSchema } from '../response';
 import { ProgressReportsContract } from './reports/progress/index';
+import { ScoreReportsContract } from './reports/scores/index';
 
 const c = initContract();
 
@@ -143,6 +144,7 @@ export const AdministrationsContract = c.router(
     },
     // Nest report sub-routers under /administrations
     progressReports: ProgressReportsContract,
+    scoreReports: ScoreReportsContract,
   },
   { pathPrefix: '/administrations' },
 );

--- a/packages/api-contract/src/v1/administrations/reports/index.ts
+++ b/packages/api-contract/src/v1/administrations/reports/index.ts
@@ -1,2 +1,3 @@
 export * from './common';
 export * from './progress/index';
+export * from './scores/index';

--- a/packages/api-contract/src/v1/administrations/reports/scores/contract.ts
+++ b/packages/api-contract/src/v1/administrations/reports/scores/contract.ts
@@ -1,0 +1,40 @@
+import { initContract } from '@ts-rest/core';
+import { z } from 'zod';
+import { ScoreOverviewQuerySchema, ScoreOverviewResponseSchema } from './schema';
+import { ErrorEnvelopeSchema, SuccessEnvelopeSchema } from '../../../response';
+
+const c = initContract();
+
+/**
+ * Contract for score report endpoints.
+ * Nested under AdministrationsContract — the parent provides the /administrations pathPrefix.
+ */
+export const ScoreReportsContract = c.router({
+  getOverview: {
+    method: 'GET',
+    path: '/:id/reports/scores/overview',
+    pathParams: z.object({ id: z.string().uuid() }),
+    query: ScoreOverviewQuerySchema,
+    responses: {
+      200: SuccessEnvelopeSchema(ScoreOverviewResponseSchema),
+      400: ErrorEnvelopeSchema,
+      401: ErrorEnvelopeSchema,
+      403: ErrorEnvelopeSchema,
+      404: ErrorEnvelopeSchema,
+      500: ErrorEnvelopeSchema,
+    },
+    strictStatusCodes: true,
+    summary: 'Get score overview for an administration',
+    description:
+      'Returns aggregated support level distributions per task for all students in scope. ' +
+      'Not paginated — aggregates across the full population. ' +
+      'Scoped to a specific org, class, or group via scopeType/scopeId.\n\n' +
+      'Status codes:\n' +
+      '- 200: Aggregated statistics returned successfully\n' +
+      '- 400: Invalid scope (scopeId not assigned to this administration)\n' +
+      '- 401: Missing or invalid authentication token\n' +
+      '- 403: User lacks can_read_scores at the requested administration or scope level\n' +
+      '- 404: Administration not found\n' +
+      '- 500: Internal server error',
+  },
+});

--- a/packages/api-contract/src/v1/administrations/reports/scores/index.ts
+++ b/packages/api-contract/src/v1/administrations/reports/scores/index.ts
@@ -1,0 +1,2 @@
+export * from './schema';
+export * from './contract';

--- a/packages/api-contract/src/v1/administrations/reports/scores/schema.ts
+++ b/packages/api-contract/src/v1/administrations/reports/scores/schema.ts
@@ -1,0 +1,69 @@
+import { z } from 'zod';
+import { ReportScopeQuerySchema, createFilterQuerySchema, ReportTaskMetadataSchema } from '../common';
+
+/**
+ * Filter fields for the score overview endpoint.
+ *
+ * - `taskId`: limit which tasks are included in the aggregation (use `in` operator)
+ * - `user.grade`: filter the student population by grade before aggregation
+ *
+ * Note: `user.schoolName` filtering is deferred — it requires a join through
+ * org membership that is not yet implemented in the repository layer.
+ */
+export const SCORE_OVERVIEW_FILTER_FIELDS = ['taskId', 'user.grade'] as const;
+
+export type ScoreOverviewFilterField = (typeof SCORE_OVERVIEW_FILTER_FIELDS)[number];
+
+/**
+ * Query schema for the score overview endpoint.
+ * Combines scope and filter parameters. Not paginated — this is an aggregation.
+ */
+export const ScoreOverviewQuerySchema = ReportScopeQuerySchema.merge(
+  createFilterQuerySchema(SCORE_OVERVIEW_FILTER_FIELDS),
+);
+
+export type ScoreOverviewQuery = z.infer<typeof ScoreOverviewQuerySchema>;
+
+/**
+ * Support level distribution counts and percentages for a single category.
+ */
+export const SupportLevelEntrySchema = z.object({
+  count: z.number().int(),
+  /** Percentage of totalAssessed (0-100), rounded to 1 decimal place */
+  percentage: z.number(),
+});
+
+export type SupportLevelEntry = z.infer<typeof SupportLevelEntrySchema>;
+
+/**
+ * Per-task score overview with support level distribution.
+ */
+export const TaskScoreOverviewSchema = ReportTaskMetadataSchema.extend({
+  /** Number of students with a completed run and classifiable scores */
+  totalAssessed: z.number().int(),
+  /** Students with no completed run, split by assignment status */
+  totalNotAssessed: z.object({
+    required: z.number().int(),
+    optional: z.number().int(),
+  }),
+  /** Support level distribution (only for assessed students) */
+  supportLevels: z.object({
+    achievedSkill: SupportLevelEntrySchema,
+    developingSkill: SupportLevelEntrySchema,
+    needsExtraSupport: SupportLevelEntrySchema,
+  }),
+});
+
+export type TaskScoreOverview = z.infer<typeof TaskScoreOverviewSchema>;
+
+/**
+ * Response schema for the score overview endpoint.
+ */
+export const ScoreOverviewResponseSchema = z.object({
+  totalStudents: z.number().int(),
+  tasks: z.array(TaskScoreOverviewSchema),
+  /** Server timestamp when the aggregation was computed (ISO 8601) */
+  computedAt: z.string().datetime(),
+});
+
+export type ScoreOverviewResponse = z.infer<typeof ScoreOverviewResponseSchema>;

--- a/packages/api-contract/src/v1/administrations/reports/scores/schema.ts
+++ b/packages/api-contract/src/v1/administrations/reports/scores/schema.ts
@@ -26,6 +26,14 @@ export type ScoreOverviewQuery = z.infer<typeof ScoreOverviewQuerySchema>;
 
 /**
  * Support level distribution counts and percentages for a single category.
+ *
+ * Note: the three support-level percentages (achievedSkill, developingSkill,
+ * needsExtraSupport) are not guaranteed to sum to 100%. Students with completed
+ * runs whose scores can't be classified (null `getSupportLevel` return — e.g.,
+ * raw-score-only tasks, unknown task slugs, or unresolvable thresholds for the
+ * scoring version) are counted in `totalAssessed` but in none of the three
+ * buckets, so the bucket sum can be less than `totalAssessed` and the
+ * percentages can sum to less than 100%.
  */
 export const SupportLevelEntrySchema = z.object({
   count: z.number().int(),

--- a/packages/api-contract/src/v1/administrations/reports/scores/schema.ts
+++ b/packages/api-contract/src/v1/administrations/reports/scores/schema.ts
@@ -25,20 +25,10 @@ export const ScoreOverviewQuerySchema = ReportScopeQuerySchema.merge(
 export type ScoreOverviewQuery = z.infer<typeof ScoreOverviewQuerySchema>;
 
 /**
- * Support level distribution counts and percentages for a single category.
- *
- * Note: the three support-level percentages (achievedSkill, developingSkill,
- * needsExtraSupport) are not guaranteed to sum to 100%. Students with completed
- * runs whose scores can't be classified (null `getSupportLevel` return — e.g.,
- * raw-score-only tasks, unknown task slugs, or unresolvable thresholds for the
- * scoring version) are counted in `totalAssessed` but in none of the three
- * buckets, so the bucket sum can be less than `totalAssessed` and the
- * percentages can sum to less than 100%.
+ * Support level distribution counts for a single category.
  */
 export const SupportLevelEntrySchema = z.object({
   count: z.number().int(),
-  /** Percentage of totalAssessed (0-100), rounded to 1 decimal place */
-  percentage: z.number(),
 });
 
 export type SupportLevelEntry = z.infer<typeof SupportLevelEntrySchema>;


### PR DESCRIPTION
## Summary

This PR adds a new `GET /v1/administrations/:id/reports/scores/overview` endpoint that returns aggregated support-level distributions per task for all students within a requested scope, alongside the existing progress overview endpoint. It powers the overview charts at the top of the score report page, replacing client-side scoring logic with server-side aggregation backed by the new config-driven scoring service.

## Endpoint

- **Method:** `GET`
- **Path:** `/v1/administrations/:id/reports/scores/overview`
- **Required query params:** `scopeType` (`district` | `school` | `class` | `group`), `scopeId` (UUID)
- **Optional query params:** `filter` — supports `taskId:in:<uuid,uuid>` to narrow the task set and `user.grade:eq:<grade>` to narrow the student population. `user.schoolName` filtering is intentionally deferred (requires an org-membership join not yet wired up).

The endpoint is **not paginated** — it aggregates across the full population in scope.

### Response shape

```typescript
{
  totalStudents: number,
  tasks: Array<{
    taskId: string,
    taskSlug: string,
    taskName: string,
    orderIndex: number,
    totalAssessed: number,
    totalNotAssessed: { required: number, optional: number },
    supportLevels: {
      achievedSkill:    { count: number, percentage: number },
      developingSkill:  { count: number, percentage: number },
      needsExtraSupport: { count: number, percentage: number },
    },
  }>,
  computedAt: string,  // ISO 8601, server-set per request
}
```

## Authorization

The service performs two FGA checks, in order:

1. **Administration-level:** `can_read_scores` on `administration:<id>` — gate on read access to the administration overall.
2. **Scope-level:** `can_read_scores` on `<scopeType>:<scopeId>` — prevents a teacher at School A from viewing School B's scores within a shared district administration.

Both relations are defined as `supervisory_tier_group` in the FGA model (the same shape as `can_read_progress`), so admin-tier and educator-tier roles are permitted while students and caregivers are denied. The existing `FgaRelation.CAN_READ_SCORES` constant is reused — no FGA model changes were required.

Super admins bypass both checks. The endpoint follows the 404-before-403 pattern: a missing administration returns 404, not a misleading 403.

```mermaid
sequenceDiagram
    autonumber
    participant Client
    participant Route as Route (administrations.ts)
    participant Ctrl as Controller
    participant Svc as ReportService
    participant Repo as ReportRepository
    participant FGA as AuthorizationService

    Client->>Route: GET /administrations/:id/reports/scores/overview
    Route->>Ctrl: getScoreOverview(authContext, id, query)
    Ctrl->>Svc: getScoreOverview(authContext, id, query)
    Svc->>Repo: getById(id)
    alt Not found
        Repo-->>Svc: null
        Svc-->>Ctrl: ApiError 404
    else Found
        Svc->>FGA: requirePermission(userId, can_read_scores, administration:id)
        Svc->>Repo: isScopeAssignedToAdministration(id, scope)
        Svc->>FGA: requirePermission(userId, can_read_scores, scopeType:scopeId)
        Svc->>Repo: getTaskMetadata(id)
        Svc->>Repo: getAllStudentsInScope(scope, filter)
        Svc->>Repo: getCompletedRunScores(id, studentIds, variantIds)
        Note over Svc: Multi-variant dedup<br/>+ scoring classification
        Svc-->>Ctrl: ScoreOverviewResult
        Ctrl-->>Client: 200 { data: ... }
    end
```

## Multi-variant deduplication

Administrations may assign multiple variants of the same task (e.g., grade-specific variants). The service groups variants by `taskId` and ensures each student counts at most once per task:

- **Assessed students:** the first variant (in `orderIndex` order) with completed run scores wins. The student is classified using that variant's scores via `getSupportLevel()`.
- **Not-assessed students:** eligibility is evaluated across **all** variants of the task. A student is "assigned" if any variant assigns them; "optional" only if every assigning variant marks them as optional. This mirrors the priority logic in `buildProgressMap` for the progress overview.

## Files changed

- `packages/api-contract/src/v1/administrations/reports/scores/{schema,contract,index}.ts` — new sub-router contract under `AdministrationsContract`, added `scoreReports` member to the parent contract and re-exported from `reports/index.ts`.
- `apps/backend/src/repositories/report.repository.ts` — added `getAllStudentsInScope` and `getCompletedRunScores` methods plus the `StudentOverviewRow` and `RunScoreRow` row types. Reuses the existing `buildStudentInScopeQuery` helper.
- `apps/backend/src/services/report/report.service.ts` — added `verifyAdministrationScoreReadAccess`, parameterized `authorizeScopeAccess` with an optional `relation` (default `CAN_READ_PROGRESS`) so it can be reused for `CAN_READ_SCORES`, added the `getScoreOverview` method, and added private helpers (`groupVariantsByTaskId` exported for unit testing, `aggregateTaskGroup`, `findScoredVariant`, `evaluateEligibilityAcrossVariants`, `resolveNumericScore`, `resolveStringScore`, `buildScoreLookup`, `buildEmptyTaskOverview`).
- `apps/backend/src/services/report/report.types.ts` — added `ScoreOverviewInput`, `ScoreOverviewResult`, `ServiceTaskScoreOverview`, `ServiceSupportLevelEntry`.
- `apps/backend/src/controllers/administrations.controller.ts` — added `getScoreOverview` controller method following the `getProgressOverview` pattern. Service and contract types are structurally identical, so the result is returned directly.
- `apps/backend/src/routes/administrations.ts` — wired `scoreReports.getOverview` inside the existing `AdministrationsContract` router.
- `apps/backend/src/test-support/repositories/report.repository.ts` — added `getAllStudentsInScope` and `getCompletedRunScores` mocks.

## Test coverage

### Service unit tests (`report.service.test.ts`)

Authorization and lifecycle: 404 on missing administration; 403 when FGA denies `can_read_scores` at administration or scope level; 400 when scope isn't assigned; super admin bypass; empty results when no students or no tasks; ISO 8601 `computedAt`.

Aggregation: assessed counting, not-assessed required/optional split, exclusion of unassigned students, percentage rounding, multi-variant dedup (variant-A-wins for scored students, any-required-wins for not-assessed students).

Edge cases: `taskId` filter excludes everything → empty `tasks` short-circuit; scoring version edge cases (non-`scoringVersion` params ignored, non-numeric values ignored, string-numeric values accepted — observed via swr's v0 vs v7 cutoffs); assessment-computed classification for `roam-alpaca` via the `supportLevel` score field; angle-bracket percentile strings (`">99"`); unresolvable scores (totalAssessed++ but no bucket increment, not double-counted as not-assessed).

Helper unit tests: `groupVariantsByTaskId` covering empty input, dedup with representative selection, and input-order preservation.

### Controller unit tests (`administrations.controller.test.ts`)

Success path with full data round-trip; ApiError → typed error response mapping for 400, 403, 404, and 500; non-ApiError re-throw; argument forwarding to the service.

### Route integration tests (`reports.integration.test.ts`)

Authorization: 401, super admin, district admin, site admin, district teacher 403, school principal at school scope 200, school principal at district scope 403, student 403, caregiver 403, cross-district admin 403, class teacher requesting school scope 403.

Scope validation: 400 for unassigned scope, 400 for missing `scopeType` / `scopeId`, 404 for non-existent administration.

Response shape: full structural assertions; per-task internal consistency (bucketed-assessed ≤ totalAssessed, totalEngaged ≤ totalStudents, percentages 0–100 with at most 1 decimal); `taskId` and `user.grade` filter behavior; multi-variant dedup (4 variants of `task` + 2 variants of `task2` collapse to 2 entries); class scope; group scope (empty `tasks`).

FDW-backed: a real completed run + percentile score for `grade5Student` is counted in `totalAssessed`; remaining students without runs land in `totalNotAssessed` and the totals are bounded by `totalStudents`.

## Known follow-ups

- **End-to-end support-level bucket assertion at the integration level.** The base fixture's task uses an auto-generated slug, so the scoring config registry returns `null` and `getSupportLevel` doesn't classify. To verify a specific bucket increment end-to-end we'd need to provision a fresh task with a known slug (e.g., `swr`) plus its own variant and assignment — additional fixture wiring. Classification logic is heavily covered by unit tests via the per-version cutoff observation, so this is a thin gap.
- **`user.schoolName` filtering** is documented as deferred; the endpoint accepts only `taskId` and `user.grade` filters today.

## Validation

Run from the repo root:

```bash
npm run check-types
npm run format:check
npm run test:unit -w apps/backend
npm run test:integration -w apps/backend  # requires a running Postgres
```

Resolves [1682](https://github.com/yeatmanlab/roar-project-management/issues/1682)

## Types of changes

What types of changes does this pull request introduce?

<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (non-breaking change that does not add functionality but makes code cleaner or more efficient)
- [x] Documentation Update
- [x] Tests (new or updated tests)
- [ ] Style (changes to code styling)
- [ ] CI (continuous integration changes)
- [ ] Repository Maintenance
- [ ] Other (please describe below)

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask.  We're here
to help! This is simply a reminder of what we are going to look for before
merging your code.
-->

- [x] I have read the [guidelines for contributing](https://github.com/yeatmanlab/roar-dashboard/blob/main/.github/CONTRIBUTING.md).
- [x] The changes in this PR are as small as they can be. They represent one and only one fix or enhancement.
- [x] Linting checks pass with my changes.
- [x] Any existing unit tests pass with my changes.
- [x] Any existing end-to-end tests pass with my changes.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] If this PR fixes an existing issue, I have added a unit or end-to-end test that will detect if this issue reoccurs.
- [x] I have added JSDoc comments as appropriate.
- [ ] I have added the necessary documentation to the [roar-docs repository](https://github.com/yeatmanlab/roar-docs).
- [x] I have shared this PR on the roar-pr-reviews channel (if I have access)
- [x] I have linked relevant issues (if any)

## Justification of missing checklist items

<!--
If you feel that a checklist item above is not applicable to this PR, please
provide your justification here. Otherwise, delete this section.
-->

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
