### PR TITLE
Add `GET /v1/administrations/:id/reports/scores/students`

### DIFF
--- a/apps/backend/src/controllers/administrations.controller.test.ts
+++ b/apps/backend/src/controllers/administrations.controller.test.ts
@@ -11,6 +11,7 @@ import type {
   ReportTaskMetadata,
   ProgressStudent,
   ScoreOverviewQuery,
+  StudentScoresQuery,
 } from '@roar-dashboard/api-contract';
 import { ApiError } from '../errors/api-error';
 import { ApiErrorCode } from '../enums/api-error-code.enum';
@@ -2006,6 +2007,151 @@ describe('AdministrationsController', () => {
       await Controller.getScoreOverview(mockAuthContext, testAdminId, scoreQuery);
 
       expect(mockGetScoreOverview).toHaveBeenCalledWith(mockAuthContext, testAdminId, scoreQuery);
+    });
+  });
+
+  describe('listStudentScores', () => {
+    const testAdminId = 'admin-uuid-1';
+
+    const studentScoresQuery: StudentScoresQuery = {
+      scopeType: 'district',
+      scopeId: 'district-uuid-1',
+      page: 1,
+      perPage: 25,
+      sortBy: 'user.lastName',
+      sortOrder: 'asc',
+      filter: [],
+    };
+
+    const testStudentScoresResult = {
+      tasks: [
+        {
+          taskId: 'task-1',
+          taskSlug: 'swr',
+          taskName: 'ROAR - Word',
+          orderIndex: 0,
+        },
+      ],
+      items: [
+        {
+          user: {
+            userId: 'user-1',
+            assessmentPid: null,
+            username: 'jdoe',
+            email: 'jdoe@school.edu',
+            firstName: 'Jane',
+            lastName: 'Doe',
+            grade: '3',
+            schoolName: 'Lincoln Elementary',
+          },
+          scores: {
+            'task-1': {
+              rawScore: 520,
+              percentile: 45,
+              standardScore: 102,
+              supportLevel: 'developingSkill' as const,
+              reliable: true,
+              engagementFlags: [],
+              optional: false,
+              completed: true,
+            },
+          },
+        },
+      ],
+      totalItems: 50,
+    };
+
+    it('returns 200 with paginated student scores and computed totalPages', async () => {
+      mockListStudentScores.mockResolvedValue(testStudentScoresResult);
+
+      const { AdministrationsController: Controller } = await import('./administrations.controller');
+      const result = await Controller.listStudentScores(mockAuthContext, testAdminId, studentScoresQuery);
+
+      const data = expectOkResponse(result);
+      expect(data.tasks).toHaveLength(1);
+      expect(data.items).toHaveLength(1);
+      expect(data.items[0]!.scores['task-1']!.supportLevel).toBe('developingSkill');
+      expect(data.pagination).toEqual({
+        page: 1,
+        perPage: 25,
+        totalItems: 50,
+        totalPages: 2, // ceil(50 / 25)
+      });
+    });
+
+    it('maps ApiError to typed error response for 400', async () => {
+      mockListStudentScores.mockRejectedValue(
+        new ApiError('Bad request', {
+          statusCode: StatusCodes.BAD_REQUEST,
+          code: ApiErrorCode.REQUEST_VALIDATION_FAILED,
+        }),
+      );
+
+      const { AdministrationsController: Controller } = await import('./administrations.controller');
+      const result = await Controller.listStudentScores(mockAuthContext, testAdminId, studentScoresQuery);
+
+      expect(result.status).toBe(StatusCodes.BAD_REQUEST);
+    });
+
+    it('maps ApiError to typed error response for 403', async () => {
+      mockListStudentScores.mockRejectedValue(
+        new ApiError('Forbidden', {
+          statusCode: StatusCodes.FORBIDDEN,
+          code: ApiErrorCode.AUTH_FORBIDDEN,
+        }),
+      );
+
+      const { AdministrationsController: Controller } = await import('./administrations.controller');
+      const result = await Controller.listStudentScores(mockAuthContext, testAdminId, studentScoresQuery);
+
+      expect(result.status).toBe(StatusCodes.FORBIDDEN);
+    });
+
+    it('maps ApiError to typed error response for 404', async () => {
+      mockListStudentScores.mockRejectedValue(
+        new ApiError('Not found', {
+          statusCode: StatusCodes.NOT_FOUND,
+          code: ApiErrorCode.RESOURCE_NOT_FOUND,
+        }),
+      );
+
+      const { AdministrationsController: Controller } = await import('./administrations.controller');
+      const result = await Controller.listStudentScores(mockAuthContext, testAdminId, studentScoresQuery);
+
+      expect(result.status).toBe(StatusCodes.NOT_FOUND);
+    });
+
+    it('maps ApiError to typed error response for 500', async () => {
+      mockListStudentScores.mockRejectedValue(
+        new ApiError('Internal', {
+          statusCode: StatusCodes.INTERNAL_SERVER_ERROR,
+          code: ApiErrorCode.DATABASE_QUERY_FAILED,
+        }),
+      );
+
+      const { AdministrationsController: Controller } = await import('./administrations.controller');
+      const result = await Controller.listStudentScores(mockAuthContext, testAdminId, studentScoresQuery);
+
+      expect(result.status).toBe(StatusCodes.INTERNAL_SERVER_ERROR);
+    });
+
+    it('re-throws non-ApiError errors', async () => {
+      mockListStudentScores.mockRejectedValue(new Error('unexpected'));
+
+      const { AdministrationsController: Controller } = await import('./administrations.controller');
+
+      await expect(Controller.listStudentScores(mockAuthContext, testAdminId, studentScoresQuery)).rejects.toThrow(
+        'unexpected',
+      );
+    });
+
+    it('passes authContext, administrationId, and query to service', async () => {
+      mockListStudentScores.mockResolvedValue(testStudentScoresResult);
+
+      const { AdministrationsController: Controller } = await import('./administrations.controller');
+      await Controller.listStudentScores(mockAuthContext, testAdminId, studentScoresQuery);
+
+      expect(mockListStudentScores).toHaveBeenCalledWith(mockAuthContext, testAdminId, studentScoresQuery);
     });
   });
 });

--- a/apps/backend/src/controllers/administrations.controller.test.ts
+++ b/apps/backend/src/controllers/administrations.controller.test.ts
@@ -54,6 +54,7 @@ describe('AdministrationsController', () => {
   const mockGetScoreOverview = vi.fn();
   const mockGetUserAdministrations = vi.fn();
   const mockGetUserAdministration = vi.fn();
+  const mockListStudentScores = vi.fn();
   const mockAuthContext = { userId: 'user-123', isSuperAdmin: false };
 
   beforeEach(() => {
@@ -78,6 +79,7 @@ describe('AdministrationsController', () => {
       listProgressStudents: mockListProgressStudents,
       getProgressOverview: mockGetProgressOverview,
       getScoreOverview: mockGetScoreOverview,
+      listStudentScores: mockListStudentScores,
     });
   });
   describe('list', () => {

--- a/apps/backend/src/controllers/administrations.controller.ts
+++ b/apps/backend/src/controllers/administrations.controller.ts
@@ -1,5 +1,5 @@
 import { StatusCodes } from 'http-status-codes';
-import type { GetTreeOptions } from '../services/administration/administration.service';
+import type { GetTreeOptions, TreeNodeStats } from '../services/administration/administration.service';
 import { AdministrationService } from '../services/administration/administration.service';
 import { ReportService } from '../services/report/report.service';
 import type {
@@ -10,6 +10,7 @@ import type {
   AdministrationTreeQuery,
   AdministrationsListQuery,
   Condition,
+  CreateAdministrationRequest,
   OrganizationTreeNode,
   ProgressOverviewQuery,
   ProgressStudent,

--- a/apps/backend/src/controllers/administrations.controller.ts
+++ b/apps/backend/src/controllers/administrations.controller.ts
@@ -16,8 +16,8 @@ import type {
   ProgressStudentsQuery,
   ReportTaskMetadata,
   ScoreOverviewQuery,
-  TreeNodeStats,
-  CreateAdministrationRequest,
+  StudentScoresQuery,
+  StudentScoreRow,
 } from '@roar-dashboard/api-contract';
 import type {
   AgreementWithVersion,
@@ -519,6 +519,56 @@ export const AdministrationsController = {
           StatusCodes.BAD_REQUEST,
           StatusCodes.NOT_FOUND,
           StatusCodes.FORBIDDEN,
+          StatusCodes.INTERNAL_SERVER_ERROR,
+        ]);
+      }
+      throw error;
+    }
+  },
+
+  /**
+   * List paginated per-student scores for an administration.
+   *
+   * Delegates to ReportService for authorization, score classification, and
+   * per-row dedup across multi-variant tasks. The service returns
+   * `ServiceStudentScoreRow` objects whose shape is structurally equivalent
+   * to the contract's `StudentScoreRow`, so the result is returned directly.
+   *
+   * @param authContext - User's auth context
+   * @param administrationId - The administration to report on
+   * @param query - Pagination, sort, filter, and scope parameters
+   */
+  listStudentScores: async (authContext: AuthContext, administrationId: string, query: StudentScoresQuery) => {
+    try {
+      const result = await reportService.listStudentScores(authContext, administrationId, query);
+
+      // Service and contract types are structurally equivalent (same field
+      // names: tasks[], items[], totalItems). The cast is implicit via TS structural
+      // typing — see report.types.ts for the source of truth on each side.
+      const tasks: ReportTaskMetadata[] = result.tasks;
+      const items: StudentScoreRow[] = result.items;
+
+      return {
+        status: StatusCodes.OK as const,
+        body: {
+          data: {
+            tasks,
+            items,
+            pagination: {
+              page: query.page,
+              perPage: query.perPage,
+              totalItems: result.totalItems,
+              totalPages: Math.ceil(result.totalItems / query.perPage),
+            },
+          },
+        },
+      };
+    } catch (error) {
+      if (error instanceof ApiError) {
+        return toErrorResponse(error, [
+          StatusCodes.BAD_REQUEST,
+          StatusCodes.FORBIDDEN,
+          StatusCodes.NOT_FOUND,
           StatusCodes.INTERNAL_SERVER_ERROR,
         ]);
       }

--- a/apps/backend/src/repositories/report.repository.ts
+++ b/apps/backend/src/repositories/report.repository.ts
@@ -961,8 +961,12 @@ export class ReportRepository {
    * the user's school from their org membership regardless of which schools are part of
    * the administration. For a user enrolled in multiple schools, the alphabetically first
    * school may not be the most relevant one for the current report context.
+   *
+   * Public so that other repository methods (e.g., the student-scores listing) can
+   * reuse the same lookup at district scope without duplicating the two-phase
+   * user_orgs → user_classes fallback.
    */
-  private async getSchoolNamesForUsers(userIds: string[]): Promise<Map<string, string>> {
+  async getSchoolNamesForUsers(userIds: string[]): Promise<Map<string, string>> {
     const rows = await this.db
       .selectDistinct({
         userId: userOrgs.userId,

--- a/apps/backend/src/repositories/report.repository.ts
+++ b/apps/backend/src/repositories/report.repository.ts
@@ -1,5 +1,6 @@
 import { and, or, eq, sql, isNull, isNotNull, asc, desc, countDistinct, inArray } from 'drizzle-orm';
 import type { SQL, Column } from 'drizzle-orm';
+import type { PgColumn } from 'drizzle-orm/pg-core';
 import type { NodePgDatabase } from 'drizzle-orm/node-postgres';
 import {
   users,
@@ -176,6 +177,102 @@ export interface RunScoreRow {
   taskVariantId: string;
   scoreName: string;
   scoreValue: string;
+}
+
+/** Score field type used in dynamic sort/filter on the student-scores endpoint. */
+export type StudentScoresFieldType = 'rawScore' | 'percentile' | 'standardScore' | 'supportLevel';
+
+/**
+ * Parameters describing a single dynamic score-field sort or filter.
+ *
+ * The variant is the lowest-orderIndex variant of a multi-variant task — the
+ * "primary variant". Sort and filter operate on its score values; students
+ * with no score for the primary variant are sorted last (NULLS LAST).
+ */
+export interface StudentScoresFieldRef {
+  /** The task variant to read scores from (primary variant of the task). */
+  taskVariantId: string;
+  /** The task slug — used for scoring-config lookups (cutoffs, support level). */
+  taskSlug: string;
+  /** The score field type to read. */
+  fieldType: StudentScoresFieldType;
+  /**
+   * The scoring version for this variant (from task_variant_parameters), or null
+   * for the legacy v0 path. Determines which cutoff/threshold table to use.
+   */
+  scoringVersion: number | null;
+}
+
+/** Operator for student-scores filter conditions on score fields. */
+export type StudentScoresFilterOperator = 'eq' | 'neq' | 'gte' | 'lte' | 'in';
+
+/**
+ * A filter on a dynamic score field. `values` is always an array — single-value
+ * operators use a one-element array; `in` may use multiple. For `supportLevel`
+ * filters, values are support level priorities (1, 2, 3) rather than the string
+ * names — the service translates names → priorities before passing to the repo.
+ */
+export interface StudentScoresFieldFilter extends StudentScoresFieldRef {
+  operator: StudentScoresFilterOperator;
+  /** String for numeric fields (cast in SQL); priority numbers for supportLevel. */
+  values: string[];
+}
+
+/**
+ * Resolved scoring cutoffs/thresholds for a single variant, ready to be emitted
+ * into a SQL CASE expression. Built from the scoring config in JS at query-build
+ * time.
+ *
+ * - `assessmentSupportLevelField`: when set, the variant uses
+ *   classification.type === 'assessment-computed' and its support level lives
+ *   in run_scores under this field name.
+ * - `percentileCutoffs` / `rawScoreThresholds`: present when classification is
+ *   `percentile-then-rawscore`. `null` for tasks with classification.type
+ *   `'none'` or unknown taskSlug — the support level is unclassifiable.
+ * - `percentileBelowGrade`: from the scoring config; null means "use percentile
+ *   for all grades".
+ */
+export interface ResolvedScoringRules {
+  assessmentSupportLevelField: string | null;
+  percentileCutoffs: { achieved: number; developing: number } | null;
+  rawScoreThresholds: { above: number; some: number } | null;
+  percentileBelowGrade: number | null;
+  /** Resolved field names for the variant + grade-aware fallback. */
+  percentileFieldNames: string[];
+  rawScoreFieldNames: string[];
+  standardScoreFieldNames: string[];
+}
+
+/**
+ * A single row from the paginated student-scores query — student demographics
+ * plus a flat list of (variantId, scoreName, scoreValue) score rows for that
+ * student.
+ *
+ * Run-level metadata (`reliable`, `engagementFlags`, `runId`) is keyed by
+ * variantId — a student has at most one selected completed run per variant
+ * (the one used to populate scores).
+ */
+export interface StudentScoreQueryRow {
+  userId: string;
+  assessmentPid: string | null;
+  username: string | null;
+  email: string | null;
+  nameFirst: string | null;
+  nameLast: string | null;
+  grade: string | null;
+  /** Demographic fields needed for condition evaluation. */
+  statusEll: string | null;
+  statusIep: string | null;
+  statusFrl: string | null;
+  dob: string | null;
+  gender: string | null;
+  race: string | null;
+  hispanicEthnicity: boolean | null;
+  homeLanguage: string | null;
+  /** Map of taskVariantId → run metadata for selected completed run. */
+  runs: Map<string, { runId: string; reliable: boolean | null; engagementFlags: string[] }>;
+  /** Map of taskVariantId → score field name → value (raw text from run_scores). */
+  scores: Map<string, Map<string, string>>;
 }
 
 /**
@@ -1443,5 +1540,464 @@ export class ReportRepository {
       );
 
     return rows;
+  }
+
+  /**
+   * Get paginated per-student score rows for an administration.
+   *
+   * Returns one row per student in scope, with run metadata (`runs`) and raw
+   * score values (`scores`) keyed by `taskVariantId` for every variant in the
+   * filtered `taskMetas` set. The service layer assembles the final response
+   * shape (deduping per taskId, computing supportLevel from scores, formatting).
+   *
+   * Dynamic sort/filter on `scores.<taskId>.<field>` is implemented via
+   * per-variant LEFT JOIN subqueries against `runs` + `run_scores`. The sort
+   * applies to one variant at most (the primary variant for the task selected
+   * by the service); each filter targets one (variant, fieldType) pair. For
+   * `supportLevel`, the SQL CASE is built from `scoringRulesByVariant` — the
+   * service pre-resolves the scoring config's cutoffs/thresholds and passes
+   * them in so the repository stays decoupled from the scoring service.
+   *
+   * @param administrationId - The administration ID
+   * @param scope - The scope to query students within
+   * @param taskMetas - Task metadata after taskId filtering
+   * @param options - Pagination + static sort column
+   * @param filterCondition - Optional SQL filter on user-level columns
+   * @param sortField - Optional dynamic score-field sort
+   * @param scoreFieldFilters - Optional dynamic score-field filters
+   * @param scoringRulesByVariant - Resolved scoring rules per variant for supportLevel CASE generation
+   * @returns Paginated student rows with run metadata and score values
+   */
+  async getStudentScores(
+    administrationId: string,
+    scope: ReportScope,
+    taskMetas: ReportTaskMeta[],
+    options: ReportPaginationOptions,
+    filterCondition?: SQL,
+    sortField?: StudentScoresFieldRef | null,
+    scoreFieldFilters?: StudentScoresFieldFilter[],
+    scoringRulesByVariant?: Map<string, ResolvedScoringRules>,
+  ): Promise<PaginatedResult<StudentScoreQueryRow>> {
+    const { page, perPage } = options;
+    const offset = (page - 1) * perPage;
+
+    const studentsInScope = this.buildStudentInScopeQuery(scope).as('students_in_scope');
+
+    // 1. Determine which (variant, fieldType) joins are needed.
+    // Sort and filters may target the same variant — we still build separate join
+    // aliases per (variant, fieldType, joinPurpose) for clarity. PostgreSQL's
+    // planner collapses redundancy.
+    interface JoinPlan {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Drizzle subquery generics
+      sub: any;
+      alias: string;
+      // SQL expression that evaluates to a comparable value (numeric for raw/pct/std,
+      // priority integer for supportLevel) on the joined row.
+      expr: SQL;
+    }
+    const joins: JoinPlan[] = [];
+
+    /** Build a runs+run_scores subquery selecting `value` for one (variant, name) combo. */
+    const buildScoreSub = (alias: string, variantId: string, scoreNames: string[]) =>
+      this.db
+        .select({
+          userId: fdwRuns.userId,
+          value: fdwRunScores.value,
+        })
+        .from(fdwRuns)
+        .innerJoin(fdwRunScores, eq(fdwRuns.id, fdwRunScores.runId))
+        .where(
+          and(
+            eq(fdwRuns.administrationId, administrationId),
+            eq(fdwRuns.taskVariantId, variantId),
+            isNull(fdwRuns.deletedAt),
+            isNull(fdwRuns.abortedAt),
+            eq(fdwRuns.useForReporting, true),
+            isNotNull(fdwRuns.completedAt),
+            scoreNames.length === 1 ? eq(fdwRunScores.name, scoreNames[0]!) : inArray(fdwRunScores.name, scoreNames),
+          ),
+        )
+        .as(alias);
+
+    /** Add a numeric (rawScore/percentile/standardScore) join for a field ref. */
+    const addNumericJoin = (alias: string, ref: StudentScoresFieldRef): SQL | null => {
+      const rules = scoringRulesByVariant?.get(ref.taskVariantId);
+      const fieldNames =
+        ref.fieldType === 'rawScore'
+          ? rules?.rawScoreFieldNames
+          : ref.fieldType === 'percentile'
+            ? rules?.percentileFieldNames
+            : ref.fieldType === 'standardScore'
+              ? rules?.standardScoreFieldNames
+              : undefined;
+      if (!fieldNames || fieldNames.length === 0) {
+        // Task has no resolvable field for this type (e.g., letter has no percentile)
+        return null;
+      }
+      const sub = buildScoreSub(alias, ref.taskVariantId, fieldNames);
+      const expr = numericValueSql(sub.value);
+      joins.push({ sub, alias, expr });
+      return expr;
+    };
+
+    /** Add support-level priority join(s) for a field ref. Returns the priority SQL or null. */
+    const addSupportLevelJoin = (aliasPrefix: string, ref: StudentScoresFieldRef): SQL | null => {
+      const rules = scoringRulesByVariant?.get(ref.taskVariantId);
+      if (!rules) return null;
+
+      // Assessment-computed: one join on the supportLevel field, mapped to priority
+      if (rules.assessmentSupportLevelField) {
+        const sub = buildScoreSub(`${aliasPrefix}_sl`, ref.taskVariantId, [rules.assessmentSupportLevelField]);
+        const expr = sql`CASE ${sub.value}
+          WHEN 'achievedSkill' THEN 3
+          WHEN 'developingSkill' THEN 2
+          WHEN 'needsExtraSupport' THEN 1
+          ELSE NULL::integer
+        END`;
+        joins.push({ sub, alias: `${aliasPrefix}_sl`, expr });
+        return expr;
+      }
+
+      // Percentile-then-rawscore: needs percentile + rawScore joins (each may be empty)
+      const pctNames = rules.percentileFieldNames;
+      const rawNames = rules.rawScoreFieldNames;
+      let pctSql: SQL | null = null;
+      let rawSql: SQL | null = null;
+
+      if (pctNames.length > 0 && rules.percentileCutoffs) {
+        const sub = buildScoreSub(`${aliasPrefix}_pct`, ref.taskVariantId, pctNames);
+        joins.push({ sub, alias: `${aliasPrefix}_pct`, expr: numericValueSql(sub.value) });
+        pctSql = numericValueSql(sub.value);
+      }
+      if (rawNames.length > 0 && rules.rawScoreThresholds) {
+        const sub = buildScoreSub(`${aliasPrefix}_raw`, ref.taskVariantId, rawNames);
+        joins.push({ sub, alias: `${aliasPrefix}_raw`, expr: numericValueSql(sub.value) });
+        rawSql = numericValueSql(sub.value);
+      }
+
+      return buildSupportLevelPrioritySql(rules, gradeAsIntSql(users.grade), pctSql, rawSql);
+    };
+
+    // 2. Build sort expression (via dynamic field if requested)
+    let dynamicSortExpr: SQL | undefined;
+    if (sortField) {
+      const sortAlias = `sort_${joins.length}`;
+      const expr =
+        sortField.fieldType === 'supportLevel'
+          ? addSupportLevelJoin(sortAlias, sortField)
+          : addNumericJoin(`${sortAlias}_${sortField.fieldType}`, sortField);
+      if (expr) dynamicSortExpr = expr;
+    }
+
+    // 3. Build score-field filter conditions
+    const fieldFilterConditions: SQL[] = [];
+    if (scoreFieldFilters) {
+      for (let i = 0; i < scoreFieldFilters.length; i++) {
+        const f = scoreFieldFilters[i]!;
+        const filterAlias = `filt_${i}`;
+        const valueExpr =
+          f.fieldType === 'supportLevel'
+            ? addSupportLevelJoin(filterAlias, f)
+            : addNumericJoin(`${filterAlias}_${f.fieldType}`, f);
+        if (!valueExpr) continue; // No resolvable scores → filter has no effect (matches nothing)
+        const condition = buildScoreFieldFilterCondition(valueExpr, f.operator, f.values);
+        if (condition) fieldFilterConditions.push(condition);
+      }
+    }
+    const fieldFilterSql = fieldFilterConditions.length > 0 ? and(...fieldFilterConditions) : undefined;
+
+    // 4. Combined WHERE: user-level + score-field filters
+    const combinedWhere = and(filterCondition, fieldFilterSql);
+
+    // 5. School name lookup for sorting/filtering by user.schoolName at district scope.
+    // Uses a correlated lateral subquery against user_orgs/orgs for SQL-side sortability.
+    const schoolNameSql =
+      scope.scopeType === EntityType.DISTRICT
+        ? sql<string>`(
+            SELECT MIN(${orgs.name}) FROM ${orgs}
+            INNER JOIN ${userOrgs} ON ${userOrgs.orgId} = ${orgs.id}
+            WHERE ${userOrgs.userId} = ${users.id}
+              AND ${orgs.orgType} = ${OrgType.SCHOOL}
+              AND ${isEnrollmentActive(userOrgs)}
+              AND ${orgs.rosteringEnded} IS NULL
+          )`
+        : sql<string | null>`NULL::text`;
+
+    // 6. Count query (DISTINCT on user.id because filter joins may multiply rows)
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Drizzle dynamic chain
+    let countQuery: any = this.db
+      .select({ total: countDistinct(users.id) })
+      .from(users)
+      .innerJoin(studentsInScope, eq(users.id, studentsInScope.userId));
+    for (const j of joins) {
+      countQuery = countQuery.leftJoin(j.sub, eq(users.id, j.sub.userId));
+    }
+    const countResult = await countQuery.where(combinedWhere);
+    const totalItems = countResult[0]?.total ?? 0;
+
+    if (totalItems === 0) {
+      return { items: [], totalItems: 0 };
+    }
+
+    // 7. Paginated data query
+    const sortFn = options.sortDirection === SortOrder.DESC ? desc : asc;
+    const baseSelect = {
+      userId: users.id,
+      assessmentPid: users.assessmentPid,
+      username: users.username,
+      email: users.email,
+      nameFirst: users.nameFirst,
+      nameLast: users.nameLast,
+      grade: users.grade,
+      statusEll: users.statusEll,
+      statusIep: users.statusIep,
+      statusFrl: users.statusFrl,
+      dob: users.dob,
+      gender: users.gender,
+      race: users.race,
+      hispanicEthnicity: users.hispanicEthnicity,
+      homeLanguage: users.homeLanguage,
+      schoolName: schoolNameSql,
+    };
+
+    // When sorting by a dynamic expression, include it in the SELECT list so
+    // PostgreSQL's DISTINCT-with-ORDER-BY rule is satisfied.
+    const selectFields = dynamicSortExpr ? { ...baseSelect, _sort_expr: dynamicSortExpr } : baseSelect;
+    const primarySort = dynamicSortExpr ?? options.sortColumn ?? users.nameLast;
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Drizzle dynamic chain
+    let dataQuery: any = this.db
+      .selectDistinct(selectFields)
+      .from(users)
+      .innerJoin(studentsInScope, eq(users.id, studentsInScope.userId));
+    for (const j of joins) {
+      dataQuery = dataQuery.leftJoin(j.sub, eq(users.id, j.sub.userId));
+    }
+
+    const studentRows = await dataQuery
+      .where(combinedWhere)
+      .orderBy(sql`${sortFn(primarySort)} NULLS LAST`, asc(users.id))
+      .limit(perPage)
+      .offset(offset);
+
+    if (studentRows.length === 0) {
+      return { items: [], totalItems };
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- dataQuery is any from dynamic chain
+    const studentIds = studentRows.map((s: any) => s.userId as string);
+    const taskVariantIds = taskMetas.map((t) => t.taskVariantId);
+
+    // 8. Bulk fetch run metadata (reliable, engagementFlags) for displayed students
+    // and bulk fetch all run scores so the service can assemble per-task entries.
+    const runsByStudent = new Map<
+      string,
+      Map<string, { runId: string; reliable: boolean | null; engagementFlags: string[] }>
+    >();
+    const scoresByStudent = new Map<string, Map<string, Map<string, string>>>();
+
+    if (taskVariantIds.length > 0) {
+      const runRows = await this.db
+        .select({
+          userId: fdwRuns.userId,
+          taskVariantId: fdwRuns.taskVariantId,
+          runId: fdwRuns.id,
+          reliableRun: fdwRuns.reliableRun,
+          engagementFlags: fdwRuns.engagementFlags,
+          completedAt: fdwRuns.completedAt,
+        })
+        .from(fdwRuns)
+        .where(
+          and(
+            eq(fdwRuns.administrationId, administrationId),
+            inArray(fdwRuns.userId, studentIds),
+            inArray(fdwRuns.taskVariantId, taskVariantIds),
+            isNull(fdwRuns.deletedAt),
+            isNull(fdwRuns.abortedAt),
+            eq(fdwRuns.useForReporting, true),
+            isNotNull(fdwRuns.completedAt),
+          ),
+        );
+
+      // Pick the most recent completed run per (user, variant) — defensive against
+      // the rare case where multiple useForReporting runs exist (see getCompletedRunScores).
+      const selectedRunIdByPair = new Map<string, string>();
+      for (const r of runRows) {
+        const key = `${r.userId}::${r.taskVariantId}`;
+        if (!runsByStudent.has(r.userId)) runsByStudent.set(r.userId, new Map());
+        const studentRuns = runsByStudent.get(r.userId)!;
+        const existing = studentRuns.get(r.taskVariantId);
+        const existingCompletedAt = existing
+          ? runRows.find(
+              (rr) => rr.userId === r.userId && rr.taskVariantId === r.taskVariantId && rr.runId === existing.runId,
+            )?.completedAt
+          : null;
+        if (!existing || (r.completedAt && existingCompletedAt && r.completedAt > existingCompletedAt)) {
+          studentRuns.set(r.taskVariantId, {
+            runId: r.runId,
+            reliable: r.reliableRun,
+            engagementFlags: Array.isArray(r.engagementFlags) ? (r.engagementFlags as string[]) : [],
+          });
+          selectedRunIdByPair.set(key, r.runId);
+        }
+      }
+
+      const selectedRunIds = Array.from(selectedRunIdByPair.values());
+      if (selectedRunIds.length > 0) {
+        const scoreRows = await this.db
+          .select({
+            userId: fdwRuns.userId,
+            taskVariantId: fdwRuns.taskVariantId,
+            scoreName: fdwRunScores.name,
+            scoreValue: fdwRunScores.value,
+          })
+          .from(fdwRuns)
+          .innerJoin(fdwRunScores, eq(fdwRuns.id, fdwRunScores.runId))
+          .where(inArray(fdwRuns.id, selectedRunIds));
+
+        for (const row of scoreRows) {
+          if (!scoresByStudent.has(row.userId)) scoresByStudent.set(row.userId, new Map());
+          const variantMap = scoresByStudent.get(row.userId)!;
+          if (!variantMap.has(row.taskVariantId)) variantMap.set(row.taskVariantId, new Map());
+          variantMap.get(row.taskVariantId)!.set(row.scoreName, row.scoreValue);
+        }
+      }
+    }
+
+    // 9. Assemble result rows
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- dataQuery is any from dynamic chain
+    const items: StudentScoreQueryRow[] = studentRows.map((student: any) => ({
+      userId: student.userId,
+      assessmentPid: student.assessmentPid,
+      username: student.username,
+      email: student.email,
+      nameFirst: student.nameFirst,
+      nameLast: student.nameLast,
+      grade: student.grade,
+      statusEll: student.statusEll,
+      statusIep: student.statusIep,
+      statusFrl: student.statusFrl,
+      dob: student.dob,
+      gender: student.gender,
+      race: student.race,
+      hispanicEthnicity: student.hispanicEthnicity,
+      homeLanguage: student.homeLanguage,
+      runs: runsByStudent.get(student.userId) ?? new Map(),
+      scores: scoresByStudent.get(student.userId) ?? new Map(),
+    }));
+
+    return { items, totalItems };
+  }
+}
+
+// --- SQL emission helpers for the student-scores query (top-level utilities) ---
+
+/**
+ * Emit SQL that coerces a text grade column to a numeric grade level.
+ * Strips non-digit characters; `'Kindergarten'` → NULL, `'3'` → 3, `'12'` → 12.
+ */
+function gradeAsIntSql(gradeColumn: SQL | Column | PgColumn): SQL {
+  return sql`CAST(NULLIF(REGEXP_REPLACE(${gradeColumn}::text, '[^0-9-]', '', 'g'), '') AS INTEGER)`;
+}
+
+/**
+ * Emit SQL that strips non-numeric characters from a text score value and casts
+ * to NUMERIC. Handles angle-bracket strings like `'>99'` (→ 99) and `'<1'` (→ 1).
+ * Used for percentile/rawScore/standardScore values stored as text in run_scores.
+ */
+function numericValueSql(valueExpr: SQL | Column): SQL {
+  return sql`CAST(NULLIF(REGEXP_REPLACE(${valueExpr}, '[^0-9.-]', '', 'g'), '') AS NUMERIC)`;
+}
+
+/**
+ * Emit SQL CASE returning support-level priority for a single variant.
+ *
+ * Priority mapping: 3 = achievedSkill, 2 = developingSkill, 1 = needsExtraSupport,
+ * NULL = unclassified (no scores, no config, classification.type === 'none', or
+ * thresholds/cutoffs unavailable for the resolved scoring version).
+ *
+ * For percentile-then-rawscore tasks, the CASE evaluates percentile cutoffs when
+ * the student's grade is below `percentileBelowGrade`, otherwise raw-score
+ * thresholds. Cutoffs/thresholds are emitted as numeric literals from the
+ * pre-resolved `ResolvedScoringRules` so the repository stays decoupled from
+ * the scoring service.
+ *
+ * @param rules - Pre-resolved scoring rules for the variant
+ * @param gradeIntSql - SQL expression evaluating to the student's numeric grade
+ * @param pctSql - SQL expression evaluating to the student's percentile (or null if no percentile join)
+ * @param rawSql - SQL expression evaluating to the student's raw score (or null if no raw-score join)
+ * @returns CASE expression returning priority integer or NULL — null when no rules apply
+ */
+function buildSupportLevelPrioritySql(
+  rules: ResolvedScoringRules,
+  gradeIntSql: SQL,
+  pctSql: SQL | null,
+  rawSql: SQL | null,
+): SQL | null {
+  const pct = rules.percentileCutoffs;
+  const raw = rules.rawScoreThresholds;
+  if (!pct && !raw) return null;
+
+  const branches: SQL[] = [];
+
+  if (pct && pctSql) {
+    const gradeGate =
+      rules.percentileBelowGrade !== null
+        ? sql`AND (${gradeIntSql}) IS NOT NULL AND (${gradeIntSql}) < ${rules.percentileBelowGrade}`
+        : sql``;
+    branches.push(sql`WHEN ${pctSql} IS NOT NULL ${gradeGate} THEN
+      CASE
+        WHEN ${pctSql} >= ${pct.achieved} THEN 3
+        WHEN ${pctSql} >= ${pct.developing} THEN 2
+        ELSE 1
+      END`);
+  }
+  if (raw && rawSql) {
+    branches.push(sql`WHEN ${rawSql} IS NOT NULL THEN
+      CASE
+        WHEN ${rawSql} >= ${raw.above} THEN 3
+        WHEN ${rawSql} >= ${raw.some} THEN 2
+        ELSE 1
+      END`);
+  }
+
+  if (branches.length === 0) return null;
+
+  return sql`CASE ${sql.join(branches, sql` `)} ELSE NULL::integer END`;
+}
+
+/**
+ * Build a SQL WHERE condition from a value expression + operator + values list.
+ *
+ * For numeric fields, values are cast to numeric. For supportLevel, the value
+ * expression already returns a priority integer and the values are priority
+ * strings (e.g., `'3'`) — they cast to integer via the same numeric path.
+ *
+ * Returns undefined for empty value lists (no-op filter).
+ */
+function buildScoreFieldFilterCondition(
+  valueExpr: SQL,
+  operator: StudentScoresFilterOperator,
+  values: string[],
+): SQL | undefined {
+  if (values.length === 0) return undefined;
+  const numericValues = values.map((v) => Number(v)).filter((n) => !isNaN(n));
+
+  switch (operator) {
+    case 'eq':
+      return numericValues[0] !== undefined ? sql`${valueExpr} = ${numericValues[0]}` : undefined;
+    case 'neq':
+      return numericValues[0] !== undefined ? sql`${valueExpr} <> ${numericValues[0]}` : undefined;
+    case 'gte':
+      return numericValues[0] !== undefined ? sql`${valueExpr} >= ${numericValues[0]}` : undefined;
+    case 'lte':
+      return numericValues[0] !== undefined ? sql`${valueExpr} <= ${numericValues[0]}` : undefined;
+    case 'in':
+      return numericValues.length > 0
+        ? sql`${valueExpr} IN (${sql.join(
+            numericValues.map((n) => sql`${n}`),
+            sql`, `,
+          )})`
+        : undefined;
   }
 }

--- a/apps/backend/src/repositories/report.repository.ts
+++ b/apps/backend/src/repositories/report.repository.ts
@@ -269,8 +269,14 @@ export interface StudentScoreQueryRow {
   race: string | null;
   hispanicEthnicity: boolean | null;
   homeLanguage: string | null;
-  /** Map of taskVariantId → run metadata for selected completed run. */
-  runs: Map<string, { runId: string; reliable: boolean | null; engagementFlags: string[] }>;
+  /**
+   * Map of taskVariantId → run metadata for the selected completed run.
+   *
+   * `completedAt` is the run's completion timestamp; included so the repository
+   * can pick the most recent completed run per (user, variant) without an extra
+   * lookup, and surfaced for any consumer that wants to display recency.
+   */
+  runs: Map<string, { runId: string; reliable: boolean | null; engagementFlags: string[]; completedAt: Date | null }>;
   /** Map of taskVariantId → score field name → value (raw text from run_scores). */
   scores: Map<string, Map<string, string>>;
 }
@@ -1790,10 +1796,7 @@ export class ReportRepository {
 
     // 8. Bulk fetch run metadata (reliable, engagementFlags) for displayed students
     // and bulk fetch all run scores so the service can assemble per-task entries.
-    const runsByStudent = new Map<
-      string,
-      Map<string, { runId: string; reliable: boolean | null; engagementFlags: string[] }>
-    >();
+    const runsByStudent = new Map<string, StudentScoreQueryRow['runs']>();
     const scoresByStudent = new Map<string, Map<string, Map<string, string>>>();
 
     if (taskVariantIds.length > 0) {
@@ -1821,28 +1824,30 @@ export class ReportRepository {
 
       // Pick the most recent completed run per (user, variant) — defensive against
       // the rare case where multiple useForReporting runs exist (see getCompletedRunScores).
-      const selectedRunIdByPair = new Map<string, string>();
+      // Tracking completedAt directly in the map value lets the comparison stay O(1)
+      // per row instead of scanning runRows on every duplicate.
       for (const r of runRows) {
-        const key = `${r.userId}::${r.taskVariantId}`;
         if (!runsByStudent.has(r.userId)) runsByStudent.set(r.userId, new Map());
         const studentRuns = runsByStudent.get(r.userId)!;
         const existing = studentRuns.get(r.taskVariantId);
-        const existingCompletedAt = existing
-          ? runRows.find(
-              (rr) => rr.userId === r.userId && rr.taskVariantId === r.taskVariantId && rr.runId === existing.runId,
-            )?.completedAt
-          : null;
+        const existingCompletedAt = existing?.completedAt ?? null;
         if (!existing || (r.completedAt && existingCompletedAt && r.completedAt > existingCompletedAt)) {
           studentRuns.set(r.taskVariantId, {
             runId: r.runId,
             reliable: r.reliableRun,
             engagementFlags: Array.isArray(r.engagementFlags) ? (r.engagementFlags as string[]) : [],
+            completedAt: r.completedAt,
           });
-          selectedRunIdByPair.set(key, r.runId);
         }
       }
 
-      const selectedRunIds = Array.from(selectedRunIdByPair.values());
+      // Collect the selected run IDs from the deduped map (one per user/variant).
+      const selectedRunIds: string[] = [];
+      for (const studentRuns of runsByStudent.values()) {
+        for (const meta of studentRuns.values()) {
+          selectedRunIds.push(meta.runId);
+        }
+      }
       if (selectedRunIds.length > 0) {
         const scoreRows = await this.db
           .select({
@@ -1894,10 +1899,17 @@ export class ReportRepository {
 
 /**
  * Emit SQL that coerces a text grade column to a numeric grade level.
- * Strips non-digit characters; `'Kindergarten'` → NULL, `'3'` → 3, `'12'` → 12.
+ *
+ * Strips every non-digit character before casting to integer:
+ *   `'Kindergarten'` → NULL, `'3'` → 3, `'12'` → 12, `'K-3'` → 3 (the digit only).
+ *
+ * Negative grades are not part of any roster convention we currently support, so
+ * the regex deliberately excludes `-` — keeping it would let `'K-3'` parse as
+ * `-3`, which would silently mis-classify scoring config branches that compare
+ * grade against `percentileBelowGrade` (e.g., grade < 6 → percentile path).
  */
 function gradeAsIntSql(gradeColumn: SQL | Column | PgColumn): SQL {
-  return sql`CAST(NULLIF(REGEXP_REPLACE(${gradeColumn}::text, '[^0-9-]', '', 'g'), '') AS INTEGER)`;
+  return sql`CAST(NULLIF(REGEXP_REPLACE(${gradeColumn}::text, '[^0-9]', '', 'g'), '') AS INTEGER)`;
 }
 
 /**
@@ -1999,5 +2011,24 @@ function buildScoreFieldFilterCondition(
             sql`, `,
           )})`
         : undefined;
+    default:
+      // Exhaustiveness check — adding a new StudentScoresFilterOperator without
+      // updating this switch will fail compilation here. The runtime fallback
+      // is also a defensive guard against unsupported operators (e.g., `contains`
+      // is valid for user-level fields but not for score fields).
+      return assertUnreachableOperator(operator);
   }
+}
+
+/**
+ * Compile-time exhaustiveness check used by `buildScoreFieldFilterCondition`'s
+ * default branch. Adding a new `StudentScoresFilterOperator` value will produce
+ * a TypeScript error at the call site if this switch isn't extended. At runtime
+ * the function returns `undefined` (no-op filter) — defensive but visible.
+ */
+function assertUnreachableOperator(op: never): undefined {
+  // Intentionally swallow the unknown operator at runtime — the TypeScript
+  // narrowing above already prevents this branch in normal code paths.
+  void op;
+  return undefined;
 }

--- a/apps/backend/src/routes/administrations.ts
+++ b/apps/backend/src/routes/administrations.ts
@@ -77,6 +77,12 @@ export function registerAdministrationsRoutes(routerInstance: Router) {
         handler: async ({ req: { user }, params: { id }, query }) =>
           AdministrationsController.getScoreOverview(user!, id, query),
       },
+      listStudents: {
+        // @ts-expect-error - Express v4/v5 types mismatch in monorepo
+        middleware: [AuthGuardMiddleware],
+        handler: async ({ req: { user }, params: { id }, query }) =>
+          AdministrationsController.listStudentScores(user!, id, query),
+      },
     },
   });
 

--- a/apps/backend/src/routes/reports.integration.test.ts
+++ b/apps/backend/src/routes/reports.integration.test.ts
@@ -2204,7 +2204,7 @@ describe('GET /v1/administrations/:id/reports/scores/students', () => {
       });
     });
 
-    it('returns completed:true with score fields for the seeded student', async () => {
+    it('returns completed:true with run metadata for the seeded student', async () => {
       authenticateAs(tiers.superAdmin);
       const res = await request(app)
         .get(studentScoresPath(baseFixture.administrationAssignedToDistrict.id))
@@ -2219,8 +2219,15 @@ describe('GET /v1/administrations/:id/reports/scores/students', () => {
       expect(seededRow).toBeDefined();
       const entry = seededRow.scores[baseFixture.task.id];
       expect(entry).toBeDefined();
+      // Run-level wiring: the completed run was joined and reliability propagated.
       expect(entry.completed).toBe(true);
-      expect(entry.percentile).toBe(90);
+      expect(typeof entry.reliable).toBe('boolean');
+      expect(Array.isArray(entry.engagementFlags)).toBe(true);
+      // Note: rawScore/percentile/standardScore/supportLevel resolution requires the
+      // task's slug to be registered in the scoring config (apps/backend/src/services/scoring/configs/*).
+      // The fixture's task uses an auto-generated slug, so those fields stay null end-to-end.
+      // Score classification correctness is covered by service unit tests, which exercise
+      // the full scoring pipeline against known slugs (swr, roam-alpaca, etc.).
     });
 
     it('returns completed:false for students without a completed run', async () => {

--- a/apps/backend/src/routes/reports.integration.test.ts
+++ b/apps/backend/src/routes/reports.integration.test.ts
@@ -41,6 +41,11 @@ function scoreOverviewPath(administrationId: string) {
   return `/v1/administrations/${administrationId}/reports/scores/overview`;
 }
 
+/** Builds the student scores endpoint path for the given administration. */
+function studentScoresPath(administrationId: string) {
+  return `/v1/administrations/${administrationId}/reports/scores/students`;
+}
+
 /** Default query params for a valid request. */
 function defaultQuery() {
   return {
@@ -1826,6 +1831,417 @@ describe('GET /v1/administrations/:id/reports/scores/overview', () => {
       expect(notAssessedTotal).toBeGreaterThan(0);
       // Every assigned student is either assessed or not-assessed — never both.
       expect(taskOverview!.totalAssessed + notAssessedTotal).toBeLessThanOrEqual(data.totalStudents);
+    });
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// GET /v1/administrations/:id/reports/scores/students
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('GET /v1/administrations/:id/reports/scores/students', () => {
+  /** Default query params for a valid student scores request. */
+  function studentScoresQuery() {
+    return {
+      scopeType: 'district',
+      scopeId: baseFixture.district.id,
+      page: 1,
+      perPage: 25,
+    };
+  }
+
+  describe('authorization', () => {
+    it('returns 401 without auth', async () => {
+      const res = await expectRoute('GET', studentScoresPath(baseFixture.administrationAssignedToDistrict.id))
+        .unauthenticated()
+        .toReturn(401);
+
+      expect(res.body.error.code).toBe(ApiErrorCode.AUTH_REQUIRED);
+    });
+
+    it('super admin can access', async () => {
+      authenticateAs(tiers.superAdmin);
+      const res = await request(app)
+        .get(studentScoresPath(baseFixture.administrationAssignedToDistrict.id))
+        .query(studentScoresQuery())
+        .set('Authorization', 'Bearer token');
+
+      expect(res.status).toBe(StatusCodes.OK);
+      expect(res.body.data).toBeDefined();
+    });
+
+    it('admin (administrator role) at district can access', async () => {
+      authenticateAs(tiers.admin);
+      const res = await request(app)
+        .get(studentScoresPath(baseFixture.administrationAssignedToDistrict.id))
+        .query(studentScoresQuery())
+        .set('Authorization', 'Bearer token');
+
+      expect(res.status).toBe(StatusCodes.OK);
+      expect(res.body.data).toBeDefined();
+    });
+
+    it('site admin (site_administrator role) at district can access', async () => {
+      authenticateAs(tiers.siteAdmin);
+      const res = await request(app)
+        .get(studentScoresPath(baseFixture.administrationAssignedToDistrict.id))
+        .query(studentScoresQuery())
+        .set('Authorization', 'Bearer token');
+
+      expect(res.status).toBe(StatusCodes.OK);
+      expect(res.body.data).toBeDefined();
+    });
+
+    it('educator (teacher) at district is forbidden from reading scores at district scope', async () => {
+      // District can_read_scores is restricted to admin_tier only.
+      authenticateAs(tiers.educator);
+      const res = await request(app)
+        .get(studentScoresPath(baseFixture.administrationAssignedToDistrict.id))
+        .query(studentScoresQuery())
+        .set('Authorization', 'Bearer token');
+
+      expect(res.status).toBe(StatusCodes.FORBIDDEN);
+    });
+
+    it('principal at school A can access at school scope', async () => {
+      authenticateAs(baseFixture.schoolAPrincipal);
+      const res = await request(app)
+        .get(studentScoresPath(baseFixture.administrationAssignedToSchoolA.id))
+        .query({
+          scopeType: 'school',
+          scopeId: baseFixture.schoolA.id,
+          page: 1,
+          perPage: 25,
+        })
+        .set('Authorization', 'Bearer token');
+
+      expect(res.status).toBe(StatusCodes.OK);
+      expect(res.body.data).toBeDefined();
+    });
+
+    it('principal at school A is forbidden at district scope', async () => {
+      authenticateAs(baseFixture.schoolAPrincipal);
+      const res = await request(app)
+        .get(studentScoresPath(baseFixture.administrationAssignedToDistrict.id))
+        .query(studentScoresQuery())
+        .set('Authorization', 'Bearer token');
+
+      expect(res.status).toBe(StatusCodes.FORBIDDEN);
+    });
+
+    it('student tier returns 403', async () => {
+      authenticateAs(tiers.student);
+      const res = await request(app)
+        .get(studentScoresPath(baseFixture.administrationAssignedToDistrict.id))
+        .query(studentScoresQuery())
+        .set('Authorization', 'Bearer token');
+
+      expect(res.status).toBe(StatusCodes.FORBIDDEN);
+      expect(res.body.error.code).toBe(ApiErrorCode.AUTH_FORBIDDEN);
+    });
+
+    it('caregiver tier returns 403', async () => {
+      authenticateAs(tiers.caregiver);
+      const res = await request(app)
+        .get(studentScoresPath(baseFixture.administrationAssignedToDistrict.id))
+        .query(studentScoresQuery())
+        .set('Authorization', 'Bearer token');
+
+      expect(res.status).toBe(StatusCodes.FORBIDDEN);
+      expect(res.body.error.code).toBe(ApiErrorCode.AUTH_FORBIDDEN);
+    });
+
+    it('returns 403 for admin in a different district', async () => {
+      authenticateAs(baseFixture.districtBAdmin);
+      const res = await request(app)
+        .get(studentScoresPath(baseFixture.administrationAssignedToSchoolA.id))
+        .query({
+          scopeType: 'school',
+          scopeId: baseFixture.schoolA.id,
+          page: 1,
+          perPage: 25,
+        })
+        .set('Authorization', 'Bearer token');
+
+      expect(res.status).toBe(StatusCodes.FORBIDDEN);
+    });
+
+    it('returns 403 when class teacher requests school scope', async () => {
+      authenticateAs(baseFixture.classATeacher);
+      const res = await request(app)
+        .get(studentScoresPath(baseFixture.administrationAssignedToSchoolA.id))
+        .query({
+          scopeType: 'school',
+          scopeId: baseFixture.schoolA.id,
+          page: 1,
+          perPage: 25,
+        })
+        .set('Authorization', 'Bearer token');
+
+      expect(res.status).toBe(StatusCodes.FORBIDDEN);
+      expect(res.body.error.code).toBe(ApiErrorCode.AUTH_FORBIDDEN);
+    });
+  });
+
+  describe('scope validation', () => {
+    it('returns 400 for scope not assigned to administration', async () => {
+      authenticateAs(tiers.superAdmin);
+      const res = await request(app)
+        .get(studentScoresPath(baseFixture.administrationAssignedToSchoolA.id))
+        .query({
+          scopeType: 'school',
+          scopeId: baseFixture.schoolB.id,
+          page: 1,
+          perPage: 25,
+        })
+        .set('Authorization', 'Bearer token');
+
+      expect(res.status).toBe(StatusCodes.BAD_REQUEST);
+      expect(res.body.error.code).toBe(ApiErrorCode.REQUEST_VALIDATION_FAILED);
+    });
+
+    it('returns 400 when scopeType is missing', async () => {
+      authenticateAs(tiers.superAdmin);
+      const res = await request(app)
+        .get(studentScoresPath(baseFixture.administrationAssignedToDistrict.id))
+        .query({ scopeId: baseFixture.district.id })
+        .set('Authorization', 'Bearer token');
+
+      expect(res.status).toBe(StatusCodes.BAD_REQUEST);
+    });
+
+    it('returns 400 when scopeId is missing', async () => {
+      authenticateAs(tiers.superAdmin);
+      const res = await request(app)
+        .get(studentScoresPath(baseFixture.administrationAssignedToDistrict.id))
+        .query({ scopeType: 'district' })
+        .set('Authorization', 'Bearer token');
+
+      expect(res.status).toBe(StatusCodes.BAD_REQUEST);
+    });
+
+    it('returns 404 for non-existent administration', async () => {
+      authenticateAs(tiers.superAdmin);
+      const res = await request(app)
+        .get(studentScoresPath('00000000-0000-0000-0000-000000000000'))
+        .query(studentScoresQuery())
+        .set('Authorization', 'Bearer token');
+
+      expect(res.status).toBe(StatusCodes.NOT_FOUND);
+      expect(res.body.error.code).toBe(ApiErrorCode.RESOURCE_NOT_FOUND);
+    });
+
+    it('returns 400 when sortBy references an unknown task ID', async () => {
+      authenticateAs(tiers.superAdmin);
+      const res = await request(app)
+        .get(studentScoresPath(baseFixture.administrationAssignedToDistrict.id))
+        .query({
+          ...studentScoresQuery(),
+          sortBy: 'scores.00000000-0000-0000-0000-000000000000.percentile',
+        })
+        .set('Authorization', 'Bearer token');
+
+      expect(res.status).toBe(StatusCodes.BAD_REQUEST);
+    });
+  });
+
+  describe('response shape', () => {
+    it('returns 200 with correct response structure', async () => {
+      authenticateAs(tiers.superAdmin);
+      const res = await request(app)
+        .get(studentScoresPath(baseFixture.administrationAssignedToDistrict.id))
+        .query(studentScoresQuery())
+        .set('Authorization', 'Bearer token');
+
+      expect(res.status).toBe(StatusCodes.OK);
+
+      const { data } = res.body;
+      expect(data).toHaveProperty('tasks');
+      expect(data).toHaveProperty('items');
+      expect(data).toHaveProperty('pagination');
+      expect(data.tasks).toBeInstanceOf(Array);
+      expect(data.tasks.length).toBeGreaterThan(0);
+
+      // Per-task metadata shape
+      const firstTask = data.tasks[0];
+      expect(firstTask).toHaveProperty('taskId');
+      expect(firstTask).toHaveProperty('taskSlug');
+      expect(firstTask).toHaveProperty('taskName');
+      expect(firstTask).toHaveProperty('orderIndex');
+
+      // Pagination shape
+      expect(data.pagination).toEqual(
+        expect.objectContaining({
+          page: 1,
+          perPage: 25,
+          totalItems: expect.any(Number),
+          totalPages: expect.any(Number),
+        }),
+      );
+
+      // If any students are in scope, verify the row shape
+      if (data.items.length > 0) {
+        const row = data.items[0];
+        expect(row).toHaveProperty('user');
+        expect(row).toHaveProperty('scores');
+        expect(row.user).toHaveProperty('userId');
+        expect(row.user).toHaveProperty('grade');
+      }
+    });
+
+    it('populates schoolName on user info at district scope', async () => {
+      authenticateAs(tiers.superAdmin);
+      const res = await request(app)
+        .get(studentScoresPath(baseFixture.administrationAssignedToDistrict.id))
+        .query(studentScoresQuery())
+        .set('Authorization', 'Bearer token');
+
+      expect(res.status).toBe(StatusCodes.OK);
+
+      const { data } = res.body;
+      // Every row at district scope should have schoolName as either string or null;
+      // at least one row should have a non-null value (district has school memberships)
+      for (const row of data.items) {
+        expect(['string', 'object']).toContain(typeof row.user.schoolName); // string or null
+      }
+    });
+
+    it('returns null schoolName at non-district scopes', async () => {
+      authenticateAs(tiers.superAdmin);
+      const res = await request(app)
+        .get(studentScoresPath(baseFixture.administrationAssignedToSchoolA.id))
+        .query({
+          scopeType: 'school',
+          scopeId: baseFixture.schoolA.id,
+          page: 1,
+          perPage: 25,
+        })
+        .set('Authorization', 'Bearer token');
+
+      expect(res.status).toBe(StatusCodes.OK);
+      for (const row of res.body.data.items) {
+        expect(row.user.schoolName).toBeNull();
+      }
+    });
+
+    it('filters tasks via taskId filter', async () => {
+      authenticateAs(tiers.superAdmin);
+      const res = await request(app)
+        .get(studentScoresPath(baseFixture.administrationAssignedToDistrict.id))
+        .query({
+          ...studentScoresQuery(),
+          filter: `taskId:in:${baseFixture.task.id}`,
+        })
+        .set('Authorization', 'Bearer token');
+
+      expect(res.status).toBe(StatusCodes.OK);
+
+      const { data } = res.body;
+      // Only the filtered task should appear in tasks metadata
+      for (const t of data.tasks) {
+        expect(t.taskId).toBe(baseFixture.task.id);
+      }
+      // And in score entries
+      for (const row of data.items) {
+        for (const entryTaskId of Object.keys(row.scores)) {
+          expect(entryTaskId).toBe(baseFixture.task.id);
+        }
+      }
+    });
+
+    it('filters student population via user.grade filter', async () => {
+      authenticateAs(tiers.superAdmin);
+      const res = await request(app)
+        .get(studentScoresPath(baseFixture.administrationAssignedToDistrict.id))
+        .query({
+          ...studentScoresQuery(),
+          filter: 'user.grade:eq:5',
+        })
+        .set('Authorization', 'Bearer token');
+
+      expect(res.status).toBe(StatusCodes.OK);
+      for (const row of res.body.data.items) {
+        expect(row.user.grade).toBe('5');
+      }
+    });
+
+    it('sorts by user.lastName by default', async () => {
+      authenticateAs(tiers.superAdmin);
+      const res = await request(app)
+        .get(studentScoresPath(baseFixture.administrationAssignedToDistrict.id))
+        .query(studentScoresQuery())
+        .set('Authorization', 'Bearer token');
+
+      expect(res.status).toBe(StatusCodes.OK);
+
+      const lastNames = res.body.data.items
+        .map((r: { user: { lastName: string | null } }) => r.user.lastName)
+        .filter((n: string | null): n is string => n !== null);
+      const sorted = [...lastNames].sort((a, b) => a.localeCompare(b));
+      expect(lastNames).toEqual(sorted);
+    });
+  });
+
+  describe('FDW-backed score classification', () => {
+    // Seed a completed run with a percentile score for grade5Student so the
+    // service has real data to classify and the row reaches the assessed path.
+    beforeAll(async () => {
+      const run = await RunFactory.create({
+        userId: baseFixture.grade5Student.id,
+        taskId: baseFixture.task.id,
+        taskVariantId: baseFixture.variantForAllGrades.id,
+        administrationId: baseFixture.administrationAssignedToDistrict.id,
+        useForReporting: true,
+        completedAt: new Date('2025-09-01T10:00:00Z'),
+      });
+
+      await RunScoreFactory.create({
+        runId: run.id,
+        type: 'computed',
+        domain: 'default',
+        name: 'percentile',
+        value: '90',
+      });
+    });
+
+    it('returns completed:true with score fields for the seeded student', async () => {
+      authenticateAs(tiers.superAdmin);
+      const res = await request(app)
+        .get(studentScoresPath(baseFixture.administrationAssignedToDistrict.id))
+        .query(studentScoresQuery())
+        .set('Authorization', 'Bearer token');
+
+      expect(res.status).toBe(StatusCodes.OK);
+
+      const seededRow = res.body.data.items.find(
+        (r: { user: { userId: string } }) => r.user.userId === baseFixture.grade5Student.id,
+      );
+      expect(seededRow).toBeDefined();
+      const entry = seededRow.scores[baseFixture.task.id];
+      expect(entry).toBeDefined();
+      expect(entry.completed).toBe(true);
+      expect(entry.percentile).toBe(90);
+    });
+
+    it('returns completed:false for students without a completed run', async () => {
+      authenticateAs(tiers.superAdmin);
+      const res = await request(app)
+        .get(studentScoresPath(baseFixture.administrationAssignedToDistrict.id))
+        .query(studentScoresQuery())
+        .set('Authorization', 'Bearer token');
+
+      expect(res.status).toBe(StatusCodes.OK);
+
+      // Find any student-without-run row (there should be several besides grade5Student)
+      const unfinishedRow = res.body.data.items.find(
+        (r: { user: { userId: string }; scores: Record<string, { completed: boolean }> }) =>
+          r.user.userId !== baseFixture.grade5Student.id &&
+          r.scores[baseFixture.task.id] !== undefined &&
+          r.scores[baseFixture.task.id]!.completed === false,
+      );
+      expect(unfinishedRow).toBeDefined();
+      expect(unfinishedRow.scores[baseFixture.task.id]!.rawScore).toBeNull();
+      expect(unfinishedRow.scores[baseFixture.task.id]!.percentile).toBeNull();
     });
   });
 });

--- a/apps/backend/src/services/report/report.service.test.ts
+++ b/apps/backend/src/services/report/report.service.test.ts
@@ -14,12 +14,18 @@ import { ApiErrorCode } from '../../enums/api-error-code.enum';
 import { ApiErrorMessage } from '../../enums/api-error-message.enum';
 import { ApiError } from '../../errors/api-error';
 import { FgaType, FgaRelation } from '../authorization/fga-constants';
-import type { ProgressStudentsInput, ProgressOverviewInput, ScoreOverviewInput } from './report.types';
+import type {
+  ProgressStudentsInput,
+  ProgressOverviewInput,
+  ScoreOverviewInput,
+  StudentScoresInput,
+} from './report.types';
 import type {
   ReportTaskMeta,
   StudentProgressRow,
   StudentOverviewRow,
   RunScoreRow,
+  StudentScoreQueryRow,
   TaskStatusCount,
 } from '../../repositories/report.repository';
 import { Operator } from '../../types/condition';
@@ -1991,6 +1997,483 @@ describe('ReportService', () => {
       const groups = groupVariantsByTaskId([z, a]);
 
       expect(groups.map((g) => g.representative.taskId)).toEqual(['z-task', 'a-task']);
+    });
+  });
+
+  describe('listStudentScores', () => {
+    const baseQuery: StudentScoresInput = {
+      scopeType: 'district',
+      scopeId: 'district-uuid-1',
+      page: 1,
+      perPage: 25,
+      sortBy: 'user.lastName',
+      sortOrder: 'asc',
+      filter: [],
+    };
+
+    /** Build a StudentScoreQueryRow with default null demographics. */
+    function buildQueryRow(overrides: Partial<StudentScoreQueryRow> & { userId: string }): StudentScoreQueryRow {
+      return {
+        assessmentPid: null,
+        username: null,
+        email: null,
+        nameFirst: null,
+        nameLast: null,
+        grade: '3',
+        statusEll: null,
+        statusIep: null,
+        statusFrl: null,
+        dob: null,
+        gender: null,
+        race: null,
+        hispanicEthnicity: null,
+        homeLanguage: null,
+        runs: new Map(),
+        scores: new Map(),
+        ...overrides,
+      };
+    }
+
+    /** Build a default getStudentScores mock return value. */
+    function setupDefaultStudentScoresMocks(items: StudentScoreQueryRow[] = [], totalItems = items.length) {
+      mockReportRepository.getStudentScores.mockResolvedValue({ items, totalItems });
+      mockTaskVariantParameterRepository.getByTaskVariantIds.mockResolvedValue([]);
+      mockReportRepository.getSchoolNamesForUsers.mockResolvedValue(new Map());
+    }
+
+    // --- Authorization ---
+
+    it('returns 404 when administration does not exist', async () => {
+      mockAdministrationRepository.getById.mockResolvedValue(null);
+
+      const service = createService();
+      await expect(service.listStudentScores(teacherAuth, testAdministrationId, baseQuery)).rejects.toMatchObject({
+        statusCode: StatusCodes.NOT_FOUND,
+        code: ApiErrorCode.RESOURCE_NOT_FOUND,
+      });
+    });
+
+    it('returns 403 when FGA denies can_read_scores on administration', async () => {
+      mockAuthorizationService.requirePermission.mockRejectedValue(
+        new ApiError(ApiErrorMessage.FORBIDDEN, {
+          statusCode: StatusCodes.FORBIDDEN,
+          code: ApiErrorCode.AUTH_FORBIDDEN,
+        }),
+      );
+
+      const service = createService();
+      await expect(service.listStudentScores(teacherAuth, testAdministrationId, baseQuery)).rejects.toMatchObject({
+        statusCode: StatusCodes.FORBIDDEN,
+        code: ApiErrorCode.AUTH_FORBIDDEN,
+      });
+
+      expect(mockAuthorizationService.requirePermission).toHaveBeenCalledWith(
+        teacherAuth.userId,
+        FgaRelation.CAN_READ_SCORES,
+        `${FgaType.ADMINISTRATION}:${testAdministrationId}`,
+      );
+    });
+
+    it('returns 400 when scope is not assigned to administration', async () => {
+      mockReportRepository.isScopeAssignedToAdministration.mockResolvedValue(false);
+
+      const service = createService();
+      await expect(service.listStudentScores(teacherAuth, testAdministrationId, baseQuery)).rejects.toMatchObject({
+        statusCode: StatusCodes.BAD_REQUEST,
+        code: ApiErrorCode.REQUEST_VALIDATION_FAILED,
+      });
+    });
+
+    it('returns 403 when FGA denies can_read_scores at scope level', async () => {
+      mockAuthorizationService.requirePermission.mockResolvedValueOnce(undefined).mockRejectedValueOnce(
+        new ApiError(ApiErrorMessage.FORBIDDEN, {
+          statusCode: StatusCodes.FORBIDDEN,
+          code: ApiErrorCode.AUTH_FORBIDDEN,
+        }),
+      );
+
+      const service = createService();
+      await expect(service.listStudentScores(teacherAuth, testAdministrationId, baseQuery)).rejects.toMatchObject({
+        statusCode: StatusCodes.FORBIDDEN,
+      });
+
+      expect(mockAuthorizationService.requirePermission).toHaveBeenNthCalledWith(
+        2,
+        teacherAuth.userId,
+        FgaRelation.CAN_READ_SCORES,
+        `${FgaType.DISTRICT}:district-uuid-1`,
+      );
+    });
+
+    it('super admin bypasses FGA checks', async () => {
+      setupDefaultStudentScoresMocks();
+
+      const service = createService();
+      await service.listStudentScores(superAdminAuth, testAdministrationId, baseQuery);
+
+      expect(mockAuthorizationService.requirePermission).not.toHaveBeenCalled();
+    });
+
+    // --- Pagination + response shape ---
+
+    it('returns paginated rows with totalItems and tasks metadata', async () => {
+      const row = buildQueryRow({ userId: 'student-1', nameFirst: 'Jane', nameLast: 'Doe', grade: '3' });
+      setupDefaultStudentScoresMocks([row], 42);
+
+      const service = createService();
+      const result = await service.listStudentScores(superAdminAuth, testAdministrationId, baseQuery);
+
+      expect(result.totalItems).toBe(42);
+      expect(result.items).toHaveLength(1);
+      expect(result.tasks).toHaveLength(testTaskMetas.length);
+      expect(result.items[0]!.user.firstName).toBe('Jane');
+      expect(result.items[0]!.user.lastName).toBe('Doe');
+    });
+
+    // --- Dynamic sort: unknown taskId → 400 ---
+
+    it('returns 400 when dynamic sort references an unknown task ID', async () => {
+      const service = createService();
+
+      await expect(
+        service.listStudentScores(superAdminAuth, testAdministrationId, {
+          ...baseQuery,
+          sortBy: 'scores.00000000-0000-0000-0000-000000000000.percentile',
+        }),
+      ).rejects.toMatchObject({
+        statusCode: StatusCodes.BAD_REQUEST,
+        code: ApiErrorCode.REQUEST_VALIDATION_FAILED,
+      });
+    });
+
+    it('passes a primary-variant sort field ref to the repository for dynamic score sort', async () => {
+      setupDefaultStudentScoresMocks();
+
+      const service = createService();
+      await service.listStudentScores(superAdminAuth, testAdministrationId, {
+        ...baseQuery,
+        sortBy: `scores.${TASK_ID_1}.percentile`,
+      });
+
+      const callArgs = mockReportRepository.getStudentScores.mock.calls[0]!;
+      const sortField = callArgs[5];
+      expect(sortField).toMatchObject({
+        taskVariantId: VARIANT_ID_1,
+        taskSlug: 'swr',
+        fieldType: 'percentile',
+      });
+    });
+
+    // --- taskId filter (merged across multiple entries) ---
+
+    it('merges multiple taskId filter entries into a single allow-list', async () => {
+      setupDefaultStudentScoresMocks();
+
+      const service = createService();
+      await service.listStudentScores(superAdminAuth, testAdministrationId, {
+        ...baseQuery,
+        filter: [
+          { field: 'taskId', operator: 'in', value: TASK_ID_1 },
+          { field: 'taskId', operator: 'in', value: TASK_ID_3 },
+        ],
+      });
+
+      const taskMetasArg = mockReportRepository.getStudentScores.mock.calls[0]![2];
+      const seenIds = new Set(taskMetasArg.map((t) => t.taskId));
+      expect(seenIds).toEqual(new Set([TASK_ID_1, TASK_ID_3]));
+    });
+
+    // --- Dynamic score-field filter translation ---
+
+    it('translates supportLevel:eq:achievedSkill into priority 3', async () => {
+      setupDefaultStudentScoresMocks();
+
+      const service = createService();
+      await service.listStudentScores(superAdminAuth, testAdministrationId, {
+        ...baseQuery,
+        filter: [{ field: `scores.${TASK_ID_1}.supportLevel`, operator: 'eq', value: 'achievedSkill' }],
+      });
+
+      const fieldFilters = mockReportRepository.getStudentScores.mock.calls[0]![6];
+      expect(fieldFilters).toHaveLength(1);
+      expect(fieldFilters![0]).toMatchObject({
+        taskVariantId: VARIANT_ID_1,
+        fieldType: 'supportLevel',
+        operator: 'eq',
+        values: ['3'],
+      });
+    });
+
+    it('translates supportLevel:in:achievedSkill,developingSkill into priorities [3, 2]', async () => {
+      setupDefaultStudentScoresMocks();
+
+      const service = createService();
+      await service.listStudentScores(superAdminAuth, testAdministrationId, {
+        ...baseQuery,
+        filter: [{ field: `scores.${TASK_ID_1}.supportLevel`, operator: 'in', value: 'achievedSkill,developingSkill' }],
+      });
+
+      const fieldFilters = mockReportRepository.getStudentScores.mock.calls[0]![6];
+      expect(fieldFilters![0]!.values).toEqual(['3', '2']);
+    });
+
+    it('drops supportLevel:eq:optional from SQL filters (post-fetch only)', async () => {
+      setupDefaultStudentScoresMocks();
+
+      const service = createService();
+      await service.listStudentScores(superAdminAuth, testAdministrationId, {
+        ...baseQuery,
+        filter: [{ field: `scores.${TASK_ID_1}.supportLevel`, operator: 'eq', value: 'optional' }],
+      });
+
+      const fieldFilters = mockReportRepository.getStudentScores.mock.calls[0]![6];
+      // 'optional' has no SQL representation; the resolver returns null and we drop it
+      expect(fieldFilters).toEqual([]);
+    });
+
+    it('passes numeric score-range filter values verbatim', async () => {
+      setupDefaultStudentScoresMocks();
+
+      const service = createService();
+      await service.listStudentScores(superAdminAuth, testAdministrationId, {
+        ...baseQuery,
+        filter: [{ field: `scores.${TASK_ID_1}.rawScore`, operator: 'gte', value: '500' }],
+      });
+
+      const fieldFilters = mockReportRepository.getStudentScores.mock.calls[0]![6];
+      expect(fieldFilters![0]).toMatchObject({
+        fieldType: 'rawScore',
+        operator: 'gte',
+        values: ['500'],
+      });
+    });
+
+    it('returns 400 when dynamic filter references an unknown task ID', async () => {
+      const service = createService();
+
+      await expect(
+        service.listStudentScores(superAdminAuth, testAdministrationId, {
+          ...baseQuery,
+          filter: [{ field: 'scores.00000000-0000-0000-0000-000000000000.percentile', operator: 'gte', value: '50' }],
+        }),
+      ).rejects.toMatchObject({
+        statusCode: StatusCodes.BAD_REQUEST,
+        code: ApiErrorCode.REQUEST_VALIDATION_FAILED,
+      });
+    });
+
+    // --- Per-row assembly: classification, dedup, optional/null support level ---
+
+    it('classifies scored students using the scoring service', async () => {
+      const row = buildQueryRow({
+        userId: 'student-1',
+        grade: '3',
+        runs: new Map([[VARIANT_ID_1, { runId: 'run-1', reliable: true, engagementFlags: [] }]]),
+        scores: new Map([[VARIANT_ID_1, new Map([['percentile', '90']])]]),
+      });
+      setupDefaultStudentScoresMocks([row], 1);
+
+      const service = createService();
+      const result = await service.listStudentScores(superAdminAuth, testAdministrationId, baseQuery);
+
+      const swrEntry = result.items[0]!.scores[TASK_ID_1]!;
+      expect(swrEntry.completed).toBe(true);
+      // grade 3, swr v0 cutoffs achieved=50 → percentile 90 → achievedSkill
+      expect(swrEntry.supportLevel).toBe('achievedSkill');
+      expect(swrEntry.percentile).toBe(90);
+      expect(swrEntry.reliable).toBe(true);
+      expect(swrEntry.engagementFlags).toEqual([]);
+    });
+
+    it('marks not-assessed students as completed:false with supportLevel="optional" when task is optional', async () => {
+      const row = buildQueryRow({ userId: 'student-1', grade: '3' });
+      setupDefaultStudentScoresMocks([row], 1);
+      mockTaskService.evaluateTaskVariantEligibility.mockReturnValue({ isAssigned: true, isOptional: true });
+
+      const service = createService();
+      const result = await service.listStudentScores(superAdminAuth, testAdministrationId, baseQuery);
+
+      const entry = result.items[0]!.scores[TASK_ID_1]!;
+      expect(entry.completed).toBe(false);
+      expect(entry.supportLevel).toBe('optional');
+      expect(entry.optional).toBe(true);
+      expect(entry.rawScore).toBeNull();
+    });
+
+    it('marks not-assessed students as completed:false with supportLevel=null when task is required', async () => {
+      const row = buildQueryRow({ userId: 'student-1', grade: '3' });
+      setupDefaultStudentScoresMocks([row], 1);
+      mockTaskService.evaluateTaskVariantEligibility.mockReturnValue({ isAssigned: true, isOptional: false });
+
+      const service = createService();
+      const result = await service.listStudentScores(superAdminAuth, testAdministrationId, baseQuery);
+
+      const entry = result.items[0]!.scores[TASK_ID_1]!;
+      expect(entry.completed).toBe(false);
+      expect(entry.supportLevel).toBeNull();
+      expect(entry.optional).toBe(false);
+    });
+
+    it('omits tasks not assigned to the student from the scores map', async () => {
+      const row = buildQueryRow({ userId: 'student-1', grade: '3' });
+      setupDefaultStudentScoresMocks([row], 1);
+      mockTaskService.evaluateTaskVariantEligibility.mockReturnValue({ isAssigned: false, isOptional: false });
+
+      const service = createService();
+      const result = await service.listStudentScores(superAdminAuth, testAdministrationId, baseQuery);
+
+      expect(result.items[0]!.scores[TASK_ID_1]).toBeUndefined();
+    });
+
+    it('rounds score values to integers', async () => {
+      const row = buildQueryRow({
+        userId: 'student-1',
+        grade: '3',
+        runs: new Map([[VARIANT_ID_1, { runId: 'run-1', reliable: true, engagementFlags: [] }]]),
+        scores: new Map([
+          [
+            VARIANT_ID_1,
+            new Map([
+              ['percentile', '90.7'],
+              ['roarScore', '512.4'],
+            ]),
+          ],
+        ]),
+      });
+      setupDefaultStudentScoresMocks([row], 1);
+
+      const service = createService();
+      const result = await service.listStudentScores(superAdminAuth, testAdministrationId, baseQuery);
+
+      const entry = result.items[0]!.scores[TASK_ID_1]!;
+      expect(entry.percentile).toBe(91);
+      expect(entry.rawScore).toBe(512);
+    });
+
+    it('uses first variant with completed scores in multi-variant tasks (per-row dedup)', async () => {
+      const SHARED_TASK = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
+      const variantA: ReportTaskMeta = {
+        taskId: SHARED_TASK,
+        taskVariantId: 'var-a',
+        taskSlug: 'swr',
+        taskName: 'ROAR - Word',
+        orderIndex: 0,
+        conditionsAssignment: null,
+        conditionsRequirements: null,
+      };
+      const variantB: ReportTaskMeta = {
+        taskId: SHARED_TASK,
+        taskVariantId: 'var-b',
+        taskSlug: 'swr',
+        taskName: 'ROAR - Word',
+        orderIndex: 1,
+        conditionsAssignment: null,
+        conditionsRequirements: null,
+      };
+      mockReportRepository.getTaskMetadata.mockResolvedValue([variantA, variantB]);
+
+      // Student has scores on BOTH variants; variant A wins (lower orderIndex).
+      const row = buildQueryRow({
+        userId: 'student-1',
+        grade: '3',
+        runs: new Map([
+          ['var-a', { runId: 'run-a', reliable: true, engagementFlags: [] }],
+          ['var-b', { runId: 'run-b', reliable: false, engagementFlags: ['flagB'] }],
+        ]),
+        scores: new Map([
+          ['var-a', new Map([['percentile', '90']])],
+          ['var-b', new Map([['percentile', '10']])],
+        ]),
+      });
+      setupDefaultStudentScoresMocks([row], 1);
+
+      const service = createService();
+      const result = await service.listStudentScores(superAdminAuth, testAdministrationId, baseQuery);
+
+      // Only one entry for the shared taskId
+      expect(Object.keys(result.items[0]!.scores)).toEqual([SHARED_TASK]);
+      // Variant A (high percentile, reliable) wins
+      expect(result.items[0]!.scores[SHARED_TASK]!.supportLevel).toBe('achievedSkill');
+      expect(result.items[0]!.scores[SHARED_TASK]!.reliable).toBe(true);
+    });
+
+    it('reads supportLevel from run_scores for assessment-computed tasks (roam-alpaca)', async () => {
+      const ROAM_TASK = 'cccccccc-aaaa-bbbb-dddd-eeeeeeeeeeee';
+      const ROAM_VARIANT = 'roam-variant-1';
+      mockReportRepository.getTaskMetadata.mockResolvedValue([
+        {
+          taskId: ROAM_TASK,
+          taskVariantId: ROAM_VARIANT,
+          taskSlug: 'roam-alpaca',
+          taskName: 'ROAM - Alpaca',
+          orderIndex: 0,
+          conditionsAssignment: null,
+          conditionsRequirements: null,
+        },
+      ]);
+
+      const row = buildQueryRow({
+        userId: 'student-1',
+        grade: '3',
+        runs: new Map([[ROAM_VARIANT, { runId: 'r', reliable: true, engagementFlags: [] }]]),
+        scores: new Map([[ROAM_VARIANT, new Map([['supportLevel', 'developingSkill']])]]),
+      });
+      setupDefaultStudentScoresMocks([row], 1);
+
+      const service = createService();
+      const result = await service.listStudentScores(superAdminAuth, testAdministrationId, baseQuery);
+
+      expect(result.items[0]!.scores[ROAM_TASK]!.supportLevel).toBe('developingSkill');
+    });
+
+    // --- schoolName ---
+
+    it('populates schoolName for district scope', async () => {
+      const row = buildQueryRow({ userId: 'student-1', grade: '3' });
+      setupDefaultStudentScoresMocks([row], 1);
+      mockReportRepository.getSchoolNamesForUsers.mockResolvedValue(new Map([['student-1', 'Lincoln Elementary']]));
+
+      const service = createService();
+      const result = await service.listStudentScores(superAdminAuth, testAdministrationId, baseQuery);
+
+      expect(result.items[0]!.user.schoolName).toBe('Lincoln Elementary');
+    });
+
+    it('returns null schoolName for non-district scope', async () => {
+      const row = buildQueryRow({ userId: 'student-1', grade: '3' });
+      setupDefaultStudentScoresMocks([row], 1);
+
+      const service = createService();
+      const result = await service.listStudentScores(superAdminAuth, testAdministrationId, {
+        ...baseQuery,
+        scopeType: 'school',
+      });
+
+      expect(result.items[0]!.user.schoolName).toBeNull();
+      expect(mockReportRepository.getSchoolNamesForUsers).not.toHaveBeenCalled();
+    });
+
+    // --- Error handling ---
+
+    it('wraps unexpected repository errors in a 500 ApiError', async () => {
+      mockReportRepository.getStudentScores.mockRejectedValue(new Error('connection reset'));
+      mockTaskVariantParameterRepository.getByTaskVariantIds.mockResolvedValue([]);
+
+      const service = createService();
+      await expect(service.listStudentScores(superAdminAuth, testAdministrationId, baseQuery)).rejects.toMatchObject({
+        statusCode: StatusCodes.INTERNAL_SERVER_ERROR,
+        code: ApiErrorCode.DATABASE_QUERY_FAILED,
+      });
+    });
+
+    it('re-throws ApiError without wrapping', async () => {
+      mockAdministrationRepository.getById.mockResolvedValue(null);
+
+      const service = createService();
+      await expect(service.listStudentScores(superAdminAuth, testAdministrationId, baseQuery)).rejects.toMatchObject({
+        statusCode: StatusCodes.NOT_FOUND,
+        code: ApiErrorCode.RESOURCE_NOT_FOUND,
+      });
     });
   });
 });

--- a/apps/backend/src/services/report/report.service.test.ts
+++ b/apps/backend/src/services/report/report.service.test.ts
@@ -2183,6 +2183,29 @@ describe('ReportService', () => {
       expect(seenIds).toEqual(new Set([TASK_ID_1, TASK_ID_3]));
     });
 
+    it('returns an empty page when taskId filter excludes every task', async () => {
+      // Filter targets a UUID not present in testTaskMetas — taskMetas becomes []
+      // and the empty-task short-circuit returns immediately. No pagination query
+      // is run; totalItems is 0 by definition because no per-task entries can be
+      // assembled when no tasks are in scope.
+      setupDefaultStudentScoresMocks();
+
+      const filteredQuery: StudentScoresInput = {
+        ...baseQuery,
+        filter: [{ field: 'taskId', operator: 'in', value: '00000000-0000-0000-0000-000000000000' }],
+      };
+
+      const service = createService();
+      const result = await service.listStudentScores(superAdminAuth, testAdministrationId, filteredQuery);
+
+      expect(result.tasks).toEqual([]);
+      expect(result.items).toEqual([]);
+      expect(result.totalItems).toBe(0);
+      // Short-circuit means we don't touch the paginated row fetch or downstream queries
+      expect(mockReportRepository.getStudentScores).not.toHaveBeenCalled();
+      expect(mockReportRepository.getSchoolNamesForUsers).not.toHaveBeenCalled();
+    });
+
     // --- Dynamic score-field filter translation ---
 
     it('translates supportLevel:eq:achievedSkill into priority 3', async () => {

--- a/apps/backend/src/services/report/report.service.test.ts
+++ b/apps/backend/src/services/report/report.service.test.ts
@@ -2291,7 +2291,9 @@ describe('ReportService', () => {
       const row = buildQueryRow({
         userId: 'student-1',
         grade: '3',
-        runs: new Map([[VARIANT_ID_1, { runId: 'run-1', reliable: true, engagementFlags: [] }]]),
+        runs: new Map([
+          [VARIANT_ID_1, { runId: 'run-1', reliable: true, engagementFlags: [], completedAt: new Date('2025-09-01') }],
+        ]),
         scores: new Map([[VARIANT_ID_1, new Map([['percentile', '90']])]]),
       });
       setupDefaultStudentScoresMocks([row], 1);
@@ -2352,7 +2354,9 @@ describe('ReportService', () => {
       const row = buildQueryRow({
         userId: 'student-1',
         grade: '3',
-        runs: new Map([[VARIANT_ID_1, { runId: 'run-1', reliable: true, engagementFlags: [] }]]),
+        runs: new Map([
+          [VARIANT_ID_1, { runId: 'run-1', reliable: true, engagementFlags: [], completedAt: new Date('2025-09-01') }],
+        ]),
         scores: new Map([
           [
             VARIANT_ID_1,
@@ -2400,8 +2404,11 @@ describe('ReportService', () => {
         userId: 'student-1',
         grade: '3',
         runs: new Map([
-          ['var-a', { runId: 'run-a', reliable: true, engagementFlags: [] }],
-          ['var-b', { runId: 'run-b', reliable: false, engagementFlags: ['flagB'] }],
+          ['var-a', { runId: 'run-a', reliable: true, engagementFlags: [], completedAt: new Date('2025-09-02') }],
+          [
+            'var-b',
+            { runId: 'run-b', reliable: false, engagementFlags: ['flagB'], completedAt: new Date('2025-09-01') },
+          ],
         ]),
         scores: new Map([
           ['var-a', new Map([['percentile', '90']])],
@@ -2438,7 +2445,9 @@ describe('ReportService', () => {
       const row = buildQueryRow({
         userId: 'student-1',
         grade: '3',
-        runs: new Map([[ROAM_VARIANT, { runId: 'r', reliable: true, engagementFlags: [] }]]),
+        runs: new Map([
+          [ROAM_VARIANT, { runId: 'r', reliable: true, engagementFlags: [], completedAt: new Date('2025-09-01') }],
+        ]),
         scores: new Map([[ROAM_VARIANT, new Map([['supportLevel', 'developingSkill']])]]),
       });
       setupDefaultStudentScoresMocks([row], 1);

--- a/apps/backend/src/services/report/report.service.ts
+++ b/apps/backend/src/services/report/report.service.ts
@@ -18,6 +18,7 @@ import type {
   ServiceTaskScoreOverview,
   StudentScoresInput,
   StudentScoresSortField,
+  StudentScoresFilterField,
   StudentScoresResult,
   ServiceStudentScoreRow,
   ServiceStudentScoreEntry,
@@ -112,7 +113,7 @@ const STUDENT_SCORES_SORT_COLUMNS: Record<Exclude<StudentScoresSortField, 'user.
  * Currently we only support exact-match user-level filters in SQL; schoolName
  * filtering is delegated to the repository's own correlated subquery.
  */
-const STUDENT_SCORES_USER_FILTER_FIELDS: Record<string, PgColumn> = {
+const STUDENT_SCORES_USER_FILTER_FIELDS: Record<Exclude<StudentScoresFilterField, 'user.schoolName'>, PgColumn> = {
   'user.grade': users.grade,
   'user.firstName': users.nameFirst,
   'user.lastName': users.nameLast,

--- a/apps/backend/src/services/report/report.service.ts
+++ b/apps/backend/src/services/report/report.service.ts
@@ -16,9 +16,15 @@ import type {
   ScoreOverviewInput,
   ScoreOverviewResult,
   ServiceTaskScoreOverview,
+  StudentScoresInput,
+  StudentScoresSortField,
+  StudentScoresResult,
+  ServiceStudentScoreRow,
+  ServiceStudentScoreEntry,
+  ServiceSupportLevelValue,
   ParsedFilter,
 } from './report.types';
-import { PROGRESS_TASK_STATUS_PATTERN } from '@roar-dashboard/api-contract';
+import { PROGRESS_TASK_STATUS_PATTERN, SCORE_TASK_FIELD_PATTERN } from '@roar-dashboard/api-contract';
 import { PROGRESS_STATUS_PRIORITY } from '../../constants/progress-status';
 import { buildFilterConditions } from '../../utils/build-filter-conditions.util';
 import { ApiErrorCode } from '../../enums/api-error-code.enum';
@@ -35,12 +41,18 @@ import type {
   RunScoreRow,
   ProgressStatusSortParam,
   ProgressStatusFilterParam,
+  StudentScoresFieldRef,
+  StudentScoresFieldFilter,
+  StudentScoresFilterOperator,
+  StudentScoresFieldType,
+  StudentScoreQueryRow,
+  ResolvedScoringRules,
 } from '../../repositories/report.repository';
 import { TaskService } from '../task/task.service';
 import { AuthorizationService } from '../authorization/authorization.service';
 import { FgaType, FgaRelation } from '../authorization/fga-constants';
 import { TaskVariantParameterRepository } from '../../repositories/task-variant-parameter.repository';
-import { getSupportLevel, parseScoreValue, resolveScoreFieldNames } from '../scoring';
+import { getScoringConfig, getSupportLevel, parseScoreValue, resolveScoreFieldNames } from '../scoring';
 import { getGradeAsNumber } from '../../utils/get-grade-as-number.util';
 import { conditionToSql } from '../../utils/condition-to-sql';
 import type { Condition, ConditionEvaluationUser } from '../../types/condition';
@@ -74,6 +86,33 @@ const GRADE_AWARE_FIELDS: ReadonlySet<string> = new Set(['user.grade']);
  */
 const SCORE_OVERVIEW_USER_FILTER_FIELDS: Record<string, PgColumn> = {
   'user.grade': users.grade,
+};
+
+/** Map sortBy field strings to Drizzle column references for student scores. */
+const STUDENT_SCORES_SORT_COLUMNS: Record<StudentScoresSortField, Column> = {
+  'user.lastName': users.nameLast,
+  'user.firstName': users.nameFirst,
+  'user.username': users.username,
+  'user.grade': users.grade,
+  // user.schoolName uses a SQL subquery built inside the repository — not a column.
+  // The service routes this case via a sentinel name (handled at sort-resolution time).
+  'user.schoolName': users.id, // placeholder; not actually used at runtime for this field
+};
+
+/**
+ * Map static filter field strings to Drizzle column references for student scores.
+ * `user.schoolName` is filterable via ILIKE in district scope; the column reference
+ * is `orgs.name` joined indirectly via user_orgs — represented as a sentinel here
+ * because buildFilterConditions can't directly express a correlated lookup.
+ * Currently we only support exact-match user-level filters in SQL; schoolName
+ * filtering is delegated to the repository's own correlated subquery.
+ */
+const STUDENT_SCORES_USER_FILTER_FIELDS: Record<string, PgColumn> = {
+  'user.grade': users.grade,
+  'user.firstName': users.nameFirst,
+  'user.lastName': users.nameLast,
+  'user.username': users.username,
+  'user.email': users.email,
 };
 
 /** Per-task status counters for progress overview aggregation (7-level). */
@@ -581,7 +620,164 @@ export function ReportService({
     }
   }
 
-  return { listProgressStudents, getProgressOverview, getScoreOverview };
+  /**
+   * List paginated per-student scores for an administration.
+   *
+   * Authorization (two FGA checks):
+   * 1. `verifyAdministrationScoreReadAccess` — administration-level can_read_scores
+   * 2. `authorizeScopeAccess` with CAN_READ_SCORES — scope-level
+   *
+   * Sort and filter accept dynamic `scores.<taskId>.<field>` fields where
+   * `<field>` is one of `rawScore`, `percentile`, `standardScore`, `supportLevel`.
+   * The taskId is validated against the administration's tasks (400 if unknown).
+   * For multi-variant tasks, dynamic sort/filter targets the lowest-orderIndex
+   * variant of the task (the "primary variant") so SQL-level ordering remains
+   * deterministic across pages.
+   *
+   * Per-row dedup: each task in the response has at most one score entry per
+   * student. The service picks the first variant (in orderIndex order) with a
+   * completed run for that student. Students with no completed run on any
+   * variant of a task get `completed: false` and `supportLevel` either
+   * `'optional'` (task optional for them) or `null` (assigned-required).
+   *
+   * @throws {ApiError} NOT_FOUND if administration doesn't exist
+   * @throws {ApiError} FORBIDDEN if user lacks can_read_scores
+   * @throws {ApiError} BAD_REQUEST if scope or sort/filter task ID is invalid
+   */
+  async function listStudentScores(
+    authContext: AuthContext,
+    administrationId: string,
+    query: StudentScoresInput,
+  ): Promise<StudentScoresResult> {
+    const { userId } = authContext;
+    const { scopeType, scopeId, page, perPage, sortBy, sortOrder, filter } = query;
+
+    try {
+      // 1. Authorization
+      await verifyAdministrationScoreReadAccess(authContext, administrationId);
+      await authorizeScopeAccess(authContext, administrationId, scopeType, scopeId, FgaRelation.CAN_READ_SCORES);
+
+      // 2. Get task metadata and apply taskId filter (merge multiple entries)
+      let taskMetas = await reportRepository.getTaskMetadata(administrationId);
+      const taskIdFilters = filter.filter((f) => f.field === 'taskId');
+      if (taskIdFilters.length > 0) {
+        const allowedTaskIds = new Set(taskIdFilters.flatMap((f) => f.value.split(',').map((v) => v.trim())));
+        taskMetas = taskMetas.filter((t) => allowedTaskIds.has(t.taskId));
+      }
+
+      // 3. Build per-task primary variant map (lowest-orderIndex variant of each task)
+      const primaryVariantByTaskId = buildPrimaryVariantMap(taskMetas);
+
+      // 4. Resolve scoring versions per variant
+      const taskVariantIds = taskMetas.map((t) => t.taskVariantId);
+      const allParams =
+        taskVariantIds.length > 0 ? await taskVariantParameterRepository.getByTaskVariantIds(taskVariantIds) : [];
+      const scoringVersionByVariant = new Map<string, number>();
+      for (const param of allParams) {
+        if (param.name === 'scoringVersion') {
+          const version = typeof param.value === 'number' ? param.value : Number(param.value);
+          if (!isNaN(version)) {
+            scoringVersionByVariant.set(param.taskVariantId, version);
+          }
+        }
+      }
+
+      // 5. Resolve scoring rules per variant for SQL CASE generation in the repo
+      const scoringRulesByVariant = new Map<string, ResolvedScoringRules>();
+      for (const variant of taskMetas) {
+        scoringRulesByVariant.set(
+          variant.taskVariantId,
+          resolveScoringRulesForVariant(variant.taskSlug, scoringVersionByVariant.get(variant.taskVariantId) ?? null),
+        );
+      }
+
+      // 6. Resolve dynamic sort field (against primary variants)
+      const sortField = resolveDynamicSortField(sortBy, primaryVariantByTaskId, scoringVersionByVariant, taskMetas);
+
+      // 7. Resolve dynamic score-field filters (against primary variants)
+      const userLevelFilters: ParsedFilter[] = [];
+      const scoreFieldFilters: StudentScoresFieldFilter[] = [];
+      for (const f of filter) {
+        if (f.field === 'taskId') continue;
+        if (SCORE_TASK_FIELD_PATTERN.test(f.field)) {
+          const filterRef = resolveDynamicFilter(f, primaryVariantByTaskId, scoringVersionByVariant, taskMetas);
+          if (filterRef) scoreFieldFilters.push(filterRef);
+          continue;
+        }
+        userLevelFilters.push(f);
+      }
+
+      const filterCondition =
+        userLevelFilters.length > 0
+          ? buildFilterConditions(userLevelFilters, STUDENT_SCORES_USER_FILTER_FIELDS, {
+              gradeAwareFields: GRADE_AWARE_FIELDS,
+            })
+          : undefined;
+
+      // 8. Determine the static sort column when sorting by a user field.
+      // user.schoolName is handled inside the repository as a correlated subquery,
+      // so we pass undefined and rely on the dynamic-sort path falling through to
+      // the repo's school-name expression. Other static fields use their column.
+      let staticSortColumn: Column | undefined;
+      if (!sortField) {
+        if (sortBy === 'user.schoolName') {
+          staticSortColumn = undefined; // repo will use schoolNameSql
+        } else {
+          staticSortColumn = STUDENT_SCORES_SORT_COLUMNS[sortBy as StudentScoresSortField] ?? users.nameLast;
+        }
+      }
+
+      // 9. Repository call
+      const result = await reportRepository.getStudentScores(
+        administrationId,
+        { scopeType, scopeId },
+        taskMetas,
+        { page, perPage, sortColumn: staticSortColumn, sortDirection: sortOrder },
+        filterCondition,
+        sortField,
+        scoreFieldFilters,
+        scoringRulesByVariant,
+      );
+
+      // 10. Build response — dedupe per taskId, classify, set optional/completed
+      const tasksOrdered: ServiceTaskMetadata[] = uniqueTaskMetadataInOrder(taskMetas);
+
+      // Resolve schoolNames for district-scope rows (not auto-populated by repo for that field)
+      let schoolNamesByUser: Map<string, string> | undefined;
+      if (scopeType === EntityType.DISTRICT) {
+        schoolNamesByUser = await reportRepository.getSchoolNamesForUsers(result.items.map((s) => s.userId));
+      }
+
+      const items: ServiceStudentScoreRow[] = result.items.map((row) =>
+        assembleStudentScoreRow(
+          row,
+          taskMetas,
+          scoringVersionByVariant,
+          taskService.evaluateTaskVariantEligibility,
+          scopeType,
+          schoolNamesByUser,
+        ),
+      );
+
+      return { tasks: tasksOrdered, items, totalItems: result.totalItems };
+    } catch (error) {
+      if (error instanceof ApiError) throw error;
+
+      logger.error(
+        { err: error, context: { userId, administrationId, scopeType, scopeId } },
+        'Failed to retrieve student scores report',
+      );
+
+      throw new ApiError('Failed to retrieve student scores report', {
+        statusCode: StatusCodes.INTERNAL_SERVER_ERROR,
+        code: ApiErrorCode.DATABASE_QUERY_FAILED,
+        context: { userId, administrationId, scopeType, scopeId },
+        cause: error,
+      });
+    }
+  }
+
+  return { listProgressStudents, getProgressOverview, getScoreOverview, listStudentScores };
 }
 
 // --- Progress sort/filter resolution helpers ---
@@ -1044,4 +1240,394 @@ function aggregateTaskGroup(
       needsExtraSupport: { count: needsSupportCount },
     },
   };
+}
+
+// --- Student-scores helpers ---
+
+/**
+ * Build a map of taskId → primary variant (lowest orderIndex within the task).
+ * The primary variant is what dynamic sort/filter on `scores.<taskId>.<field>`
+ * resolves against — it ensures SQL ordering is deterministic across pages
+ * even when a task has multiple grade-specific variants.
+ *
+ * Assumes `taskMetas` is already ordered by orderIndex (as returned by
+ * `getTaskMetadata`).
+ */
+function buildPrimaryVariantMap(taskMetas: ReportTaskMeta[]): Map<string, ReportTaskMeta> {
+  const out = new Map<string, ReportTaskMeta>();
+  for (const meta of taskMetas) {
+    if (!out.has(meta.taskId)) {
+      out.set(meta.taskId, meta);
+    }
+  }
+  return out;
+}
+
+/**
+ * Return a deduplicated list of task metadata (one entry per taskId) preserving
+ * the orderIndex order of the input. Used for the response's `tasks` array so
+ * the frontend renders one column per task.
+ */
+function uniqueTaskMetadataInOrder(taskMetas: ReportTaskMeta[]): ServiceTaskMetadata[] {
+  const seen = new Set<string>();
+  const out: ServiceTaskMetadata[] = [];
+  for (const meta of taskMetas) {
+    if (!seen.has(meta.taskId)) {
+      seen.add(meta.taskId);
+      out.push({
+        taskId: meta.taskId,
+        taskSlug: meta.taskSlug,
+        taskName: meta.taskName,
+        orderIndex: meta.orderIndex,
+      });
+    }
+  }
+  return out;
+}
+
+/**
+ * Resolve the scoring config for a variant + scoring version into the shape the
+ * repository needs for SQL CASE generation. Decouples the repository from the
+ * scoring service.
+ *
+ * Returns an empty rules object for unknown task slugs and for `'none'`
+ * classification — those tasks have no support level the SQL CASE can compute.
+ */
+function resolveScoringRulesForVariant(taskSlug: string, scoringVersion: number | null): ResolvedScoringRules {
+  const empty: ResolvedScoringRules = {
+    assessmentSupportLevelField: null,
+    percentileCutoffs: null,
+    rawScoreThresholds: null,
+    percentileBelowGrade: null,
+    percentileFieldNames: [],
+    rawScoreFieldNames: [],
+    standardScoreFieldNames: [],
+  };
+
+  const config = getScoringConfig(taskSlug);
+  if (!config) return empty;
+
+  const fieldNames = resolveScoreFieldNames(taskSlug, null, scoringVersion);
+  const baseRules: ResolvedScoringRules = {
+    ...empty,
+    percentileFieldNames: fieldNames.percentileFieldNames,
+    rawScoreFieldNames: fieldNames.rawScoreFieldNames,
+    standardScoreFieldNames: fieldNames.standardScoreFieldNames,
+  };
+
+  if (config.classification.type === 'assessment-computed') {
+    return {
+      ...baseRules,
+      assessmentSupportLevelField: config.classification.supportLevelField ?? 'supportLevel',
+    };
+  }
+  if (config.classification.type === 'none') {
+    return baseRules;
+  }
+
+  // percentile-then-rawscore
+  const version = scoringVersion ?? 0;
+  const pctEntry = config.classification.percentileCutoffs.find((e) => version >= e.minVersion);
+  const rawEntry = config.classification.rawScoreThresholds.find((e) => version >= e.minVersion);
+  return {
+    ...baseRules,
+    percentileCutoffs: pctEntry?.cutoffs ?? null,
+    rawScoreThresholds: rawEntry?.thresholds ?? null,
+    // percentileBelowGrade defaults to 6 (exclusive); null in the config means
+    // "use percentile for all grades", which we represent as null in the rules.
+    percentileBelowGrade: config.classification.percentileBelowGrade ?? 6,
+  };
+}
+
+/**
+ * Parse a `scores.<uuid>.<field>` string into its components.
+ * Returns null if the string doesn't match the expected pattern.
+ */
+function parseScoreFieldString(field: string): { taskId: string; fieldType: StudentScoresFieldType } | null {
+  if (!SCORE_TASK_FIELD_PATTERN.test(field)) return null;
+  const parts = field.split('.');
+  if (parts.length !== 3) return null;
+  const taskId = parts[1]!;
+  const fieldType = parts[2] as StudentScoresFieldType;
+  return { taskId, fieldType };
+}
+
+/**
+ * Resolve a dynamic sort string into a `StudentScoresFieldRef` against the
+ * primary variant of the referenced task. Returns null for static sort fields
+ * (the caller falls back to the static-column path) and throws 400 for
+ * unknown task IDs.
+ */
+function resolveDynamicSortField(
+  sortBy: string,
+  primaryVariantByTaskId: Map<string, ReportTaskMeta>,
+  scoringVersionByVariant: Map<string, number>,
+  taskMetas: ReportTaskMeta[],
+): StudentScoresFieldRef | null {
+  const parsed = parseScoreFieldString(sortBy);
+  if (!parsed) return null;
+
+  const variant = primaryVariantByTaskId.get(parsed.taskId);
+  if (!variant) {
+    throw new ApiError('Invalid task ID in sort field', {
+      statusCode: StatusCodes.BAD_REQUEST,
+      code: ApiErrorCode.REQUEST_VALIDATION_FAILED,
+      context: { sortBy, availableTaskIds: taskMetas.map((t) => t.taskId) },
+    });
+  }
+
+  return {
+    taskVariantId: variant.taskVariantId,
+    taskSlug: variant.taskSlug,
+    fieldType: parsed.fieldType,
+    scoringVersion: scoringVersionByVariant.get(variant.taskVariantId) ?? null,
+  };
+}
+
+/**
+ * Mapping between contract-side support level names and the SQL priority
+ * integers the repository's CASE expressions return.
+ */
+const SUPPORT_LEVEL_NAME_TO_PRIORITY: Record<string, number> = {
+  achievedSkill: 3,
+  developingSkill: 2,
+  needsExtraSupport: 1,
+};
+
+/**
+ * Resolve a dynamic score-field filter into a `StudentScoresFieldFilter`. For
+ * `supportLevel` filters the level names (`achievedSkill`, etc.) are translated
+ * to priority integers so the repository can compare against its CASE output.
+ *
+ * Returns null when the filter targets an unsupported value (e.g.,
+ * `supportLevel:eq:optional` — `optional` requires post-fetch logic and isn't
+ * representable in the SQL CASE; the service silently drops the filter and
+ * documents the limitation in the API contract).
+ *
+ * @throws {ApiError} BAD_REQUEST if the task ID is unknown
+ */
+function resolveDynamicFilter(
+  filter: ParsedFilter,
+  primaryVariantByTaskId: Map<string, ReportTaskMeta>,
+  scoringVersionByVariant: Map<string, number>,
+  taskMetas: ReportTaskMeta[],
+): StudentScoresFieldFilter | null {
+  const parsed = parseScoreFieldString(filter.field);
+  if (!parsed) return null;
+
+  const variant = primaryVariantByTaskId.get(parsed.taskId);
+  if (!variant) {
+    throw new ApiError('Invalid task ID in filter field', {
+      statusCode: StatusCodes.BAD_REQUEST,
+      code: ApiErrorCode.REQUEST_VALIDATION_FAILED,
+      context: { field: filter.field, availableTaskIds: taskMetas.map((t) => t.taskId) },
+    });
+  }
+
+  // Translate values: numeric fields use raw strings (cast in SQL); supportLevel
+  // names map to priorities (3/2/1). 'optional' has no SQL representation — drop
+  // those values from the filter list.
+  let values: string[];
+  if (parsed.fieldType === 'supportLevel') {
+    const rawValues = filter.operator === 'in' ? filter.value.split(',').map((v) => v.trim()) : [filter.value];
+    values = rawValues
+      .map((v) => SUPPORT_LEVEL_NAME_TO_PRIORITY[v])
+      .filter((p): p is number => p !== undefined)
+      .map(String);
+    if (values.length === 0) return null;
+  } else {
+    values = filter.operator === 'in' ? filter.value.split(',').map((v) => v.trim()) : [filter.value];
+  }
+
+  return {
+    taskVariantId: variant.taskVariantId,
+    taskSlug: variant.taskSlug,
+    fieldType: parsed.fieldType,
+    scoringVersion: scoringVersionByVariant.get(variant.taskVariantId) ?? null,
+    operator: filter.operator as StudentScoresFilterOperator,
+    values,
+  };
+}
+
+/**
+ * Round a numeric score to an integer for the API response. Returns null for
+ * null/NaN inputs.
+ */
+function roundScoreOrNull(value: number | null): number | null {
+  if (value === null || isNaN(value)) return null;
+  return Math.round(value);
+}
+
+/**
+ * Type for the evaluateTaskVariantEligibility function from TaskService.
+ */
+type StudentEligibilityEvaluator = (
+  user: ConditionEvaluationUser,
+  conditionsAssignment: Condition | null,
+  conditionsRequirements: Condition | null,
+) => { isAssigned: boolean; isOptional: boolean };
+
+/**
+ * Convert a single repository row into a service-shaped student row with one
+ * score entry per taskId. For each task:
+ *
+ * - If any variant has a completed run for this student, pick the
+ *   lowest-orderIndex variant with scores and classify; that becomes the
+ *   per-task entry.
+ * - Otherwise, evaluate condition assignment/requirement across all variants.
+ *   `assigned` if any variant assigns; `optional` only if every assigning
+ *   variant marks the student optional.
+ * - Tasks where every variant excludes the student via `conditionsAssignment`
+ *   are omitted from the `scores` map (they're not visible to that student).
+ */
+function assembleStudentScoreRow(
+  row: StudentScoreQueryRow,
+  taskMetas: ReportTaskMeta[],
+  scoringVersionByVariant: Map<string, number>,
+  evaluateEligibility: StudentEligibilityEvaluator,
+  scopeType: ScopeType,
+  schoolNamesByUser: Map<string, string> | undefined,
+): ServiceStudentScoreRow {
+  // Group variants by taskId, preserving orderIndex order
+  const variantsByTaskId = new Map<string, ReportTaskMeta[]>();
+  const taskOrder: string[] = [];
+  for (const meta of taskMetas) {
+    if (!variantsByTaskId.has(meta.taskId)) {
+      variantsByTaskId.set(meta.taskId, []);
+      taskOrder.push(meta.taskId);
+    }
+    variantsByTaskId.get(meta.taskId)!.push(meta);
+  }
+
+  const scores: Record<string, ServiceStudentScoreEntry> = {};
+
+  for (const taskId of taskOrder) {
+    const variants = variantsByTaskId.get(taskId)!;
+
+    // Find the first variant with completed run + scores
+    let scored: {
+      variant: ReportTaskMeta;
+      scoreMap: Map<string, string>;
+      runMeta: { reliable: boolean | null; engagementFlags: string[] };
+    } | null = null;
+    for (const v of variants) {
+      const variantScores = row.scores.get(v.taskVariantId);
+      const runMeta = row.runs.get(v.taskVariantId);
+      if (variantScores && variantScores.size > 0 && runMeta) {
+        scored = {
+          variant: v,
+          scoreMap: variantScores,
+          runMeta: { reliable: runMeta.reliable, engagementFlags: runMeta.engagementFlags },
+        };
+        break;
+      }
+    }
+
+    if (scored) {
+      const scoringVersion = scoringVersionByVariant.get(scored.variant.taskVariantId) ?? null;
+      const gradeLevel = getGradeAsNumber(row.grade);
+      const fieldNames = resolveScoreFieldNames(scored.variant.taskSlug, gradeLevel, scoringVersion);
+
+      const percentile = pickFirstNumeric(scored.scoreMap, fieldNames.percentileFieldNames);
+      const rawScore = pickFirstNumeric(scored.scoreMap, fieldNames.rawScoreFieldNames);
+      const standardScore = pickFirstNumeric(scored.scoreMap, fieldNames.standardScoreFieldNames);
+      const assessmentSupportLevel = pickFirstString(scored.scoreMap, ['supportLevel', 'support_level']);
+
+      const supportLevel = getSupportLevel({
+        grade: row.grade,
+        percentile,
+        rawScore,
+        taskSlug: scored.variant.taskSlug,
+        scoringVersion,
+        assessmentSupportLevel,
+      }) as ServiceSupportLevelValue | null;
+
+      // Eligibility for the optional flag (independent of completion)
+      const eligibility = evaluateAcrossVariants(row, variants, evaluateEligibility);
+
+      scores[taskId] = {
+        rawScore: roundScoreOrNull(rawScore),
+        percentile: roundScoreOrNull(percentile),
+        standardScore: roundScoreOrNull(standardScore),
+        supportLevel,
+        reliable: scored.runMeta.reliable,
+        engagementFlags: scored.runMeta.engagementFlags,
+        optional: eligibility.isOptional,
+        completed: true,
+      };
+    } else {
+      // No completed run on any variant — evaluate condition across variants
+      const eligibility = evaluateAcrossVariants(row, variants, evaluateEligibility);
+      if (!eligibility.isAssigned) continue; // task not visible to this student
+
+      scores[taskId] = {
+        rawScore: null,
+        percentile: null,
+        standardScore: null,
+        supportLevel: eligibility.isOptional ? 'optional' : null,
+        reliable: null,
+        engagementFlags: [],
+        optional: eligibility.isOptional,
+        completed: false,
+      };
+    }
+  }
+
+  return {
+    user: {
+      userId: row.userId,
+      assessmentPid: row.assessmentPid,
+      username: row.username,
+      email: row.email,
+      firstName: row.nameFirst,
+      lastName: row.nameLast,
+      grade: row.grade,
+      schoolName: scopeType === EntityType.DISTRICT ? (schoolNamesByUser?.get(row.userId) ?? null) : null,
+    },
+    scores,
+  };
+}
+
+/** Pick the first matching field name's value parsed as a number, else null. */
+function pickFirstNumeric(scoreMap: Map<string, string>, fieldNames: string[]): number | null {
+  for (const name of fieldNames) {
+    const v = scoreMap.get(name);
+    if (v !== undefined) {
+      const parsed = parseScoreValue(v);
+      if (parsed !== null) return parsed;
+    }
+  }
+  return null;
+}
+
+/** Pick the first matching field name's raw string value, else null. */
+function pickFirstString(scoreMap: Map<string, string>, fieldNames: string[]): string | null {
+  for (const name of fieldNames) {
+    const v = scoreMap.get(name);
+    if (v !== undefined) return v;
+  }
+  return null;
+}
+
+/**
+ * Evaluate task-variant eligibility across every variant of a task.
+ * A student is "assigned" if any variant assigns them; "optional" only when
+ * every assigning variant marks them optional. Mirrors the score-overview
+ * helper of the same intent.
+ */
+function evaluateAcrossVariants(
+  user: ConditionEvaluationUser,
+  variants: ReportTaskMeta[],
+  evaluateEligibility: StudentEligibilityEvaluator,
+): { isAssigned: boolean; isOptional: boolean } {
+  let anyAssigned = false;
+  let anyRequired = false;
+  for (const v of variants) {
+    const { isAssigned, isOptional } = evaluateEligibility(user, v.conditionsAssignment, v.conditionsRequirements);
+    if (isAssigned) {
+      anyAssigned = true;
+      if (!isOptional) anyRequired = true;
+    }
+  }
+  return { isAssigned: anyAssigned, isOptional: anyAssigned && !anyRequired };
 }

--- a/apps/backend/src/services/report/report.service.ts
+++ b/apps/backend/src/services/report/report.service.ts
@@ -706,7 +706,7 @@ export function ReportService({
       }
 
       // 7. Resolve dynamic sort field (against primary variants)
-      const sortField = resolveDynamicSortField(sortBy, primaryVariantByTaskId, scoringVersionByVariant, taskMetas);
+      const sortField = resolveDynamicSortField(sortBy, primaryVariantByTaskId, scoringVersionByVariant);
 
       // 8. Resolve dynamic score-field filters (against primary variants)
       const userLevelFilters: ParsedFilter[] = [];
@@ -714,7 +714,7 @@ export function ReportService({
       for (const f of filter) {
         if (f.field === 'taskId') continue;
         if (SCORE_TASK_FIELD_PATTERN.test(f.field)) {
-          const filterRef = resolveDynamicFilter(f, primaryVariantByTaskId, scoringVersionByVariant, taskMetas);
+          const filterRef = resolveDynamicFilter(f, primaryVariantByTaskId, scoringVersionByVariant);
           if (filterRef) scoreFieldFilters.push(filterRef);
           continue;
         }
@@ -1430,25 +1430,18 @@ function resolveDynamicSortField(
   sortBy: string,
   primaryVariantByTaskId: Map<string, ReportTaskMeta>,
   scoringVersionByVariant: Map<string, number>,
-  taskMetas: ReportTaskMeta[],
 ): StudentScoresFieldRef | null {
   const parsed = parseScoreFieldString(sortBy);
   if (!parsed) return null;
 
   const variant = primaryVariantByTaskId.get(parsed.taskId);
-  if (!variant) {
-    throw new ApiError('Invalid task ID in sort field', {
-      statusCode: StatusCodes.BAD_REQUEST,
-      code: ApiErrorCode.REQUEST_VALIDATION_FAILED,
-      context: { sortBy, availableTaskIds: taskMetas.map((t) => t.taskId) },
-    });
-  }
 
+  // Guaranteed to exist with validation from validateDynamicFieldTaskIds (line 683)
   return {
-    taskVariantId: variant.taskVariantId,
-    taskSlug: variant.taskSlug,
+    taskVariantId: variant!.taskVariantId,
+    taskSlug: variant!.taskSlug,
     fieldType: parsed.fieldType,
-    scoringVersion: scoringVersionByVariant.get(variant.taskVariantId) ?? null,
+    scoringVersion: scoringVersionByVariant.get(variant!.taskVariantId) ?? null,
   };
 }
 
@@ -1478,19 +1471,11 @@ function resolveDynamicFilter(
   filter: ParsedFilter,
   primaryVariantByTaskId: Map<string, ReportTaskMeta>,
   scoringVersionByVariant: Map<string, number>,
-  taskMetas: ReportTaskMeta[],
 ): StudentScoresFieldFilter | null {
   const parsed = parseScoreFieldString(filter.field);
   if (!parsed) return null;
 
   const variant = primaryVariantByTaskId.get(parsed.taskId);
-  if (!variant) {
-    throw new ApiError('Invalid task ID in filter field', {
-      statusCode: StatusCodes.BAD_REQUEST,
-      code: ApiErrorCode.REQUEST_VALIDATION_FAILED,
-      context: { field: filter.field, availableTaskIds: taskMetas.map((t) => t.taskId) },
-    });
-  }
 
   // Translate values: numeric fields use raw strings (cast in SQL); supportLevel
   // names map to priorities (3/2/1). 'optional' has no SQL representation — drop
@@ -1507,11 +1492,12 @@ function resolveDynamicFilter(
     values = filter.operator === 'in' ? filter.value.split(',').map((v) => v.trim()) : [filter.value];
   }
 
+  // Guaranteed to exist with validation from validateDynamicFieldTaskIds (line 683)
   return {
-    taskVariantId: variant.taskVariantId,
-    taskSlug: variant.taskSlug,
+    taskVariantId: variant!.taskVariantId,
+    taskSlug: variant!.taskSlug,
     fieldType: parsed.fieldType,
-    scoringVersion: scoringVersionByVariant.get(variant.taskVariantId) ?? null,
+    scoringVersion: scoringVersionByVariant.get(variant!.taskVariantId) ?? null,
     operator: filter.operator as StudentScoresFilterOperator,
     values,
   };

--- a/apps/backend/src/services/report/report.service.ts
+++ b/apps/backend/src/services/report/report.service.ts
@@ -719,6 +719,14 @@ export function ReportService({
             })
           : undefined;
 
+      // Short-circuit: when the taskId filter (or an empty administration) leaves
+      // no tasks in scope, no per-task entries can be assembled. Skip the
+      // pagination + score JOINs and return an empty page. Matches the analogous
+      // short-circuit in getScoreOverview.
+      if (taskMetas.length === 0) {
+        return { tasks: [], items: [], totalItems: 0 };
+      }
+
       // 8. Determine the static sort column when sorting by a user field.
       // user.schoolName is handled inside the repository as a correlated subquery,
       // so we pass undefined and rely on the dynamic-sort path falling through to
@@ -753,10 +761,16 @@ export function ReportService({
         schoolNamesByUser = await reportRepository.getSchoolNamesForUsers(result.items.map((s) => s.userId));
       }
 
+      // Group taskMetas by taskId once — the grouping is independent of the
+      // per-student row data, so hoisting it out of the per-row map saves
+      // O(students × variants) reallocations.
+      const { taskOrder, variantsByTaskId } = groupTaskMetasByTaskId(taskMetas);
+
       const items: ServiceStudentScoreRow[] = result.items.map((row) =>
         assembleStudentScoreRow(
           row,
-          taskMetas,
+          taskOrder,
+          variantsByTaskId,
           scoringVersionByVariant,
           taskService.evaluateTaskVariantEligibility,
           scopeType,
@@ -1524,23 +1538,13 @@ type StudentEligibilityEvaluator = (
  */
 function assembleStudentScoreRow(
   row: StudentScoreQueryRow,
-  taskMetas: ReportTaskMeta[],
+  taskOrder: ReadonlyArray<string>,
+  variantsByTaskId: ReadonlyMap<string, ReportTaskMeta[]>,
   scoringVersionByVariant: Map<string, number>,
   evaluateEligibility: StudentEligibilityEvaluator,
   scopeType: ScopeType,
   schoolNamesByUser: Map<string, string> | undefined,
 ): ServiceStudentScoreRow {
-  // Group variants by taskId, preserving orderIndex order
-  const variantsByTaskId = new Map<string, ReportTaskMeta[]>();
-  const taskOrder: string[] = [];
-  for (const meta of taskMetas) {
-    if (!variantsByTaskId.has(meta.taskId)) {
-      variantsByTaskId.set(meta.taskId, []);
-      taskOrder.push(meta.taskId);
-    }
-    variantsByTaskId.get(meta.taskId)!.push(meta);
-  }
-
   const scores: Record<string, ServiceStudentScoreEntry> = {};
 
   for (const taskId of taskOrder) {
@@ -1573,10 +1577,10 @@ function assembleStudentScoreRow(
       // getSupportLevel below for correct cutoff selection.
       const fieldNames = resolveScoreFieldNames(scored.variant.taskSlug, gradeLevel);
 
-      const percentile = pickFirstNumeric(scored.scoreMap, fieldNames.percentileFieldNames);
-      const rawScore = pickFirstNumeric(scored.scoreMap, fieldNames.rawScoreFieldNames);
-      const standardScore = pickFirstNumeric(scored.scoreMap, fieldNames.standardScoreFieldNames);
-      const assessmentSupportLevel = pickFirstString(scored.scoreMap, ['supportLevel', 'support_level']);
+      const percentile = resolveNumericScore(scored.scoreMap, fieldNames.percentileFieldNames);
+      const rawScore = resolveNumericScore(scored.scoreMap, fieldNames.rawScoreFieldNames);
+      const standardScore = resolveNumericScore(scored.scoreMap, fieldNames.standardScoreFieldNames);
+      const assessmentSupportLevel = resolveStringScore(scored.scoreMap, ASSESSMENT_SUPPORT_LEVEL_FIELDS);
 
       const supportLevel = getSupportLevel({
         grade: row.grade,
@@ -1633,25 +1637,26 @@ function assembleStudentScoreRow(
   };
 }
 
-/** Pick the first matching field name's value parsed as a number, else null. */
-function pickFirstNumeric(scoreMap: Map<string, string>, fieldNames: string[]): number | null {
-  for (const name of fieldNames) {
-    const v = scoreMap.get(name);
-    if (v !== undefined) {
-      const parsed = parseScoreValue(v);
-      if (parsed !== null) return parsed;
+/**
+ * Group task metadata by taskId, preserving the orderIndex order of the input.
+ * Returns the ordered taskId list and a map from taskId to its variants. Pure
+ * function — depends only on `taskMetas`, so the result is hoisted out of the
+ * per-student loop in `listStudentScores` to avoid recomputing it for every row.
+ */
+function groupTaskMetasByTaskId(taskMetas: ReportTaskMeta[]): {
+  taskOrder: string[];
+  variantsByTaskId: Map<string, ReportTaskMeta[]>;
+} {
+  const variantsByTaskId = new Map<string, ReportTaskMeta[]>();
+  const taskOrder: string[] = [];
+  for (const meta of taskMetas) {
+    if (!variantsByTaskId.has(meta.taskId)) {
+      variantsByTaskId.set(meta.taskId, []);
+      taskOrder.push(meta.taskId);
     }
+    variantsByTaskId.get(meta.taskId)!.push(meta);
   }
-  return null;
-}
-
-/** Pick the first matching field name's raw string value, else null. */
-function pickFirstString(scoreMap: Map<string, string>, fieldNames: string[]): string | null {
-  for (const name of fieldNames) {
-    const v = scoreMap.get(name);
-    if (v !== undefined) return v;
-  }
-  return null;
+  return { taskOrder, variantsByTaskId };
 }
 
 /**

--- a/apps/backend/src/services/report/report.service.ts
+++ b/apps/backend/src/services/report/report.service.ts
@@ -88,15 +88,20 @@ const SCORE_OVERVIEW_USER_FILTER_FIELDS: Record<string, PgColumn> = {
   'user.grade': users.grade,
 };
 
-/** Map sortBy field strings to Drizzle column references for student scores. */
-const STUDENT_SCORES_SORT_COLUMNS: Record<StudentScoresSortField, Column> = {
+/**
+ * Map sortBy field strings to Drizzle column references for student scores.
+ *
+ * `user.schoolName` is intentionally excluded — it has no direct column to
+ * point at (the value is a correlated subquery built inside the repository).
+ * The service routes that case explicitly before consulting this map, and the
+ * type omits it so any accidental lookup fails at compile time rather than
+ * silently falling back to a wrong column.
+ */
+const STUDENT_SCORES_SORT_COLUMNS: Record<Exclude<StudentScoresSortField, 'user.schoolName'>, Column> = {
   'user.lastName': users.nameLast,
   'user.firstName': users.nameFirst,
   'user.username': users.username,
   'user.grade': users.grade,
-  // user.schoolName uses a SQL subquery built inside the repository — not a column.
-  // The service routes this case via a sentinel name (handled at sort-resolution time).
-  'user.schoolName': users.id, // placeholder; not actually used at runtime for this field
 };
 
 /**
@@ -687,7 +692,7 @@ export function ReportService({
         }
       }
 
-      // 5. Resolve scoring rules per variant for SQL CASE generation in the repo
+      // 6. Resolve scoring rules per variant for SQL CASE generation in the repo
       const scoringRulesByVariant = new Map<string, ResolvedScoringRules>();
       for (const variant of taskMetas) {
         scoringRulesByVariant.set(
@@ -696,10 +701,10 @@ export function ReportService({
         );
       }
 
-      // 6. Resolve dynamic sort field (against primary variants)
+      // 7. Resolve dynamic sort field (against primary variants)
       const sortField = resolveDynamicSortField(sortBy, primaryVariantByTaskId, scoringVersionByVariant, taskMetas);
 
-      // 7. Resolve dynamic score-field filters (against primary variants)
+      // 8. Resolve dynamic score-field filters (against primary variants)
       const userLevelFilters: ParsedFilter[] = [];
       const scoreFieldFilters: StudentScoresFieldFilter[] = [];
       for (const f of filter) {
@@ -727,20 +732,23 @@ export function ReportService({
         return { tasks: [], items: [], totalItems: 0 };
       }
 
-      // 8. Determine the static sort column when sorting by a user field.
+      // 9. Determine the static sort column when sorting by a user field.
       // user.schoolName is handled inside the repository as a correlated subquery,
       // so we pass undefined and rely on the dynamic-sort path falling through to
       // the repo's school-name expression. Other static fields use their column.
+      // The map deliberately omits `user.schoolName` — TypeScript's narrowing on
+      // the explicit equality check below makes the lookup safe.
       let staticSortColumn: Column | undefined;
       if (!sortField) {
         if (sortBy === 'user.schoolName') {
           staticSortColumn = undefined; // repo will use schoolNameSql
         } else {
-          staticSortColumn = STUDENT_SCORES_SORT_COLUMNS[sortBy as StudentScoresSortField] ?? users.nameLast;
+          const key = sortBy as Exclude<StudentScoresSortField, 'user.schoolName'>;
+          staticSortColumn = STUDENT_SCORES_SORT_COLUMNS[key] ?? users.nameLast;
         }
       }
 
-      // 9. Repository call
+      // 10. Repository call
       const result = await reportRepository.getStudentScores(
         administrationId,
         { scopeType, scopeId },
@@ -752,7 +760,7 @@ export function ReportService({
         scoringRulesByVariant,
       );
 
-      // 10. Build response — dedupe per taskId, classify, set optional/completed
+      // 11. Build response — dedupe per taskId, classify, set optional/completed
       const tasksOrdered: ServiceTaskMetadata[] = uniqueTaskMetadataInOrder(taskMetas);
 
       // Resolve schoolNames for district-scope rows (not auto-populated by repo for that field)
@@ -1515,13 +1523,11 @@ function roundScoreOrNull(value: number | null): number | null {
 }
 
 /**
- * Type for the evaluateTaskVariantEligibility function from TaskService.
+ * Alias of `EligibilityEvaluator` for use in the student-scores helpers.
+ * Kept as a re-export so the consuming code reads naturally; both names refer
+ * to the same `TaskService.evaluateTaskVariantEligibility` shape.
  */
-type StudentEligibilityEvaluator = (
-  user: ConditionEvaluationUser,
-  conditionsAssignment: Condition | null,
-  conditionsRequirements: Condition | null,
-) => { isAssigned: boolean; isOptional: boolean };
+type StudentEligibilityEvaluator = EligibilityEvaluator;
 
 /**
  * Convert a single repository row into a service-shaped student row with one

--- a/apps/backend/src/services/report/report.service.ts
+++ b/apps/backend/src/services/report/report.service.ts
@@ -629,7 +629,7 @@ export function ReportService({
    * List paginated per-student scores for an administration.
    *
    * Authorization (two FGA checks):
-   * 1. `verifyAdministrationScoreReadAccess` — administration-level can_read_scores
+   * 1. `verifyAdministrationAccess` — administration-level can_read_scores
    * 2. `authorizeScopeAccess` with CAN_READ_SCORES — scope-level
    *
    * Sort and filter accept dynamic `scores.<taskId>.<field>` fields where
@@ -659,7 +659,11 @@ export function ReportService({
 
     try {
       // 1. Authorization
-      await verifyAdministrationScoreReadAccess(authContext, administrationId);
+      await administrationService.verifyAdministrationAccess(
+        authContext,
+        administrationId,
+        FgaRelation.CAN_READ_SCORES,
+      );
       await authorizeScopeAccess(authContext, administrationId, scopeType, scopeId, FgaRelation.CAN_READ_SCORES);
 
       // 2. Get task metadata and apply taskId filter (merge multiple entries)

--- a/apps/backend/src/services/report/report.service.ts
+++ b/apps/backend/src/services/report/report.service.ts
@@ -668,7 +668,12 @@ export function ReportService({
       // 3. Build per-task primary variant map (lowest-orderIndex variant of each task)
       const primaryVariantByTaskId = buildPrimaryVariantMap(taskMetas);
 
-      // 4. Resolve scoring versions per variant
+      // 4. Validate any dynamic score-field references in sort/filter BEFORE
+      // any further DB call — bad task IDs should fail fast as 400, not get
+      // silently swallowed into a 500 by a downstream failure.
+      validateDynamicFieldTaskIds(sortBy, filter, primaryVariantByTaskId, taskMetas);
+
+      // 5. Resolve scoring versions per variant
       const taskVariantIds = taskMetas.map((t) => t.taskVariantId);
       const allParams =
         taskVariantIds.length > 0 ? await taskVariantParameterRepository.getByTaskVariantIds(taskVariantIds) : [];
@@ -1353,6 +1358,43 @@ function parseScoreFieldString(field: string): { taskId: string; fieldType: Stud
 }
 
 /**
+ * Validate that every dynamic `scores.<taskId>.<field>` reference in `sortBy`
+ * and `filter` resolves to a known taskId. Throws 400 on any unknown taskId.
+ *
+ * Called before fetching scoring versions so input-validation errors fail fast
+ * as 400 rather than getting wrapped as 500 by an unrelated downstream failure.
+ */
+function validateDynamicFieldTaskIds(
+  sortBy: string,
+  filter: ParsedFilter[],
+  primaryVariantByTaskId: Map<string, ReportTaskMeta>,
+  taskMetas: ReportTaskMeta[],
+): void {
+  const knownIds = () => taskMetas.map((t) => t.taskId);
+
+  const sortParsed = parseScoreFieldString(sortBy);
+  if (sortParsed && !primaryVariantByTaskId.has(sortParsed.taskId)) {
+    throw new ApiError('Invalid task ID in sort field', {
+      statusCode: StatusCodes.BAD_REQUEST,
+      code: ApiErrorCode.REQUEST_VALIDATION_FAILED,
+      context: { sortBy, availableTaskIds: knownIds() },
+    });
+  }
+
+  for (const f of filter) {
+    if (f.field === 'taskId') continue;
+    const parsed = parseScoreFieldString(f.field);
+    if (parsed && !primaryVariantByTaskId.has(parsed.taskId)) {
+      throw new ApiError('Invalid task ID in filter field', {
+        statusCode: StatusCodes.BAD_REQUEST,
+        code: ApiErrorCode.REQUEST_VALIDATION_FAILED,
+        context: { field: f.field, availableTaskIds: knownIds() },
+      });
+    }
+  }
+}
+
+/**
  * Resolve a dynamic sort string into a `StudentScoresFieldRef` against the
  * primary variant of the referenced task. Returns null for static sort fields
  * (the caller falls back to the static-column path) and throws 400 for
@@ -1526,7 +1568,10 @@ function assembleStudentScoreRow(
     if (scored) {
       const scoringVersion = scoringVersionByVariant.get(scored.variant.taskVariantId) ?? null;
       const gradeLevel = getGradeAsNumber(row.grade);
-      const fieldNames = resolveScoreFieldNames(scored.variant.taskSlug, gradeLevel, scoringVersion);
+      // Match score-overview's resolution strategy: omit scoringVersion so all-version
+      // field names are returned. This is best-effort — the version is still passed to
+      // getSupportLevel below for correct cutoff selection.
+      const fieldNames = resolveScoreFieldNames(scored.variant.taskSlug, gradeLevel);
 
       const percentile = pickFirstNumeric(scored.scoreMap, fieldNames.percentileFieldNames);
       const rawScore = pickFirstNumeric(scored.scoreMap, fieldNames.rawScoreFieldNames);

--- a/apps/backend/src/services/report/report.types.ts
+++ b/apps/backend/src/services/report/report.types.ts
@@ -162,3 +162,70 @@ export interface ScoreOverviewResult {
   /** ISO 8601 timestamp when the aggregation was computed */
   computedAt: string;
 }
+
+/** Query input for listStudentScores. */
+export interface StudentScoresInput {
+  scopeType: ScopeType;
+  scopeId: string;
+  page: number;
+  perPage: number;
+  sortBy: string;
+  sortOrder: 'asc' | 'desc';
+  filter: ParsedFilter[];
+}
+
+/** Static sort fields for student scores. */
+export type StudentScoresSortField =
+  | 'user.lastName'
+  | 'user.firstName'
+  | 'user.username'
+  | 'user.grade'
+  | 'user.schoolName';
+
+/** Static filter fields for student scores (excludes `taskId` which is handled separately). */
+export type StudentScoresFilterField =
+  | 'user.grade'
+  | 'user.firstName'
+  | 'user.lastName'
+  | 'user.username'
+  | 'user.email'
+  | 'user.schoolName';
+
+/**
+ * Support-level value as returned in per-task score entries.
+ *
+ * `optional` appears only when the student has no completed run AND the task is
+ * optional for them per condition evaluation. Students with completed runs are
+ * categorized into their actual support level regardless of optional status.
+ *
+ * `null` is returned when classification is not possible (no score data,
+ * unknown task, or thresholds unavailable for the resolved scoring version).
+ */
+export type ServiceSupportLevelValue = 'achievedSkill' | 'developingSkill' | 'needsExtraSupport' | 'optional';
+
+/** Per-task score entry on a student row. */
+export interface ServiceStudentScoreEntry {
+  rawScore: number | null;
+  percentile: number | null;
+  standardScore: number | null;
+  supportLevel: ServiceSupportLevelValue | null;
+  reliable: boolean | null;
+  engagementFlags: string[];
+  /** Whether this task is optional for the student per condition evaluation. */
+  optional: boolean;
+  /** Whether the student has at least one completed run for this task. */
+  completed: boolean;
+}
+
+/** A student row in score results. */
+export interface ServiceStudentScoreRow {
+  user: ServiceUserInfo;
+  scores: Record<string, ServiceStudentScoreEntry>;
+}
+
+/** Return type for listStudentScores. */
+export interface StudentScoresResult {
+  tasks: ServiceTaskMetadata[];
+  items: ServiceStudentScoreRow[];
+  totalItems: number;
+}

--- a/apps/backend/src/test-support/repositories/report.repository.ts
+++ b/apps/backend/src/test-support/repositories/report.repository.ts
@@ -18,6 +18,7 @@ export function createMockReportRepository(): MockedObject<ReportRepository> {
     getProgressOverviewCountsBulk: vi.fn(),
     getAllStudentsInScope: vi.fn(),
     getCompletedRunScores: vi.fn(),
+    getSchoolNamesForUsers: vi.fn(),
   } as unknown as MockedObject<ReportRepository>;
 }
 

--- a/apps/backend/src/test-support/repositories/report.repository.ts
+++ b/apps/backend/src/test-support/repositories/report.repository.ts
@@ -19,6 +19,7 @@ export function createMockReportRepository(): MockedObject<ReportRepository> {
     getAllStudentsInScope: vi.fn(),
     getCompletedRunScores: vi.fn(),
     getSchoolNamesForUsers: vi.fn(),
+    getStudentScores: vi.fn(),
   } as unknown as MockedObject<ReportRepository>;
 }
 

--- a/packages/api-contract/src/v1/administrations/reports/scores/contract.ts
+++ b/packages/api-contract/src/v1/administrations/reports/scores/contract.ts
@@ -66,6 +66,14 @@ export const ScoreReportsContract = c.router({
       'static user fields. Task IDs in dynamic fields are validated against the administration ' +
       'and return 400 if unknown. Sorting by support level uses a per-variant SQL CASE ' +
       "expression built from the scoring config's resolved cutoffs.\n\n" +
+      'Filter behavior notes:\n' +
+      '- `supportLevel:eq:optional` and `supportLevel:in:...,optional,...` are silently dropped ' +
+      'from SQL filtering — `optional` is not a classifiable support level, it depends on ' +
+      'per-student condition evaluation rather than score values, and has no SQL representation. ' +
+      'The request still returns 200 with the unfiltered (or only-the-other-values-filtered) page; ' +
+      'no warning is surfaced. Treat `optional` as a post-fetch client-side filter.\n' +
+      '- Multiple `taskId:in:<uuid>` filter entries are merged into a single allow-list ' +
+      '(unioned). Other filter fields combine via AND across entries.\n\n' +
       'Status codes:\n' +
       '- 200: Paginated student score rows returned\n' +
       '- 400: Invalid scope, unknown task ID in sort/filter, or invalid filter\n' +

--- a/packages/api-contract/src/v1/administrations/reports/scores/contract.ts
+++ b/packages/api-contract/src/v1/administrations/reports/scores/contract.ts
@@ -1,6 +1,11 @@
 import { initContract } from '@ts-rest/core';
 import { z } from 'zod';
-import { ScoreOverviewQuerySchema, ScoreOverviewResponseSchema } from './schema';
+import {
+  ScoreOverviewQuerySchema,
+  ScoreOverviewResponseSchema,
+  StudentScoresQuerySchema,
+  StudentScoresResponseSchema,
+} from './schema';
 import { ErrorEnvelopeSchema, SuccessEnvelopeSchema } from '../../../response';
 
 const c = initContract();
@@ -32,6 +37,38 @@ export const ScoreReportsContract = c.router({
       'Status codes:\n' +
       '- 200: Aggregated statistics returned successfully\n' +
       '- 400: Invalid scope (scopeId not assigned to this administration)\n' +
+      '- 401: Missing or invalid authentication token\n' +
+      '- 403: User lacks can_read_scores at the requested administration or scope level\n' +
+      '- 404: Administration not found\n' +
+      '- 500: Internal server error',
+  },
+  listStudents: {
+    method: 'GET',
+    path: '/:id/reports/scores/students',
+    pathParams: z.object({ id: z.string().uuid() }),
+    query: StudentScoresQuerySchema,
+    responses: {
+      200: SuccessEnvelopeSchema(StudentScoresResponseSchema),
+      400: ErrorEnvelopeSchema,
+      401: ErrorEnvelopeSchema,
+      403: ErrorEnvelopeSchema,
+      404: ErrorEnvelopeSchema,
+      500: ErrorEnvelopeSchema,
+    },
+    strictStatusCodes: true,
+    summary: 'List per-student scores for an administration',
+    description:
+      'Returns paginated per-student score data for an administration, scoped to a ' +
+      'specific org, class, or group via scopeType/scopeId. ' +
+      'Each row includes per-task scores (rawScore, percentile, standardScore, supportLevel) ' +
+      'plus reliability and engagement flags.\n\n' +
+      'Sorting and filtering accept dynamic `scores.<taskId>.<field>` fields in addition to ' +
+      'static user fields. Task IDs in dynamic fields are validated against the administration ' +
+      'and return 400 if unknown. Sorting by support level uses a per-variant SQL CASE ' +
+      "expression built from the scoring config's resolved cutoffs.\n\n" +
+      'Status codes:\n' +
+      '- 200: Paginated student score rows returned\n' +
+      '- 400: Invalid scope, unknown task ID in sort/filter, or invalid filter\n' +
       '- 401: Missing or invalid authentication token\n' +
       '- 403: User lacks can_read_scores at the requested administration or scope level\n' +
       '- 404: Administration not found\n' +

--- a/packages/api-contract/src/v1/administrations/reports/scores/schema.ts
+++ b/packages/api-contract/src/v1/administrations/reports/scores/schema.ts
@@ -1,5 +1,11 @@
 import { z } from 'zod';
-import { ReportScopeQuerySchema, createFilterQuerySchema, ReportTaskMetadataSchema } from '../common';
+import { PaginationQuerySchema, PaginationMetaSchema, createDynamicSortQuerySchema } from '../../../common/query';
+import {
+  ReportScopeQuerySchema,
+  createFilterQuerySchema,
+  ReportTaskMetadataSchema,
+  ReportUserInfoSchema,
+} from '../common';
 
 /**
  * Filter fields for the score overview endpoint.
@@ -65,3 +71,159 @@ export const ScoreOverviewResponseSchema = z.object({
 });
 
 export type ScoreOverviewResponse = z.infer<typeof ScoreOverviewResponseSchema>;
+
+// --- Student Scores schemas ---
+
+/**
+ * Per-task score field types that may appear in dynamic sort/filter strings,
+ * formatted as `scores.<taskId>.<field>`.
+ *
+ * - `rawScore` — domain-specific raw score value
+ * - `percentile` — percentile ranking
+ * - `standardScore` — normed standard score
+ * - `supportLevel` — derived classification (achievedSkill, developingSkill,
+ *   needsExtraSupport, optional, null). Sortable via per-variant SQL CASE
+ *   constructed from the scoring config's resolved cutoffs.
+ */
+export const SCORE_FIELD_TYPES = ['rawScore', 'percentile', 'standardScore', 'supportLevel'] as const;
+export type ScoreFieldType = (typeof SCORE_FIELD_TYPES)[number];
+
+/**
+ * Regex pattern matching `scores.<uuid>.<field>` for dynamic sort/filter.
+ * The UUID is validated against the administration's actual task IDs in the
+ * service layer; the field is one of `SCORE_FIELD_TYPES`.
+ */
+export const SCORE_TASK_FIELD_PATTERN =
+  /^scores\.[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\.(rawScore|percentile|standardScore|supportLevel)$/;
+
+/**
+ * Static sort fields for the student scores endpoint.
+ *
+ * Also accepts dynamic `scores.<taskId>.<field>` fields via pattern matching.
+ * The taskId UUID is validated against the administration's actual tasks in the
+ * service layer — unknown task IDs return 400.
+ *
+ * `user.schoolName` is sortable here (unlike progress) because the column is
+ * resolved via a LEFT JOIN against the org/class hierarchy that supports
+ * SQL-level ordering.
+ */
+export const STUDENT_SCORES_SORT_FIELDS = [
+  'user.lastName',
+  'user.firstName',
+  'user.username',
+  'user.grade',
+  'user.schoolName',
+] as const;
+
+export type StudentScoresSortField = (typeof STUDENT_SCORES_SORT_FIELDS)[number];
+
+/**
+ * Static filter fields for the student scores endpoint.
+ *
+ * Also accepts dynamic `scores.<taskId>.<field>` fields via pattern matching.
+ * `user.schoolName` filtering uses ILIKE for partial matches and is only
+ * meaningful at district scope.
+ */
+export const STUDENT_SCORES_FILTER_FIELDS = [
+  'taskId',
+  'user.grade',
+  'user.firstName',
+  'user.lastName',
+  'user.username',
+  'user.email',
+  'user.schoolName',
+] as const;
+
+export type StudentScoresFilterField = (typeof STUDENT_SCORES_FILTER_FIELDS)[number];
+
+/**
+ * Query schema for the student scores endpoint.
+ * Combines pagination, scope, filter, and sort parameters with dynamic score-field support.
+ */
+export const StudentScoresQuerySchema = PaginationQuerySchema.merge(ReportScopeQuerySchema)
+  .merge(
+    createFilterQuerySchema(STUDENT_SCORES_FILTER_FIELDS, {
+      dynamicFieldPatterns: [SCORE_TASK_FIELD_PATTERN],
+      dynamicFieldHint: 'scores.<taskId>.<rawScore|percentile|standardScore|supportLevel>',
+    }),
+  )
+  .merge(
+    createDynamicSortQuerySchema(
+      STUDENT_SCORES_SORT_FIELDS,
+      'user.lastName',
+      'asc',
+      [SCORE_TASK_FIELD_PATTERN],
+      'scores.<taskId>.<rawScore|percentile|standardScore|supportLevel>',
+    ),
+  );
+
+export type StudentScoresQuery = z.infer<typeof StudentScoresQuerySchema>;
+
+/**
+ * Support level classification values returned in per-task score entries.
+ *
+ * Names match the scoring service's `SupportLevel` type for consistency.
+ * `optional` appears only when the student has no completed run AND the task
+ * is optional for them per condition evaluation. Students with completed runs
+ * are categorized into their actual support level (achievedSkill, developingSkill,
+ * or needsExtraSupport) regardless of whether the task was optional.
+ *
+ * `null` is returned when classification is not possible (no score data, unknown
+ * task, or thresholds unavailable).
+ */
+export const SupportLevelValueSchema = z.enum(['achievedSkill', 'developingSkill', 'needsExtraSupport', 'optional']);
+
+export type SupportLevelValue = z.infer<typeof SupportLevelValueSchema>;
+
+/**
+ * Per-task score entry on a student row.
+ *
+ * - `completed: true` → student has a completed run; score fields populated where available
+ * - `completed: false` → student has no completed run; score fields are null and
+ *   `supportLevel` is either `'optional'` (task optional for this student) or `null` (assigned-required)
+ *
+ * `reliable` and `engagementFlags` are populated from the underlying run regardless
+ * of completion. They are null/empty when no run exists.
+ */
+export const StudentScoreEntrySchema = z.object({
+  rawScore: z.number().int().nullable(),
+  percentile: z.number().int().nullable(),
+  standardScore: z.number().int().nullable(),
+  supportLevel: SupportLevelValueSchema.nullable(),
+  reliable: z.boolean().nullable(),
+  engagementFlags: z.array(z.string()),
+  /**
+   * Whether this task is optional for the student per condition evaluation.
+   * Independent of completion status — an optional task can still be completed.
+   */
+  optional: z.boolean(),
+  /** Whether the student has at least one completed run for this task. */
+  completed: z.boolean(),
+});
+
+export type StudentScoreEntry = z.infer<typeof StudentScoreEntrySchema>;
+
+/**
+ * A student row in the score report, keyed by taskId.
+ *
+ * Tasks where `conditionsAssignment` evaluates to false for the student are excluded
+ * from the `scores` map entirely — the task is not visible to that student.
+ */
+export const StudentScoreRowSchema = z.object({
+  user: ReportUserInfoSchema,
+  scores: z.record(z.string().uuid(), StudentScoreEntrySchema),
+});
+
+export type StudentScoreRow = z.infer<typeof StudentScoreRowSchema>;
+
+/**
+ * Response schema for the student scores endpoint.
+ * Includes task metadata for column rendering and paginated student rows.
+ */
+export const StudentScoresResponseSchema = z.object({
+  tasks: z.array(ReportTaskMetadataSchema),
+  items: z.array(StudentScoreRowSchema),
+  pagination: PaginationMetaSchema,
+});
+
+export type StudentScoresResponse = z.infer<typeof StudentScoresResponseSchema>;


### PR DESCRIPTION
## Summary

This PR adds a new `GET /v1/administrations/:id/reports/scores/students` endpoint that returns paginated per-student score rows with per-task `rawScore`, `percentile`, `standardScore`, and `supportLevel` fields, plus run-level `reliable` and `engagementFlags`. It powers the main student data table on the score report page and replaces ~1400 lines of client-side scoring logic with a single server-side endpoint that runs sort/filter/classification in SQL.

This branch is **chained off `enh/1682/score-overview`** (#1714). It reuses the FGA authorization helpers (`verifyAdministrationScoreReadAccess`, `authorizeScopeAccess(...CAN_READ_SCORES)`), score classification utilities (`getSupportLevel`, `parseScoreValue`, `resolveScoreFieldNames`), and shared helpers (`groupVariantsByTaskId`, `evaluateAcrossVariants`-shape logic) introduced there.

## Endpoint

- **Method:** `GET`
- **Path:** `/v1/administrations/:id/reports/scores/students`
- **Required query params:** `scopeType` (`district` | `school` | `class` | `group`), `scopeId` (UUID)
- **Optional query params:** `page`, `perPage`, `sortBy`, `sortOrder`, `filter` (repeatable)

### Sort fields

Static: `user.lastName`, `user.firstName`, `user.username`, `user.grade`, `user.schoolName` (district scope only).

Dynamic: `scores.<taskId>.<rawScore | percentile | standardScore | supportLevel>` — task IDs are validated against the administration's tasks (returns 400 if unknown). Sort uses the lowest-`orderIndex` variant of the task (the "primary variant") so pagination ordering stays deterministic across pages.

### Filter syntax

Static: `taskId:in:<uuid,uuid>` (narrows the task set; multiple entries merge into a single allow-list), `user.grade:eq|in`, `user.schoolName:eq|contains`, `user.firstName|lastName|username|email:eq|contains`.

Dynamic: `scores.<taskId>.rawScore:gte|lte`, `scores.<taskId>.percentile:gte|lte|eq`, `scores.<taskId>.standardScore:gte|lte`, `scores.<taskId>.supportLevel:eq|in:achievedSkill,developingSkill,needsExtraSupport`. The `optional` support-level value has no SQL representation (it depends on per-student condition evaluation, not score values) and is silently dropped from filter values — documented in the contract description.

### Response shape

```typescript
{
  tasks: ReportTaskMetadata[],     // one entry per unique taskId, for column rendering
  items: Array<{
    user: ReportUserInfo,           // schoolName populated only at district scope
    scores: Record<taskId, {
      rawScore: number | null,
      percentile: number | null,
      standardScore: number | null,
      supportLevel: 'achievedSkill' | 'developingSkill' | 'needsExtraSupport' | 'optional' | null,
      reliable: boolean | null,     // null when no completed run
      engagementFlags: string[],
      optional: boolean,            // task is optional for this student per condition evaluation
      completed: boolean,           // true if any variant has a completed run with scores
    }>,
  }>,
  pagination: { page, perPage, totalItems, totalPages },
}
```

## Authorization

Two FGA checks, in order — same shape as score overview:

1. **Administration-level:** `can_read_scores` on `administration:<id>`
2. **Scope-level:** `can_read_scores` on `<scopeType>:<scopeId>`

Both use `supervisory_tier_group` in the FGA model — admin-tier and educator-tier roles only; students and caregivers get 403. Super admins bypass both. 404-before-403 ordering: missing administration returns 404 before any FGA check fires.

```mermaid
sequenceDiagram
    autonumber
    participant Client
    participant Route as Route (administrations.ts)
    participant Ctrl as Controller
    participant Svc as ReportService
    participant Repo as ReportRepository
    participant FGA as AuthorizationService

    Client->>Route: GET /administrations/:id/reports/scores/students?scopeType&scopeId&...
    Route->>Ctrl: listStudentScores(authContext, id, query)
    Ctrl->>Svc: listStudentScores(authContext, id, query)
    Svc->>Repo: getById(id)
    alt Not found
        Repo-->>Svc: null
        Svc-->>Ctrl: ApiError 404
    else Found
        Svc->>FGA: requirePermission(can_read_scores, administration:id)
        Svc->>Repo: isScopeAssignedToAdministration(id, scope)
        Svc->>FGA: requirePermission(can_read_scores, scopeType:scopeId)
        Svc->>Repo: getTaskMetadata(id)
        Note over Svc: Apply taskId filter — multi-entry merge
        Note over Svc: Validate dynamic sort/filter taskIds — 400 if unknown
        Svc->>Repo: getByTaskVariantIds — scoring versions
        Note over Svc: Resolve per-variant scoring rules — cutoffs and thresholds
        Svc->>Repo: getStudentScores — paginated with dynamic LEFT JOINs
        Svc->>Repo: getSchoolNamesForUsers — district scope only
        Note over Svc: Per-row dedup and classification
        Svc-->>Ctrl: StudentScoresResult
        Ctrl-->>Client: 200 { data: { tasks, items, pagination } }
    end
```

## Multi-variant deduplication

Administrations may assign multiple variants of the same task (e.g., grade-specific variants). The endpoint emits **at most one entry per `taskId`** in each student's `scores` map:

- **Sort/filter (SQL-level):** the primary variant (lowest `orderIndex` for the task) is used. This keeps SQL ordering deterministic across pages.
- **Per-row score selection (service-level):** the first variant (in `orderIndex` order) with a completed run AND non-empty score rows wins. Other variants are ignored for that task on that row.
- **Eligibility evaluation:** for students with no completed run on any variant, eligibility is evaluated across all variants — `optional` only when every assigning variant marks the student optional.

## SQL CASE for support-level sort and filter

`supportLevel` isn't a stored column. It's derived from per-task scoring config (percentile cutoffs vs. raw-score thresholds, version-aware) plus per-student grade. Doing it in JS would force in-memory sort and break pagination invariants.

The repository emits a per-variant `CASE` expression at query-build time, with the cutoffs/thresholds hardcoded as numeric literals from the resolved `ResolvedScoringRules` (the service builds those from the scoring config in JS). The CASE returns a priority integer (`3`=achievedSkill, `2`=developingSkill, `1`=needsExtraSupport, `NULL`=unclassified) that ORDER BY can use directly. For assessment-computed tasks (`roam-alpaca`), the CASE reads the `supportLevel` text value directly from `run_scores` and maps it to priority.

The ticket explicitly endorses this approach: _"Sorting on `supportLevel` maps to a CASE expression or computed column."_ A computed column would require a schema change; the CASE keeps it self-contained.

Helper utilities for the SQL emission live in `report.repository.ts`:

- `gradeAsIntSql` — coerces text grade to numeric (`'Kindergarten' → NULL`, `'3' → 3`)
- `numericValueSql` — strips angle brackets (`>99 → 99`) and casts text to numeric
- `buildSupportLevelPrioritySql` — emits the per-variant CASE
- `buildScoreFieldFilterCondition` — translates `eq | neq | gte | lte | in` into SQL WHERE conditions

## Files changed

- `packages/api-contract/src/v1/administrations/reports/scores/{schema,contract}.ts` — added `StudentScoresQuerySchema` (composed from `PaginationQuerySchema`, `ReportScopeQuerySchema`, `createDynamicSortQuerySchema`, `createFilterQuerySchema`), `StudentScoreEntrySchema`, `StudentScoreRowSchema`, `StudentScoresResponseSchema`, plus the `listStudents` contract endpoint nested under `ScoreReportsContract`.
- `apps/backend/src/repositories/report.repository.ts` — added `StudentScoresFieldType`, `StudentScoresFieldRef`, `StudentScoresFilterOperator`, `StudentScoresFieldFilter`, `ResolvedScoringRules`, `StudentScoreQueryRow` types. Made `getSchoolNamesForUsers` public for reuse. Added `getStudentScores` paginated query with dynamic LEFT JOINs per (variant, fieldType) used in sort/filter, plus `gradeAsIntSql` / `numericValueSql` / `buildSupportLevelPrioritySql` / `buildScoreFieldFilterCondition` SQL emitters.
- `apps/backend/src/services/report/report.service.ts` — added `listStudentScores` with FGA auth, taskId/dynamic-field validation, scoring-rule resolution, and per-row dedup + classification. Added helpers `validateDynamicFieldTaskIds`, `resolveDynamicSortField`, `resolveDynamicFilter`, `resolveScoringRulesForVariant`, `groupTaskMetasByTaskId`, `assembleStudentScoreRow`. Reuses the score-overview's `resolveNumericScore`, `resolveStringScore`, and `ASSESSMENT_SUPPORT_LEVEL_FIELDS`.
- `apps/backend/src/services/report/report.types.ts` — added `StudentScoresInput`, `StudentScoresSortField`, `StudentScoresFilterField`, `ServiceSupportLevelValue`, `ServiceStudentScoreEntry`, `ServiceStudentScoreRow`, `StudentScoresResult`.
- `apps/backend/src/controllers/administrations.controller.ts` — added `listStudentScores` controller method. Returns the service result directly via TS structural typing (same pattern as `getScoreOverview`).
- `apps/backend/src/routes/administrations.ts` — wired `scoreReports.listStudents` inside `AdministrationsContract`.
- `apps/backend/src/test-support/repositories/report.repository.ts` — added `getStudentScores` mock entry.

## Test coverage

### Service unit tests (`report.service.test.ts`)

Authorization (5): 404 when admin missing; 403 at administration scope; 400 on unassigned scope; 403 at scope-level; super-admin bypass.

Pagination + response: paginated rows + `totalItems` + tasks metadata.

Dynamic sort: 400 on unknown taskId; primary-variant ref passed to repo for `scores.<taskId>.percentile`.

Filtering: multiple `taskId` entries merged; **empty-task short-circuit returns `{ tasks: [], items: [], totalItems: 0 }` without touching `getStudentScores` or `getSchoolNamesForUsers`**; `supportLevel:eq:achievedSkill` translated to priority `3`; `supportLevel:in:achievedSkill,developingSkill` to `[3, 2]`; `supportLevel:eq:optional` silently dropped (no SQL representation); numeric range filter values forwarded; 400 on unknown taskId in filter.

Per-row assembly: classification path (percentile=90, grade=3, swr → `achievedSkill`); `optional` for unassigned/unrun-but-optional task; `null` for assigned-required no-run; excluded students omitted from scores map; integer rounding; multi-variant dedup (variant-A wins); assessment-computed (`roam-alpaca`) reads `supportLevel` from scores.

Other: `schoolName` populated for district scope only; 500 wrap on repo failure; ApiError re-throw without wrapping.

### Controller unit tests (`administrations.controller.test.ts`)

Success path with full data round-trip; ApiError → typed error response mapping for 400, 403, 404, 500; non-ApiError re-throw; argument forwarding to the service; pagination math (`totalPages = ceil(totalItems / perPage)`).

### Route integration tests (`reports.integration.test.ts`)

Authorization (10): 401, super admin, district admin, site admin, district teacher 403, school principal at school, school principal at district 403, student 403, caregiver 403, cross-district admin 403, class teacher requesting school scope 403.

Scope validation (5): 400 unassigned scope; 400 missing `scopeType`/`scopeId`; 404 unknown admin; 400 on unknown taskId in `sortBy`.

Response shape: structural assertions (tasks, items, pagination); `schoolName` populated at district scope, null at non-district; `taskId` filter narrows tasks list and per-row score keys; `user.grade` filter narrows population; default sort by `user.lastName` produces locale-sorted output.

FDW-backed: real run + run_score for `grade5Student` produces `completed: true` with run-level metadata round-tripping (`reliable: boolean`, `engagementFlags: string[]`); other district students return `completed: false` with null score fields.

## Known follow-ups

- **End-to-end support-level bucket assertion at the integration level.** The fixture's task uses an auto-generated slug not registered in the scoring config, so `resolveScoreFieldNames` returns empty arrays and per-task numeric fields stay null end-to-end. Classification correctness is fully covered by service unit tests against known slugs (`swr` for percentile-then-rawscore, `roam-alpaca` for assessment-computed). To verify a specific support-level bucket end-to-end we'd need to provision a fresh task with a known slug — would clean up several integration assertions but conflicts with the score-overview tests' exact-task-set assertion. Worth a follow-up after the chained PRs merge.
- **`schoolName` is fetched twice at district scope.** The repository SELECTs `schoolName` via a correlated subquery for SQL-level sort/filter ordering, and the service then calls `getSchoolNamesForUsers` separately for the response payload (which uses a richer `user_orgs → user_classes` two-phase fallback). The duplication is intentional today — the SQL subquery only checks `user_orgs`, while `getSchoolNamesForUsers` falls back to class enrollment. Consolidating would mean either widening the SQL subquery or losing fallback accuracy. Acceptable for now.
- **Coverage of `isScopeAssignedToAdministration` secondary branches.** The bot called this out on the score-overview PR and it applies here too. The integration tests exercise district/school/class/group scopes at the HTTP boundary, but `isScopeAssignedToAdministration`'s secondary fallback branches (`administrationClasses` lookups within the district and school cases) aren't directly hit. Acceptable for now.

## PR size

This PR is **larger than the team's 500-line target** (~2600 line insertions across 9 files). The size was an explicit decision after sizing the SQL helpers — splitting into "paginated table" + "dynamic sort/filter" phases would have produced a useful first PR but delayed the frontend's sort-by-score-field needs. If reviewers prefer to split, the natural seam is between commit 3 (repository SQL helpers + base query) and commit 4 (service-layer dynamic sort/filter resolution).

## Validation

```bash
npm run check-types
npm run format:check
npm run test:unit -w apps/backend
npm run test:integration -w apps/backend  # requires a running Postgres
```

Resolves [1683](https://github.com/yeatmanlab/roar-project-management/issues/1683)

## Types of changes

What types of changes does this pull request introduce?

<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (non-breaking change that does not add functionality but makes code cleaner or more efficient)
- [x] Documentation Update
- [x] Tests (new or updated tests)
- [ ] Style (changes to code styling)
- [ ] CI (continuous integration changes)
- [ ] Repository Maintenance
- [ ] Other (please describe below)

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask.  We're here
to help! This is simply a reminder of what we are going to look for before
merging your code.
-->

- [x] I have read the [guidelines for contributing](https://github.com/yeatmanlab/roar-dashboard/blob/main/.github/CONTRIBUTING.md).
- [x] The changes in this PR are as small as they can be. They represent one and only one fix or enhancement.
- [x] Linting checks pass with my changes.
- [x] Any existing unit tests pass with my changes.
- [x] Any existing end-to-end tests pass with my changes.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] If this PR fixes an existing issue, I have added a unit or end-to-end test that will detect if this issue reoccurs.
- [x] I have added JSDoc comments as appropriate.
- [ ] I have added the necessary documentation to the [roar-docs repository](https://github.com/yeatmanlab/roar-docs).
- [x] I have shared this PR on the roar-pr-reviews channel (if I have access)
- [x] I have linked relevant issues (if any)