### PR TITLE
Add  `GET /v1/users/:userId/administrations`

### DIFF
--- a/apps/backend/src/controllers/administrations.controller.test.ts
+++ b/apps/backend/src/controllers/administrations.controller.test.ts
@@ -43,6 +43,7 @@ describe('AdministrationsController', () => {
   const mockDeleteById = vi.fn();
   const mockListProgressStudents = vi.fn();
   const mockGetProgressOverview = vi.fn();
+  const mockGetUserAdministrations = vi.fn();
   const mockAuthContext = { userId: 'user-123', isSuperAdmin: false };
 
   beforeEach(() => {
@@ -57,6 +58,7 @@ describe('AdministrationsController', () => {
       listTaskVariants: mockListTaskVariants,
       listAgreements: mockListAgreements,
       deleteById: mockDeleteById,
+      getUserAdministrations: mockGetUserAdministrations,
     });
 
     vi.mocked(ReportService).mockReturnValue({

--- a/apps/backend/src/controllers/administrations.controller.ts
+++ b/apps/backend/src/controllers/administrations.controller.ts
@@ -1,15 +1,10 @@
 import { StatusCodes } from 'http-status-codes';
-import {
-  AdministrationService,
-  type AdministrationWithEmbeds,
-} from '../services/administration/administration.service';
+import { AdministrationService } from '../services/administration/administration.service';
 import { ReportService } from '../services/report/report.service';
 import type {
   AdministrationsListQuery,
   AdministrationTaskVariantsListQuery,
   AdministrationAgreementsListQuery,
-  Administration as ContractAdministration,
-  AdministrationBase as ContractAdministrationBase,
   AdministrationTaskVariantItem,
   Condition,
   AdministrationAgreement,
@@ -18,7 +13,6 @@ import type {
   ReportTaskMetadata,
   ProgressStudent,
 } from '@roar-dashboard/api-contract';
-import type { Administration } from '../db/schema';
 import type {
   TaskVariantWithAssignment,
   AssignmentWithOptional,
@@ -27,6 +21,7 @@ import type {
 import { ApiError } from '../errors/api-error';
 import { toErrorResponse } from '../utils/to-error-response.util';
 import type { AuthContext } from '../types/auth-context';
+import { transformAdministrationBase, transformAdministration } from './utils/administration.transform';
 
 const administrationService = AdministrationService();
 const reportService = ReportService();
@@ -38,50 +33,6 @@ const reportService = ReportService();
  */
 function hasOptionalFlag(assignment: TaskVariantWithAssignment['assignment']): assignment is AssignmentWithOptional {
   return 'optional' in assignment && typeof (assignment as AssignmentWithOptional).optional === 'boolean';
-}
-
-/**
- * Maps a database Administration entity to the base API schema.
- * Converts Date fields to ISO strings and renames fields to match the contract.
- *
- * @param admin - The database Administration entity
- * @returns The API-formatted administration base object
- */
-function transformAdministrationBase(admin: Administration): ContractAdministrationBase {
-  return {
-    id: admin.id,
-    name: admin.name,
-    publicName: admin.namePublic,
-    dates: {
-      start: admin.dateStart.toISOString(),
-      end: admin.dateEnd.toISOString(),
-      created: admin.createdAt.toISOString(),
-    },
-    isOrdered: admin.isOrdered,
-  };
-}
-
-/**
- * Maps a database Administration entity to the full API schema, attaching
- * optional embed data (stats, tasks) when present.
- *
- * @param admin - The database Administration entity with optional embeds
- * @returns The API-formatted administration object with embedded data
- */
-function transformAdministration(admin: AdministrationWithEmbeds): ContractAdministration {
-  const result: ContractAdministration = transformAdministrationBase(admin);
-
-  // Include stats if embedded
-  if (admin.stats) {
-    result.stats = admin.stats;
-  }
-
-  // Include tasks if embedded
-  if (admin.tasks) {
-    result.tasks = admin.tasks;
-  }
-
-  return result;
 }
 
 /**

--- a/apps/backend/src/controllers/users.controller.test.ts
+++ b/apps/backend/src/controllers/users.controller.test.ts
@@ -1040,5 +1040,22 @@ describe('UsersController', () => {
         }),
       );
     });
+
+    it('should return 404 when target user does not exist', async () => {
+      mockGetUserAdministrations.mockRejectedValue(
+        new ApiError(ApiErrorMessage.NOT_FOUND, {
+          statusCode: StatusCodes.NOT_FOUND,
+          code: ApiErrorCode.RESOURCE_NOT_FOUND,
+        }),
+      );
+
+      const { UsersController: Controller } = await import('./users.controller');
+      const result = await Controller.listUserAdministrations(mockAuthContext, 'non-existent-user', defaultQuery);
+
+      const errorBody = expectErrorResponse(result, StatusCodes.NOT_FOUND);
+      expect(errorBody.message).toBe(ApiErrorMessage.NOT_FOUND);
+      expect(errorBody.code).toBe(ApiErrorCode.RESOURCE_NOT_FOUND);
+      expect(errorBody.traceId).toBeDefined();
+    });
   });
 });

--- a/apps/backend/src/controllers/users.controller.test.ts
+++ b/apps/backend/src/controllers/users.controller.test.ts
@@ -4,7 +4,7 @@ import type { UpdateUserRequestBody, AdministrationsListQuery } from '@roar-dash
 import { UserFactory, AuthContextFactory } from '../test-support/factories/user.factory';
 import { AdministrationWithEmbedsFactory } from '../test-support/factories/administration.factory';
 import { MockedUserService } from '../test-support/services/user.service';
-import { MockedAdministrationService } from '../test-support/services/administration.service';
+import { MockAdministrationService } from '../test-support/services/administration.service';
 import { ApiError } from '../errors/api-error';
 import { ApiErrorCode } from '../enums/api-error-code.enum';
 import { ApiErrorMessage } from '../enums/api-error-message.enum';
@@ -72,7 +72,7 @@ describe('UsersController', () => {
       listAgreements: vi.fn(),
       deleteById: vi.fn(),
       getUserAdministrations: mockGetUserAdministrations,
-    } as MockedAdministrationService);
+    } as MockAdministrationService);
   });
 
   describe('get', () => {

--- a/apps/backend/src/controllers/users.controller.test.ts
+++ b/apps/backend/src/controllers/users.controller.test.ts
@@ -1,8 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { StatusCodes } from 'http-status-codes';
-import type { UpdateUserRequestBody } from '@roar-dashboard/api-contract';
+import type { UpdateUserRequestBody, AdministrationsListQuery } from '@roar-dashboard/api-contract';
 import { UserFactory, AuthContextFactory } from '../test-support/factories/user.factory';
+import { AdministrationWithEmbedsFactory } from '../test-support/factories/administration.factory';
 import { MockedUserService } from '../test-support/services/user.service';
+import { MockedAdministrationService } from '../test-support/services/administration.service';
 import { ApiError } from '../errors/api-error';
 import { ApiErrorCode } from '../enums/api-error-code.enum';
 import { ApiErrorMessage } from '../enums/api-error-message.enum';
@@ -12,7 +14,13 @@ vi.mock('../services/user', () => ({
   UserService: vi.fn(),
 }));
 
+// Mock the AdministrationService module
+vi.mock('../services/administration/administration.service', () => ({
+  AdministrationService: vi.fn(),
+}));
+
 import { UserService } from '../services/user';
+import { AdministrationService } from '../services/administration/administration.service';
 
 /**
  * Type-safe assertion helper for success responses.
@@ -40,18 +48,31 @@ describe('UsersController', () => {
   const mockGetById = vi.fn();
   const mockUpdate = vi.fn();
   const mockRecordUserAgreement = vi.fn();
+  const mockGetUserAdministrations = vi.fn();
   const mockAuthContext = AuthContextFactory.build({ userId: 'user-123', isSuperAdmin: false });
 
   beforeEach(() => {
     vi.clearAllMocks();
 
-    // Setup the mock service
+    // Setup the mock UserService
     vi.mocked(UserService).mockReturnValue({
       findByAuthId: vi.fn(),
       getById: mockGetById,
       update: mockUpdate,
       recordUserAgreement: mockRecordUserAgreement,
     } as MockedUserService);
+
+    // Setup the mock AdministrationService
+    vi.mocked(AdministrationService).mockReturnValue({
+      verifyAdministrationAccess: vi.fn(),
+      list: vi.fn(),
+      getById: vi.fn(),
+      getAssignees: vi.fn(),
+      listTaskVariants: vi.fn(),
+      listAgreements: vi.fn(),
+      deleteById: vi.fn(),
+      getUserAdministrations: mockGetUserAdministrations,
+    } as MockedAdministrationService);
   });
 
   describe('get', () => {
@@ -672,6 +693,352 @@ describe('UsersController', () => {
       const data = expectCreatedResponse(result);
       expect(data.id).toBe('agreement-parent-child-123');
       expect(mockRecordUserAgreement).toHaveBeenCalledWith(parentAuthContext, childUserId, validBody);
+    });
+  });
+
+  describe('listUserAdministrations', () => {
+    const targetUserId = 'target-user-123';
+    const defaultQuery: AdministrationsListQuery = {
+      page: 1,
+      perPage: 25,
+      sortBy: 'createdAt',
+      sortOrder: 'desc',
+      embed: [],
+    };
+
+    it('should return 200 with paginated administrations when successful', async () => {
+      const mockAdmins = AdministrationWithEmbedsFactory.buildList(3, {
+        id: 'admin-1',
+        name: 'Test Admin 1',
+        namePublic: 'Public Admin 1',
+        dateStart: new Date('2024-01-01T00:00:00.000Z'),
+        dateEnd: new Date('2024-12-31T23:59:59.999Z'),
+        createdAt: new Date('2023-12-01T10:00:00.000Z'),
+        isOrdered: true,
+      });
+
+      mockGetUserAdministrations.mockResolvedValue({
+        items: mockAdmins,
+        totalItems: 3,
+      });
+
+      const { UsersController: Controller } = await import('./users.controller');
+      const result = await Controller.listUserAdministrations(mockAuthContext, targetUserId, defaultQuery);
+
+      const data = expectOkResponse(result);
+      expect(data.items).toHaveLength(3);
+      expect(data.pagination).toEqual({
+        page: 1,
+        perPage: 25,
+        totalItems: 3,
+        totalPages: 1,
+      });
+    });
+
+    it('should transform administration fields correctly', async () => {
+      const mockAdmin = AdministrationWithEmbedsFactory.build({
+        id: 'admin-transform',
+        name: 'Internal Name',
+        namePublic: 'Public Name',
+        dateStart: new Date('2024-01-01T00:00:00.000Z'),
+        dateEnd: new Date('2024-12-31T23:59:59.999Z'),
+        createdAt: new Date('2023-12-01T10:00:00.000Z'),
+        isOrdered: false,
+      });
+
+      mockGetUserAdministrations.mockResolvedValue({
+        items: [mockAdmin],
+        totalItems: 1,
+      });
+
+      const { UsersController: Controller } = await import('./users.controller');
+      const result = await Controller.listUserAdministrations(mockAuthContext, targetUserId, defaultQuery);
+
+      const data = expectOkResponse(result);
+      expect(data.items[0]).toMatchObject({
+        id: 'admin-transform',
+        name: 'Internal Name',
+        publicName: 'Public Name',
+        dates: {
+          start: '2024-01-01T00:00:00.000Z',
+          end: '2024-12-31T23:59:59.999Z',
+          created: '2023-12-01T10:00:00.000Z',
+        },
+        isOrdered: false,
+      });
+    });
+
+    it('should include stats when embedded', async () => {
+      const mockAdmin = AdministrationWithEmbedsFactory.build({
+        stats: {
+          assigned: 100,
+          started: 75,
+          completed: 50,
+        },
+      });
+
+      mockGetUserAdministrations.mockResolvedValue({
+        items: [mockAdmin],
+        totalItems: 1,
+      });
+
+      const query: AdministrationsListQuery = {
+        ...defaultQuery,
+        embed: ['stats'],
+      };
+
+      const { UsersController: Controller } = await import('./users.controller');
+      const result = await Controller.listUserAdministrations(mockAuthContext, targetUserId, query);
+
+      const data = expectOkResponse(result);
+      expect(data.items[0]!.stats).toEqual({
+        assigned: 100,
+        started: 75,
+        completed: 50,
+      });
+    });
+
+    it('should include tasks when embedded', async () => {
+      const mockAdmin = AdministrationWithEmbedsFactory.build({
+        tasks: [
+          {
+            taskId: 'task-1',
+            taskName: 'Task One',
+            variantId: 'variant-1',
+            variantName: 'Variant One',
+            orderIndex: 0,
+          },
+        ],
+      });
+
+      mockGetUserAdministrations.mockResolvedValue({
+        items: [mockAdmin],
+        totalItems: 1,
+      });
+
+      const query: AdministrationsListQuery = {
+        ...defaultQuery,
+        embed: ['tasks'],
+      };
+
+      const { UsersController: Controller } = await import('./users.controller');
+      const result = await Controller.listUserAdministrations(mockAuthContext, targetUserId, query);
+
+      const data = expectOkResponse(result);
+      expect(data.items[0]!.tasks).toHaveLength(1);
+      expect(data.items[0]!.tasks![0]).toMatchObject({
+        taskId: 'task-1',
+        taskName: 'Task One',
+        variantId: 'variant-1',
+        variantName: 'Variant One',
+        orderIndex: 0,
+      });
+    });
+
+    it('should not include stats or tasks when not embedded', async () => {
+      const mockAdmin = AdministrationWithEmbedsFactory.build();
+
+      mockGetUserAdministrations.mockResolvedValue({
+        items: [mockAdmin],
+        totalItems: 1,
+      });
+
+      const { UsersController: Controller } = await import('./users.controller');
+      const result = await Controller.listUserAdministrations(mockAuthContext, targetUserId, defaultQuery);
+
+      const data = expectOkResponse(result);
+      expect(data.items[0]).not.toHaveProperty('stats');
+      expect(data.items[0]).not.toHaveProperty('tasks');
+    });
+
+    it('should pass status filter to service when provided', async () => {
+      mockGetUserAdministrations.mockResolvedValue({
+        items: [],
+        totalItems: 0,
+      });
+
+      const query: AdministrationsListQuery = {
+        ...defaultQuery,
+        status: 'active',
+      };
+
+      const { UsersController: Controller } = await import('./users.controller');
+      await Controller.listUserAdministrations(mockAuthContext, targetUserId, query);
+
+      expect(mockGetUserAdministrations).toHaveBeenCalledWith(
+        mockAuthContext,
+        targetUserId,
+        expect.objectContaining({
+          status: 'active',
+        }),
+      );
+    });
+
+    it('should not pass status filter to service when not provided', async () => {
+      mockGetUserAdministrations.mockResolvedValue({
+        items: [],
+        totalItems: 0,
+      });
+
+      const { UsersController: Controller } = await import('./users.controller');
+      await Controller.listUserAdministrations(mockAuthContext, targetUserId, defaultQuery);
+
+      expect(mockGetUserAdministrations).toHaveBeenCalledWith(
+        mockAuthContext,
+        targetUserId,
+        expect.not.objectContaining({
+          status: expect.anything(),
+        }),
+      );
+    });
+
+    it('should calculate totalPages correctly', async () => {
+      mockGetUserAdministrations.mockResolvedValue({
+        items: AdministrationWithEmbedsFactory.buildList(10),
+        totalItems: 47,
+      });
+
+      const query: AdministrationsListQuery = {
+        page: 1,
+        perPage: 10,
+        sortBy: 'createdAt',
+        sortOrder: 'desc',
+        embed: [],
+      };
+
+      const { UsersController: Controller } = await import('./users.controller');
+      const result = await Controller.listUserAdministrations(mockAuthContext, targetUserId, query);
+
+      const data = expectOkResponse(result);
+      expect(data.pagination.totalPages).toBe(5); // Math.ceil(47 / 10)
+    });
+
+    it('should handle empty results', async () => {
+      mockGetUserAdministrations.mockResolvedValue({
+        items: [],
+        totalItems: 0,
+      });
+
+      const { UsersController: Controller } = await import('./users.controller');
+      const result = await Controller.listUserAdministrations(mockAuthContext, targetUserId, defaultQuery);
+
+      const data = expectOkResponse(result);
+      expect(data.items).toEqual([]);
+      expect(data.pagination).toEqual({
+        page: 1,
+        perPage: 25,
+        totalItems: 0,
+        totalPages: 0,
+      });
+    });
+
+    it('should delegate to service with correct arguments', async () => {
+      mockGetUserAdministrations.mockResolvedValue({
+        items: [],
+        totalItems: 0,
+      });
+
+      const query: AdministrationsListQuery = {
+        page: 2,
+        perPage: 50,
+        sortBy: 'name',
+        sortOrder: 'asc',
+        embed: ['stats', 'tasks'],
+        status: 'active',
+      };
+
+      const { UsersController: Controller } = await import('./users.controller');
+      await Controller.listUserAdministrations(mockAuthContext, targetUserId, query);
+
+      expect(mockGetUserAdministrations).toHaveBeenCalledWith(mockAuthContext, targetUserId, {
+        page: 2,
+        perPage: 50,
+        sortBy: 'name',
+        sortOrder: 'asc',
+        embed: ['stats', 'tasks'],
+        status: 'active',
+      });
+      expect(mockGetUserAdministrations).toHaveBeenCalledTimes(1);
+    });
+
+    it('should return 500 when service throws INTERNAL_SERVER_ERROR', async () => {
+      const error = new ApiError(ApiErrorMessage.INTERNAL_SERVER_ERROR, {
+        statusCode: StatusCodes.INTERNAL_SERVER_ERROR,
+        code: ApiErrorCode.DATABASE_QUERY_FAILED,
+      });
+      mockGetUserAdministrations.mockRejectedValue(error);
+
+      const { UsersController: Controller } = await import('./users.controller');
+      const result = await Controller.listUserAdministrations(mockAuthContext, targetUserId, defaultQuery);
+
+      const errorBody = expectErrorResponse(result, StatusCodes.INTERNAL_SERVER_ERROR);
+      expect(errorBody.message).toBe(ApiErrorMessage.INTERNAL_SERVER_ERROR);
+      expect(errorBody.code).toBe(ApiErrorCode.DATABASE_QUERY_FAILED);
+      expect(errorBody.traceId).toBeDefined();
+    });
+
+    it('should re-throw non-ApiError exceptions', async () => {
+      const unexpectedError = new Error('Unexpected database error');
+      mockGetUserAdministrations.mockRejectedValue(unexpectedError);
+
+      const { UsersController: Controller } = await import('./users.controller');
+
+      await expect(Controller.listUserAdministrations(mockAuthContext, targetUserId, defaultQuery)).rejects.toThrow(
+        'Unexpected database error',
+      );
+    });
+
+    it('should handle pagination on second page', async () => {
+      mockGetUserAdministrations.mockResolvedValue({
+        items: AdministrationWithEmbedsFactory.buildList(25),
+        totalItems: 100,
+      });
+
+      const query: AdministrationsListQuery = {
+        page: 2,
+        perPage: 25,
+        sortBy: 'createdAt',
+        sortOrder: 'desc',
+        embed: [],
+      };
+
+      const { UsersController: Controller } = await import('./users.controller');
+      const result = await Controller.listUserAdministrations(mockAuthContext, targetUserId, query);
+
+      const data = expectOkResponse(result);
+      expect(data.pagination).toEqual({
+        page: 2,
+        perPage: 25,
+        totalItems: 100,
+        totalPages: 4,
+      });
+    });
+
+    it('should handle different sort options', async () => {
+      mockGetUserAdministrations.mockResolvedValue({
+        items: [],
+        totalItems: 0,
+      });
+
+      const query: AdministrationsListQuery = {
+        page: 1,
+        perPage: 25,
+        sortBy: 'name',
+        sortOrder: 'asc',
+        embed: [],
+      };
+
+      const { UsersController: Controller } = await import('./users.controller');
+      await Controller.listUserAdministrations(mockAuthContext, targetUserId, query);
+
+      expect(mockGetUserAdministrations).toHaveBeenCalledWith(
+        mockAuthContext,
+        targetUserId,
+        expect.objectContaining({
+          sortBy: 'name',
+          sortOrder: 'asc',
+        }),
+      );
     });
   });
 });

--- a/apps/backend/src/controllers/users.controller.test.ts
+++ b/apps/backend/src/controllers/users.controller.test.ts
@@ -1057,5 +1057,22 @@ describe('UsersController', () => {
       expect(errorBody.code).toBe(ApiErrorCode.RESOURCE_NOT_FOUND);
       expect(errorBody.traceId).toBeDefined();
     });
+
+    it('should return 403 when requester has no shared administrations with target user', async () => {
+      mockGetUserAdministrations.mockRejectedValue(
+        new ApiError(ApiErrorMessage.FORBIDDEN, {
+          statusCode: StatusCodes.FORBIDDEN,
+          code: ApiErrorCode.AUTH_FORBIDDEN,
+        }),
+      );
+
+      const { UsersController: Controller } = await import('./users.controller');
+      const result = await Controller.listUserAdministrations(mockAuthContext, targetUserId, defaultQuery);
+
+      const errorBody = expectErrorResponse(result, StatusCodes.FORBIDDEN);
+      expect(errorBody.message).toBe(ApiErrorMessage.FORBIDDEN);
+      expect(errorBody.code).toBe(ApiErrorCode.AUTH_FORBIDDEN);
+      expect(errorBody.traceId).toBeDefined();
+    });
   });
 });

--- a/apps/backend/src/controllers/users.controller.ts
+++ b/apps/backend/src/controllers/users.controller.ts
@@ -1,12 +1,20 @@
 import type { AuthContext } from '../types/auth-context';
 import type { User } from '../db/schema';
-import type { UserResponse, UpdateUserRequestBody, RecordUserAgreementRequestBody } from '@roar-dashboard/api-contract';
+import type {
+  UserResponse,
+  UpdateUserRequestBody,
+  RecordUserAgreementRequestBody,
+  AdministrationsListQuery,
+} from '@roar-dashboard/api-contract';
 import { StatusCodes } from 'http-status-codes';
 import { UserService } from '../services/user';
+import { AdministrationService } from '../services/administration/administration.service';
 import { ApiError } from '../errors/api-error';
 import { toErrorResponse } from '../utils/to-error-response.util';
+import { transformAdministration } from './utils/administration.transform';
 
 const userService = UserService();
+const administrationService = AdministrationService();
 
 /**
  * Transform a User database record into a UserResponse API schema.
@@ -157,6 +165,56 @@ export const UsersController = {
           StatusCodes.CONFLICT,
           StatusCodes.INTERNAL_SERVER_ERROR,
         ]);
+      }
+      throw error;
+    }
+  },
+
+  /**
+   * List specified user's administrations with pagination, sorting, optional status filter, and embeds.
+   *
+   * Delegates to AdministrationService for authorization and retrieval.
+   * Transforms database entities to the API response format.
+   *
+   * @param authContext - User's authentication context
+   * @param userId - UUID of the user whose administrations to list
+   * @param query - Query parameters (pagination, sorting, status filter, embed options)
+   */
+  listUserAdministrations: async (authContext: AuthContext, userId: string, query: AdministrationsListQuery) => {
+    try {
+      const { page, perPage, sortBy, sortOrder, embed, status } = query;
+
+      const result = await administrationService.getUserAdministrations(authContext, userId, {
+        page,
+        perPage,
+        sortBy,
+        sortOrder,
+        embed,
+        ...(status && { status }),
+      });
+
+      // Transform to API response format
+      const items = result.items.map(transformAdministration);
+
+      const totalPages = Math.ceil(result.totalItems / perPage);
+
+      return {
+        status: StatusCodes.OK as const,
+        body: {
+          data: {
+            items,
+            pagination: {
+              page,
+              perPage,
+              totalItems: result.totalItems,
+              totalPages,
+            },
+          },
+        },
+      };
+    } catch (error) {
+      if (error instanceof ApiError) {
+        return toErrorResponse(error, [StatusCodes.INTERNAL_SERVER_ERROR]);
       }
       throw error;
     }

--- a/apps/backend/src/controllers/users.controller.ts
+++ b/apps/backend/src/controllers/users.controller.ts
@@ -214,7 +214,11 @@ export const UsersController = {
       };
     } catch (error) {
       if (error instanceof ApiError) {
-        return toErrorResponse(error, [StatusCodes.NOT_FOUND, StatusCodes.INTERNAL_SERVER_ERROR]);
+        return toErrorResponse(error, [
+          StatusCodes.NOT_FOUND,
+          StatusCodes.FORBIDDEN,
+          StatusCodes.INTERNAL_SERVER_ERROR,
+        ]);
       }
       throw error;
     }

--- a/apps/backend/src/controllers/users.controller.ts
+++ b/apps/backend/src/controllers/users.controller.ts
@@ -214,7 +214,7 @@ export const UsersController = {
       };
     } catch (error) {
       if (error instanceof ApiError) {
-        return toErrorResponse(error, [StatusCodes.INTERNAL_SERVER_ERROR]);
+        return toErrorResponse(error, [StatusCodes.NOT_FOUND, StatusCodes.INTERNAL_SERVER_ERROR]);
       }
       throw error;
     }

--- a/apps/backend/src/controllers/utils/administration.transform.test.ts
+++ b/apps/backend/src/controllers/utils/administration.transform.test.ts
@@ -1,0 +1,315 @@
+import { describe, it, expect } from 'vitest';
+import { transformAdministrationBase, transformAdministration } from './administration.transform';
+import {
+  AdministrationFactory,
+  AdministrationWithEmbedsFactory,
+} from '../../test-support/factories/administration.factory';
+
+describe('administration.transform', () => {
+  describe('transformAdministrationBase', () => {
+    it('maps all required fields correctly', () => {
+      const admin = AdministrationFactory.build({
+        id: 'test-admin-id',
+        name: 'Internal Administration Name',
+        namePublic: 'Public Administration Name',
+        dateStart: new Date('2024-01-01T00:00:00.000Z'),
+        dateEnd: new Date('2024-12-31T23:59:59.999Z'),
+        createdAt: new Date('2023-12-01T10:00:00.000Z'),
+        isOrdered: true,
+      });
+
+      const result = transformAdministrationBase(admin);
+
+      expect(result.id).toBe('test-admin-id');
+      expect(result.name).toBe('Internal Administration Name');
+      expect(result.publicName).toBe('Public Administration Name');
+      expect(result.isOrdered).toBe(true);
+    });
+
+    it('converts Date fields to ISO strings', () => {
+      const admin = AdministrationFactory.build({
+        dateStart: new Date('2024-01-01T00:00:00.000Z'),
+        dateEnd: new Date('2024-12-31T23:59:59.999Z'),
+        createdAt: new Date('2023-12-01T10:00:00.000Z'),
+      });
+
+      const result = transformAdministrationBase(admin);
+
+      expect(result.dates.start).toBe('2024-01-01T00:00:00.000Z');
+      expect(result.dates.end).toBe('2024-12-31T23:59:59.999Z');
+      expect(result.dates.created).toBe('2023-12-01T10:00:00.000Z');
+    });
+
+    it('renames namePublic to publicName', () => {
+      const admin = AdministrationFactory.build({
+        namePublic: 'Test Public Name',
+      });
+
+      const result = transformAdministrationBase(admin);
+
+      expect(result.publicName).toBe('Test Public Name');
+      expect(result).not.toHaveProperty('namePublic');
+    });
+
+    it('handles isOrdered as false', () => {
+      const admin = AdministrationFactory.build({
+        isOrdered: false,
+      });
+
+      const result = transformAdministrationBase(admin);
+
+      expect(result.isOrdered).toBe(false);
+    });
+
+    it('omits internal fields from response', () => {
+      const admin = AdministrationFactory.build({
+        description: 'Internal description',
+        excludedFromResearch: null,
+        excludedFromResearchBy: null,
+        excludedFromResearchReason: null,
+        createdBy: 'user-id',
+        updatedAt: new Date(),
+      });
+
+      const result = transformAdministrationBase(admin);
+
+      expect(result).not.toHaveProperty('description');
+      expect(result).not.toHaveProperty('excludedFromResearch');
+      expect(result).not.toHaveProperty('excludedFromResearchBy');
+      expect(result).not.toHaveProperty('excludedFromResearchReason');
+      expect(result).not.toHaveProperty('createdBy');
+      expect(result).not.toHaveProperty('updatedAt');
+    });
+
+    it('preserves milliseconds in ISO string conversion', () => {
+      const admin = AdministrationFactory.build({
+        dateStart: new Date('2024-01-01T12:34:56.789Z'),
+        dateEnd: new Date('2024-12-31T23:59:59.123Z'),
+        createdAt: new Date('2023-12-01T10:20:30.456Z'),
+      });
+
+      const result = transformAdministrationBase(admin);
+
+      expect(result.dates.start).toBe('2024-01-01T12:34:56.789Z');
+      expect(result.dates.end).toBe('2024-12-31T23:59:59.123Z');
+      expect(result.dates.created).toBe('2023-12-01T10:20:30.456Z');
+    });
+  });
+
+  describe('transformAdministration', () => {
+    it('returns base administration when no embeds are present', () => {
+      const admin = AdministrationWithEmbedsFactory.build({
+        id: 'test-id',
+        name: 'Test Admin',
+        namePublic: 'Test Public',
+        dateStart: new Date('2024-01-01T00:00:00.000Z'),
+        dateEnd: new Date('2024-12-31T23:59:59.999Z'),
+        createdAt: new Date('2023-12-01T10:00:00.000Z'),
+        isOrdered: false,
+      });
+
+      const result = transformAdministration(admin);
+
+      expect(result.id).toBe('test-id');
+      expect(result.name).toBe('Test Admin');
+      expect(result.publicName).toBe('Test Public');
+      expect(result.isOrdered).toBe(false);
+      expect(result).not.toHaveProperty('stats');
+      expect(result).not.toHaveProperty('tasks');
+    });
+
+    it('includes stats when embedded', () => {
+      const admin = AdministrationWithEmbedsFactory.build({
+        stats: {
+          assigned: 100,
+          started: 75,
+          completed: 50,
+        },
+      });
+
+      const result = transformAdministration(admin);
+
+      expect(result.stats).toEqual({
+        assigned: 100,
+        started: 75,
+        completed: 50,
+      });
+    });
+
+    it('includes tasks when embedded', () => {
+      const admin = AdministrationWithEmbedsFactory.build({
+        tasks: [
+          {
+            taskId: 'task-1',
+            taskName: 'Task One',
+            variantId: 'variant-1',
+            variantName: 'Variant One',
+            orderIndex: 0,
+          },
+          {
+            taskId: 'task-2',
+            taskName: 'Task Two',
+            variantId: 'variant-2',
+            variantName: null,
+            orderIndex: 1,
+          },
+        ],
+      });
+
+      const result = transformAdministration(admin);
+
+      expect(result.tasks).toHaveLength(2);
+      expect(result.tasks![0]).toEqual({
+        taskId: 'task-1',
+        taskName: 'Task One',
+        variantId: 'variant-1',
+        variantName: 'Variant One',
+        orderIndex: 0,
+      });
+      expect(result.tasks![1]).toEqual({
+        taskId: 'task-2',
+        taskName: 'Task Two',
+        variantId: 'variant-2',
+        variantName: null,
+        orderIndex: 1,
+      });
+    });
+
+    it('includes both stats and tasks when both are embedded', () => {
+      const admin = AdministrationWithEmbedsFactory.build({
+        stats: {
+          assigned: 50,
+          started: 30,
+          completed: 20,
+        },
+        tasks: [
+          {
+            taskId: 'task-1',
+            taskName: 'Task One',
+            variantId: 'variant-1',
+            variantName: 'Variant One',
+            orderIndex: 0,
+          },
+        ],
+      });
+
+      const result = transformAdministration(admin);
+
+      expect(result.stats).toEqual({
+        assigned: 50,
+        started: 30,
+        completed: 20,
+      });
+      expect(result.tasks).toHaveLength(1);
+      expect(result.tasks![0]!.taskId).toBe('task-1');
+    });
+
+    it('handles stats with zero values', () => {
+      const admin = AdministrationWithEmbedsFactory.build({
+        stats: {
+          assigned: 0,
+          started: 0,
+          completed: 0,
+        },
+      });
+
+      const result = transformAdministration(admin);
+
+      expect(result.stats).toEqual({
+        assigned: 0,
+        started: 0,
+        completed: 0,
+      });
+    });
+
+    it('handles empty tasks array', () => {
+      const admin = AdministrationWithEmbedsFactory.build({
+        tasks: [],
+      });
+
+      const result = transformAdministration(admin);
+
+      expect(result.tasks).toEqual([]);
+    });
+
+    it('preserves task order by orderIndex', () => {
+      const admin = AdministrationWithEmbedsFactory.build({
+        tasks: [
+          {
+            taskId: 'task-3',
+            taskName: 'Task Three',
+            variantId: 'variant-3',
+            variantName: 'Variant Three',
+            orderIndex: 2,
+          },
+          {
+            taskId: 'task-1',
+            taskName: 'Task One',
+            variantId: 'variant-1',
+            variantName: 'Variant One',
+            orderIndex: 0,
+          },
+          {
+            taskId: 'task-2',
+            taskName: 'Task Two',
+            variantId: 'variant-2',
+            variantName: 'Variant Two',
+            orderIndex: 1,
+          },
+        ],
+      });
+
+      const result = transformAdministration(admin);
+
+      expect(result.tasks![0]!.orderIndex).toBe(2);
+      expect(result.tasks![1]!.orderIndex).toBe(0);
+      expect(result.tasks![2]!.orderIndex).toBe(1);
+    });
+
+    it('handles tasks with null variantName', () => {
+      const admin = AdministrationWithEmbedsFactory.build({
+        tasks: [
+          {
+            taskId: 'task-1',
+            taskName: 'Task One',
+            variantId: 'variant-1',
+            variantName: null,
+            orderIndex: 0,
+          },
+        ],
+      });
+
+      const result = transformAdministration(admin);
+
+      expect(result.tasks![0]!.variantName).toBeNull();
+    });
+
+    it('maintains base administration structure with embeds', () => {
+      const admin = AdministrationWithEmbedsFactory.build({
+        id: 'embed-test-id',
+        name: 'Embed Test Admin',
+        namePublic: 'Embed Test Public',
+        dateStart: new Date('2024-06-01T00:00:00.000Z'),
+        dateEnd: new Date('2024-06-30T23:59:59.999Z'),
+        createdAt: new Date('2024-05-01T10:00:00.000Z'),
+        isOrdered: true,
+        stats: {
+          assigned: 10,
+          started: 5,
+          completed: 2,
+        },
+      });
+
+      const result = transformAdministration(admin);
+
+      expect(result.id).toBe('embed-test-id');
+      expect(result.name).toBe('Embed Test Admin');
+      expect(result.publicName).toBe('Embed Test Public');
+      expect(result.dates.start).toBe('2024-06-01T00:00:00.000Z');
+      expect(result.dates.end).toBe('2024-06-30T23:59:59.999Z');
+      expect(result.dates.created).toBe('2024-05-01T10:00:00.000Z');
+      expect(result.isOrdered).toBe(true);
+      expect(result.stats).toBeDefined();
+    });
+  });
+});

--- a/apps/backend/src/controllers/utils/administration.transform.ts
+++ b/apps/backend/src/controllers/utils/administration.transform.ts
@@ -1,0 +1,49 @@
+import type { Administration } from '../../db/schema';
+import type {
+  Administration as ContractAdministrationBase,
+  Administration as ContractAdministration,
+} from '@roar-dashboard/api-contract';
+import type { AdministrationWithEmbeds } from '../../services/administration/administration.service';
+/**
+ * Maps a database Administration entity to the base API schema.
+ * Converts Date fields to ISO strings and renames fields to match the contract.
+ *
+ * @param admin - The database Administration entity
+ * @returns The API-formatted administration base object
+ */
+export function transformAdministrationBase(admin: Administration): ContractAdministrationBase {
+  return {
+    id: admin.id,
+    name: admin.name,
+    publicName: admin.namePublic,
+    dates: {
+      start: admin.dateStart.toISOString(),
+      end: admin.dateEnd.toISOString(),
+      created: admin.createdAt.toISOString(),
+    },
+    isOrdered: admin.isOrdered,
+  };
+}
+
+/**
+ * Maps a database Administration entity to the full API schema, attaching
+ * optional embed data (stats, tasks) when present.
+ *
+ * @param admin - The database Administration entity with optional embeds
+ * @returns The API-formatted administration object with embedded data
+ */
+export function transformAdministration(admin: AdministrationWithEmbeds): ContractAdministration {
+  const result: ContractAdministration = transformAdministrationBase(admin);
+
+  // Include stats if embedded
+  if (admin.stats) {
+    result.stats = admin.stats;
+  }
+
+  // Include tasks if embedded
+  if (admin.tasks) {
+    result.tasks = admin.tasks;
+  }
+
+  return result;
+}

--- a/apps/backend/src/controllers/utils/administration.transform.ts
+++ b/apps/backend/src/controllers/utils/administration.transform.ts
@@ -1,5 +1,5 @@
 import type {
-  Administration as ContractAdministrationBase,
+  AdministrationBase as ContractAdministrationBase,
   Administration as ContractAdministration,
 } from '@roar-dashboard/api-contract';
 import type { Administration } from '../../db/schema';

--- a/apps/backend/src/controllers/utils/administration.transform.ts
+++ b/apps/backend/src/controllers/utils/administration.transform.ts
@@ -1,8 +1,8 @@
-import type { Administration } from '../../db/schema';
 import type {
   Administration as ContractAdministrationBase,
   Administration as ContractAdministration,
 } from '@roar-dashboard/api-contract';
+import type { Administration } from '../../db/schema';
 import type { AdministrationWithEmbeds } from '../../services/administration/administration.service';
 /**
  * Maps a database Administration entity to the base API schema.

--- a/apps/backend/src/routes/users.integration.test.ts
+++ b/apps/backend/src/routes/users.integration.test.ts
@@ -1330,6 +1330,15 @@ describe('GET /v1/users/:userId/administrations', () => {
       expect(res.body.error.code).toBe(ApiErrorCode.RESOURCE_NOT_FOUND);
     });
 
+    it('returns 403 when non-super-admin tries to list administrations for user with no shared access', async () => {
+      // districtBStudent is in a different district from tiers.admin (who is in districtA)
+      const res = await expectRoute('GET', `/v1/users/${baseFixture.districtBStudent.id}/administrations`)
+        .as(tiers.admin)
+        .toReturn(StatusCodes.FORBIDDEN);
+
+      expect(res.body.error.code).toBe(ApiErrorCode.AUTH_FORBIDDEN);
+    });
+
     it('returns 400 for invalid UUID in userId parameter', async () => {
       const res = await expectRoute('GET', '/v1/users/not-a-valid-uuid/administrations')
         .as(tiers.superAdmin)

--- a/apps/backend/src/routes/users.integration.test.ts
+++ b/apps/backend/src/routes/users.integration.test.ts
@@ -23,10 +23,18 @@
  * - Parent/guardian consent for minor children
  * - Duplicate consent detection (same user+version → 409)
  * - Error cases (400, 401, 403, 404, 409)
+ *
+ * GET /v1/users/:userId/administrations
+ * - Authorization (who can list administrations for which users)
+ * - Pagination and sorting
+ * - Embed options (stats, tasks)
+ * - Field transformations (Date → ISO string)
+ * - Error cases (401)
  */
 import { describe, it, expect, beforeAll } from 'vitest';
 import type express from 'express';
 import { StatusCodes } from 'http-status-codes';
+import type { Administration } from '@roar-dashboard/api-contract';
 import { createTestApp, createRouteHelper, createTierUsers } from '../test-support/route-test.helper';
 import type { TierUsers } from '../test-support/route-test.helper';
 import { baseFixture } from '../test-support/fixtures';
@@ -1087,6 +1095,264 @@ describe('POST /v1/users/:userId/agreements', () => {
         .toReturn(StatusCodes.CONFLICT);
 
       expect(res2.body.error.code).toBe(ApiErrorCode.RESOURCE_CONFLICT);
+    });
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// GET /v1/users/:userId/administrations
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('GET /v1/users/:userId/administrations', () => {
+  describe('authorization', () => {
+    it('super admin can list administrations for any user', async () => {
+      const res = await expectRoute('GET', `/v1/users/${baseFixture.schoolAStudent.id}/administrations`)
+        .as(tiers.superAdmin)
+        .toReturn(StatusCodes.OK);
+
+      expect(res.body.data).toHaveProperty('items');
+      expect(res.body.data).toHaveProperty('pagination');
+    });
+
+    it('user can list their own administrations', async () => {
+      const res = await expectRoute('GET', `/v1/users/${tiers.student.id}/administrations`)
+        .as(tiers.student)
+        .toReturn(StatusCodes.OK);
+
+      expect(res.body.data).toHaveProperty('items');
+      expect(res.body.data).toHaveProperty('pagination');
+    });
+
+    it('admin can list administrations for users in their district', async () => {
+      const res = await expectRoute('GET', `/v1/users/${baseFixture.schoolAStudent.id}/administrations`)
+        .as(tiers.admin)
+        .toReturn(StatusCodes.OK);
+
+      expect(res.body.data).toHaveProperty('items');
+      expect(res.body.data).toHaveProperty('pagination');
+    });
+
+    it('returns 401 when unauthenticated', async () => {
+      const res = await expectRoute('GET', `/v1/users/${baseFixture.schoolAStudent.id}/administrations`)
+        .unauthenticated()
+        .toReturn(StatusCodes.UNAUTHORIZED);
+
+      expect(res.body.error.code).toBe(ApiErrorCode.AUTH_REQUIRED);
+    });
+  });
+
+  describe('response structure', () => {
+    it('returns paginated response with items and pagination metadata', async () => {
+      const res = await expectRoute('GET', `/v1/users/${baseFixture.schoolAStudent.id}/administrations`)
+        .as(tiers.superAdmin)
+        .toReturn(StatusCodes.OK);
+
+      expect(res.body.data.items).toBeInstanceOf(Array);
+      expect(res.body.data.pagination).toMatchObject({
+        page: expect.any(Number),
+        perPage: expect.any(Number),
+        totalItems: expect.any(Number),
+        totalPages: expect.any(Number),
+      });
+    });
+
+    it('transforms administration fields correctly', async () => {
+      const res = await expectRoute('GET', `/v1/users/${baseFixture.schoolAStudent.id}/administrations`)
+        .as(tiers.superAdmin)
+        .toReturn(StatusCodes.OK);
+
+      if (res.body.data.items.length > 0) {
+        const admin = res.body.data.items[0];
+        expect(admin).toMatchObject({
+          id: expect.any(String),
+          name: expect.any(String),
+          publicName: expect.any(String),
+          dates: {
+            start: expect.stringMatching(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/),
+            end: expect.stringMatching(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/),
+            created: expect.stringMatching(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/),
+          },
+          isOrdered: expect.any(Boolean),
+        });
+      }
+    });
+
+    it('does not include stats or tasks by default', async () => {
+      const res = await expectRoute('GET', `/v1/users/${baseFixture.schoolAStudent.id}/administrations`)
+        .as(tiers.superAdmin)
+        .toReturn(StatusCodes.OK);
+
+      if (res.body.data.items.length > 0) {
+        const admin = res.body.data.items[0];
+        expect(admin).not.toHaveProperty('stats');
+        expect(admin).not.toHaveProperty('tasks');
+      }
+    });
+  });
+
+  describe('pagination', () => {
+    it('respects page parameter', async () => {
+      const res = await expectRoute(
+        'GET',
+        `/v1/users/${baseFixture.schoolAStudent.id}/administrations?page=1&perPage=10`,
+      )
+        .as(tiers.superAdmin)
+        .toReturn(StatusCodes.OK);
+
+      expect(res.body.data.pagination.page).toBe(1);
+      expect(res.body.data.pagination.perPage).toBe(10);
+    });
+
+    it('respects perPage parameter', async () => {
+      const res = await expectRoute(
+        'GET',
+        `/v1/users/${baseFixture.schoolAStudent.id}/administrations?page=1&perPage=5`,
+      )
+        .as(tiers.superAdmin)
+        .toReturn(StatusCodes.OK);
+
+      expect(res.body.data.pagination.perPage).toBe(5);
+      expect(res.body.data.items.length).toBeLessThanOrEqual(5);
+    });
+
+    it('calculates totalPages correctly', async () => {
+      const res = await expectRoute(
+        'GET',
+        `/v1/users/${baseFixture.schoolAStudent.id}/administrations?page=1&perPage=10`,
+      )
+        .as(tiers.superAdmin)
+        .toReturn(StatusCodes.OK);
+
+      const { totalItems, perPage, totalPages } = res.body.data.pagination;
+      expect(totalPages).toBe(Math.ceil(totalItems / perPage));
+    });
+  });
+
+  describe('sorting', () => {
+    it('respects sortBy and sortOrder parameters', async () => {
+      const res = await expectRoute(
+        'GET',
+        `/v1/users/${baseFixture.schoolAStudent.id}/administrations?sortBy=name&sortOrder=asc`,
+      )
+        .as(tiers.superAdmin)
+        .toReturn(StatusCodes.OK);
+
+      expect(res.body.data).toHaveProperty('items');
+    });
+
+    it('defaults to createdAt desc when sort parameters not provided', async () => {
+      const res = await expectRoute('GET', `/v1/users/${baseFixture.schoolAStudent.id}/administrations`)
+        .as(tiers.superAdmin)
+        .toReturn(StatusCodes.OK);
+
+      expect(res.body.data).toHaveProperty('items');
+    });
+  });
+
+  describe('embed options', () => {
+    it('includes stats when embed=stats', async () => {
+      const res = await expectRoute('GET', `/v1/users/${baseFixture.schoolAStudent.id}/administrations?embed=stats`)
+        .as(tiers.superAdmin)
+        .toReturn(StatusCodes.OK);
+
+      if (res.body.data.items.length > 0) {
+        const adminWithStats = res.body.data.items.find((item: Administration) => item.stats);
+        if (adminWithStats) {
+          expect(adminWithStats.stats).toMatchObject({
+            assigned: expect.any(Number),
+            started: expect.any(Number),
+            completed: expect.any(Number),
+          });
+        }
+      }
+    });
+
+    it('includes tasks when embed=tasks', async () => {
+      const res = await expectRoute('GET', `/v1/users/${baseFixture.schoolAStudent.id}/administrations?embed=tasks`)
+        .as(tiers.superAdmin)
+        .toReturn(StatusCodes.OK);
+
+      if (res.body.data.items.length > 0) {
+        const adminWithTasks = res.body.data.items.find((item: Administration) => item.tasks);
+        if (adminWithTasks) {
+          expect(Array.isArray(adminWithTasks.tasks)).toBe(true);
+        }
+      }
+    });
+
+    it('includes both stats and tasks when embed=stats,tasks', async () => {
+      const res = await expectRoute(
+        'GET',
+        `/v1/users/${baseFixture.schoolAStudent.id}/administrations?embed=stats,tasks`,
+      )
+        .as(tiers.superAdmin)
+        .toReturn(StatusCodes.OK);
+
+      expect(res.body.data).toHaveProperty('items');
+    });
+  });
+
+  describe('filtering', () => {
+    it('respects status filter when provided', async () => {
+      const res = await expectRoute('GET', `/v1/users/${baseFixture.schoolAStudent.id}/administrations?status=active`)
+        .as(tiers.superAdmin)
+        .toReturn(StatusCodes.OK);
+
+      expect(res.body.data).toHaveProperty('items');
+    });
+  });
+
+  describe('empty results', () => {
+    it('returns empty array when user has no administrations', async () => {
+      const userWithNoAdmins = await UserFactory.create();
+      await UserOrgFactory.create({
+        userId: userWithNoAdmins.id,
+        orgId: baseFixture.district.id,
+        role: UserRole.STUDENT,
+      });
+
+      const res = await expectRoute('GET', `/v1/users/${userWithNoAdmins.id}/administrations`)
+        .as(tiers.superAdmin)
+        .toReturn(StatusCodes.OK);
+
+      expect(res.body.data.items).toEqual([]);
+      expect(res.body.data.pagination.totalItems).toBe(0);
+      expect(res.body.data.pagination.totalPages).toBe(0);
+    });
+  });
+
+  describe('validation', () => {
+    it('returns 400 for invalid UUID in userId parameter', async () => {
+      const res = await expectRoute('GET', '/v1/users/not-a-valid-uuid/administrations')
+        .as(tiers.superAdmin)
+        .toReturn(StatusCodes.BAD_REQUEST);
+
+      const messages = res.body.issues.map((issue: { message: string }) => issue.message);
+      expect(messages).toContain('Invalid uuid');
+    });
+
+    it('returns 400 for invalid page parameter', async () => {
+      await expectRoute('GET', `/v1/users/${baseFixture.schoolAStudent.id}/administrations?page=0`)
+        .as(tiers.superAdmin)
+        .toReturn(StatusCodes.BAD_REQUEST);
+    });
+
+    it('returns 400 for invalid perPage parameter', async () => {
+      await expectRoute('GET', `/v1/users/${baseFixture.schoolAStudent.id}/administrations?perPage=0`)
+        .as(tiers.superAdmin)
+        .toReturn(StatusCodes.BAD_REQUEST);
+    });
+
+    it('returns 400 for invalid sortBy parameter', async () => {
+      await expectRoute('GET', `/v1/users/${baseFixture.schoolAStudent.id}/administrations?sortBy=invalidField`)
+        .as(tiers.superAdmin)
+        .toReturn(StatusCodes.BAD_REQUEST);
+    });
+
+    it('returns 400 for invalid sortOrder parameter', async () => {
+      await expectRoute('GET', `/v1/users/${baseFixture.schoolAStudent.id}/administrations?sortOrder=invalid`)
+        .as(tiers.superAdmin)
+        .toReturn(StatusCodes.BAD_REQUEST);
     });
   });
 });

--- a/apps/backend/src/routes/users.integration.test.ts
+++ b/apps/backend/src/routes/users.integration.test.ts
@@ -1322,6 +1322,14 @@ describe('GET /v1/users/:userId/administrations', () => {
   });
 
   describe('validation', () => {
+    it('returns 404 when target user does not exist', async () => {
+      const res = await expectRoute('GET', '/v1/users/00000000-0000-0000-0000-000000000000/administrations')
+        .as(tiers.superAdmin)
+        .toReturn(StatusCodes.NOT_FOUND);
+
+      expect(res.body.error.code).toBe(ApiErrorCode.RESOURCE_NOT_FOUND);
+    });
+
     it('returns 400 for invalid UUID in userId parameter', async () => {
       const res = await expectRoute('GET', '/v1/users/not-a-valid-uuid/administrations')
         .as(tiers.superAdmin)

--- a/apps/backend/src/routes/users.ts
+++ b/apps/backend/src/routes/users.ts
@@ -30,6 +30,12 @@ export function registerUserRoutes(routerInstance: Router) {
       handler: async ({ req: { user }, params: { userId }, body }) =>
         UsersController.recordUserAgreement(user!, userId, body),
     },
+    listUserAdministrations: {
+      // @ts-expect-error - Express v4/v5 types mismatch in monorepo
+      middleware: [AuthGuardMiddleware],
+      handler: async ({ req: { user }, params: { userId }, query }) =>
+        UsersController.listUserAdministrations(user!, userId, query),
+    },
   });
 
   // @ts-expect-error - Express v4/v5 types mismatch in monorepo

--- a/apps/backend/src/services/administration/administration.service.test.ts
+++ b/apps/backend/src/services/administration/administration.service.test.ts
@@ -2546,7 +2546,7 @@ describe('AdministrationService', () => {
       expect(mockAuthorizationService.listAccessibleObjects).not.toHaveBeenCalled();
     });
 
-    it('should return empty result when non-super-admin has no common administrations with target user', async () => {
+    it('should throw 403 when non-super-admin has no common administrations with target user', async () => {
       const mockUser = UserFactory.build({ id: 'target-user-123' });
 
       mockUserRepository.getById.mockResolvedValue(mockUser);
@@ -2554,26 +2554,27 @@ describe('AdministrationService', () => {
         .mockResolvedValueOnce(['admin-1', 'admin-2'].map((id) => `administration:${id}`))
         .mockResolvedValueOnce(['admin-3', 'admin-4'].map((id) => `administration:${id}`));
 
-      mockAdministrationRepository.getByIds.mockResolvedValue({
-        items: [],
-        totalItems: 0,
-      });
-
       const service = AdministrationService({
         administrationRepository: mockAdministrationRepository,
         userRepository: mockUserRepository,
         authorizationService: mockAuthorizationService,
       });
 
-      const result = await service.getUserAdministrations(
-        { userId: 'requester-user-456', isSuperAdmin: false },
-        'target-user-123',
-        { page: 1, perPage: 25, sortBy: 'createdAt', sortOrder: 'desc' },
-      );
+      await expect(
+        service.getUserAdministrations({ userId: 'requester-user-456', isSuperAdmin: false }, 'target-user-123', {
+          page: 1,
+          perPage: 25,
+          sortBy: 'createdAt',
+          sortOrder: 'desc',
+        }),
+      ).rejects.toMatchObject({
+        statusCode: 403,
+        message: ApiErrorMessage.FORBIDDEN,
+        code: ApiErrorCode.AUTH_FORBIDDEN,
+      });
 
-      expect(mockAdministrationRepository.getByIds).toHaveBeenCalledWith([], expect.any(Object));
-      expect(result.items).toEqual([]);
-      expect(result.totalItems).toBe(0);
+      expect(mockAuthorizationService.listAccessibleObjects).toHaveBeenCalledTimes(2);
+      expect(mockAdministrationRepository.getByIds).not.toHaveBeenCalled();
     });
 
     it('should include stats embed for super admin when requested', async () => {

--- a/apps/backend/src/services/administration/administration.service.test.ts
+++ b/apps/backend/src/services/administration/administration.service.test.ts
@@ -2376,4 +2376,327 @@ describe('AdministrationService', () => {
       );
     });
   });
+
+  describe('getUserAdministrations', () => {
+    it('should return administrations for super admin without filtering by requester permissions', async () => {
+      const mockAdmins = AdministrationFactory.buildList(3);
+
+      mockAuthorizationService.listAccessibleObjects.mockResolvedValue(mockAdmins.map((a) => `administration:${a.id}`));
+      mockAdministrationRepository.getByIds.mockResolvedValue({
+        items: mockAdmins,
+        totalItems: 3,
+      });
+
+      const service = AdministrationService({
+        administrationRepository: mockAdministrationRepository,
+        authorizationService: mockAuthorizationService,
+      });
+
+      const result = await service.getUserAdministrations(
+        { userId: 'super-admin', isSuperAdmin: true },
+        'target-user-123',
+        { page: 1, perPage: 25, sortBy: 'createdAt', sortOrder: 'desc' },
+      );
+
+      expect(mockAuthorizationService.listAccessibleObjects).toHaveBeenCalledWith(
+        'target-user-123',
+        'can_list',
+        'administration',
+      );
+      expect(mockAdministrationRepository.getByIds).toHaveBeenCalledWith(
+        mockAdmins.map((a) => a.id),
+        expect.objectContaining({ page: 1, perPage: 25 }),
+      );
+      expect(result.items).toHaveLength(3);
+      expect(result.totalItems).toBe(3);
+    });
+
+    it('should filter administrations by intersection of target and requester permissions for non-super-admin', async () => {
+      const mockAdmins = ['admin-2', 'admin-3'].map((id) => AdministrationFactory.build({ id }));
+
+      mockAuthorizationService.listAccessibleObjects
+        .mockResolvedValueOnce(['admin-1', 'admin-2', 'admin-3'].map((id) => `administration:${id}`))
+        .mockResolvedValueOnce(['admin-2', 'admin-3', 'admin-4'].map((id) => `administration:${id}`));
+
+      mockAdministrationRepository.getByIds.mockResolvedValue({
+        items: mockAdmins,
+        totalItems: 2,
+      });
+
+      const service = AdministrationService({
+        administrationRepository: mockAdministrationRepository,
+        authorizationService: mockAuthorizationService,
+      });
+
+      const result = await service.getUserAdministrations(
+        { userId: 'requester-user-456', isSuperAdmin: false },
+        'target-user-123',
+        { page: 1, perPage: 25, sortBy: 'createdAt', sortOrder: 'desc' },
+      );
+
+      expect(mockAuthorizationService.listAccessibleObjects).toHaveBeenCalledTimes(2);
+      expect(mockAuthorizationService.listAccessibleObjects).toHaveBeenNthCalledWith(
+        1,
+        'target-user-123',
+        'can_list',
+        'administration',
+      );
+      expect(mockAuthorizationService.listAccessibleObjects).toHaveBeenNthCalledWith(
+        2,
+        'requester-user-456',
+        'can_list',
+        'administration',
+      );
+      expect(mockAdministrationRepository.getByIds).toHaveBeenCalledWith(
+        ['admin-2', 'admin-3'],
+        expect.objectContaining({ page: 1, perPage: 25 }),
+      );
+      expect(result.items).toHaveLength(2);
+      expect(result.totalItems).toBe(2);
+    });
+
+    it('should return empty result when target user has no accessible administrations', async () => {
+      mockAuthorizationService.listAccessibleObjects.mockResolvedValue([]);
+
+      const service = AdministrationService({
+        administrationRepository: mockAdministrationRepository,
+        authorizationService: mockAuthorizationService,
+      });
+
+      const result = await service.getUserAdministrations(
+        { userId: 'requester-user', isSuperAdmin: false },
+        'target-user-123',
+        { page: 1, perPage: 25, sortBy: 'createdAt', sortOrder: 'desc' },
+      );
+
+      expect(mockAuthorizationService.listAccessibleObjects).toHaveBeenCalledWith(
+        'target-user-123',
+        'can_list',
+        'administration',
+      );
+      expect(mockAdministrationRepository.getByIds).not.toHaveBeenCalled();
+      expect(result.items).toEqual([]);
+      expect(result.totalItems).toBe(0);
+    });
+
+    it('should return empty result when non-super-admin has no common administrations with target user', async () => {
+      mockAuthorizationService.listAccessibleObjects
+        .mockResolvedValueOnce(['admin-1', 'admin-2'].map((id) => `administration:${id}`))
+        .mockResolvedValueOnce(['admin-3', 'admin-4'].map((id) => `administration:${id}`));
+
+      mockAdministrationRepository.getByIds.mockResolvedValue({
+        items: [],
+        totalItems: 0,
+      });
+
+      const service = AdministrationService({
+        administrationRepository: mockAdministrationRepository,
+        authorizationService: mockAuthorizationService,
+      });
+
+      const result = await service.getUserAdministrations(
+        { userId: 'requester-user-456', isSuperAdmin: false },
+        'target-user-123',
+        { page: 1, perPage: 25, sortBy: 'createdAt', sortOrder: 'desc' },
+      );
+
+      expect(mockAdministrationRepository.getByIds).toHaveBeenCalledWith([], expect.any(Object));
+      expect(result.items).toEqual([]);
+      expect(result.totalItems).toBe(0);
+    });
+
+    it('should include stats embed for super admin when requested', async () => {
+      const mockAdmin = AdministrationFactory.build({ id: 'admin-1' });
+
+      mockAuthorizationService.listAccessibleObjects.mockResolvedValue([`administration:${mockAdmin.id}`]);
+      mockAdministrationRepository.getByIds.mockResolvedValue({
+        items: [mockAdmin],
+        totalItems: 1,
+      });
+      mockAdministrationRepository.getAssignedUserCountsByAdministrationIds.mockResolvedValue(
+        new Map([[mockAdmin.id, 10]]),
+      );
+      mockRunRepository.getRunStatsByAdministrationIds.mockResolvedValue(
+        new Map([[mockAdmin.id, { started: 5, completed: 3 }]]),
+      );
+
+      const service = AdministrationService({
+        administrationRepository: mockAdministrationRepository,
+        runRepository: mockRunRepository,
+        authorizationService: mockAuthorizationService,
+      });
+
+      const result = await service.getUserAdministrations(
+        { userId: 'super-admin', isSuperAdmin: true },
+        'target-user-123',
+        { page: 1, perPage: 25, sortBy: 'createdAt', sortOrder: 'desc', embed: ['stats'] },
+      );
+
+      expect(mockAdministrationRepository.getAssignedUserCountsByAdministrationIds).toHaveBeenCalledWith([
+        mockAdmin.id,
+      ]);
+      expect(mockRunRepository.getRunStatsByAdministrationIds).toHaveBeenCalledWith([mockAdmin.id]);
+      expect(result.items[0]).toHaveProperty('stats');
+      expect(result.items[0]!.stats).toEqual({ assigned: 10, started: 5, completed: 3 });
+    });
+
+    it('should not include stats embed for non-super-admin even when requested', async () => {
+      const mockAdmin = AdministrationFactory.build({ id: 'admin-1' });
+
+      mockAuthorizationService.listAccessibleObjects
+        .mockResolvedValueOnce([`administration:${mockAdmin.id}`])
+        .mockResolvedValueOnce([`administration:${mockAdmin.id}`]);
+
+      mockAdministrationRepository.getByIds.mockResolvedValue({
+        items: [mockAdmin],
+        totalItems: 1,
+      });
+
+      const service = AdministrationService({
+        administrationRepository: mockAdministrationRepository,
+        runRepository: mockRunRepository,
+        authorizationService: mockAuthorizationService,
+      });
+
+      const result = await service.getUserAdministrations(
+        { userId: 'requester-user-456', isSuperAdmin: false },
+        'target-user-123',
+        { page: 1, perPage: 25, sortBy: 'createdAt', sortOrder: 'desc', embed: ['stats'] },
+      );
+
+      expect(mockAdministrationRepository.getAssignedUserCountsByAdministrationIds).not.toHaveBeenCalled();
+      expect(mockRunRepository.getRunStatsByAdministrationIds).not.toHaveBeenCalled();
+      expect(result.items[0]).not.toHaveProperty('stats');
+    });
+
+    it('should include tasks embed when requested', async () => {
+      const mockAdmin = AdministrationFactory.build({ id: 'admin-1' });
+
+      mockAuthorizationService.listAccessibleObjects.mockResolvedValue([`administration:${mockAdmin.id}`]);
+      mockAdministrationRepository.getByIds.mockResolvedValue({
+        items: [mockAdmin],
+        totalItems: 1,
+      });
+      mockAdministrationTaskVariantRepository.getByAdministrationIds.mockResolvedValue(
+        new Map([
+          [
+            mockAdmin.id,
+            [{ taskId: 'task-1', taskName: 'Task 1', variantId: 'variant-1', variantName: 'Variant 1', orderIndex: 0 }],
+          ],
+        ]),
+      );
+
+      const service = AdministrationService({
+        administrationRepository: mockAdministrationRepository,
+        administrationTaskVariantRepository: mockAdministrationTaskVariantRepository,
+        authorizationService: mockAuthorizationService,
+      });
+
+      const result = await service.getUserAdministrations(
+        { userId: 'super-admin', isSuperAdmin: true },
+        'target-user-123',
+        { page: 1, perPage: 25, sortBy: 'createdAt', sortOrder: 'desc', embed: ['tasks'] },
+      );
+
+      expect(mockAdministrationTaskVariantRepository.getByAdministrationIds).toHaveBeenCalledWith([mockAdmin.id]);
+      expect(result.items[0]).toHaveProperty('tasks');
+      expect(result.items[0]!.tasks).toEqual([
+        { taskId: 'task-1', taskName: 'Task 1', variantId: 'variant-1', variantName: 'Variant 1', orderIndex: 0 },
+      ]);
+    });
+
+    it('should include both stats and tasks embeds when requested by super admin', async () => {
+      const mockAdmin = AdministrationFactory.build({ id: 'admin-1' });
+
+      mockAuthorizationService.listAccessibleObjects.mockResolvedValue([`administration:${mockAdmin.id}`]);
+      mockAdministrationRepository.getByIds.mockResolvedValue({
+        items: [mockAdmin],
+        totalItems: 1,
+      });
+      mockAdministrationRepository.getAssignedUserCountsByAdministrationIds.mockResolvedValue(
+        new Map([[mockAdmin.id, 10]]),
+      );
+      mockRunRepository.getRunStatsByAdministrationIds.mockResolvedValue(
+        new Map([[mockAdmin.id, { started: 5, completed: 3 }]]),
+      );
+      mockAdministrationTaskVariantRepository.getByAdministrationIds.mockResolvedValue(
+        new Map([
+          [
+            mockAdmin.id,
+            [{ taskId: 'task-1', taskName: 'Task 1', variantId: 'variant-1', variantName: 'Variant 1', orderIndex: 0 }],
+          ],
+        ]),
+      );
+
+      const service = AdministrationService({
+        administrationRepository: mockAdministrationRepository,
+        runRepository: mockRunRepository,
+        administrationTaskVariantRepository: mockAdministrationTaskVariantRepository,
+        authorizationService: mockAuthorizationService,
+      });
+
+      const result = await service.getUserAdministrations(
+        { userId: 'super-admin', isSuperAdmin: true },
+        'target-user-123',
+        { page: 1, perPage: 25, sortBy: 'createdAt', sortOrder: 'desc', embed: ['stats', 'tasks'] },
+      );
+
+      expect(result.items[0]).toHaveProperty('stats');
+      expect(result.items[0]).toHaveProperty('tasks');
+      expect(result.items[0]!.stats).toEqual({ assigned: 10, started: 5, completed: 3 });
+      expect(result.items[0]!.tasks).toEqual([
+        { taskId: 'task-1', taskName: 'Task 1', variantId: 'variant-1', variantName: 'Variant 1', orderIndex: 0 },
+      ]);
+    });
+
+    it('should apply status filter when provided', async () => {
+      const mockAdmins = AdministrationFactory.buildList(2);
+
+      mockAuthorizationService.listAccessibleObjects.mockResolvedValue(mockAdmins.map((a) => `administration:${a.id}`));
+      mockAdministrationRepository.getByIds.mockResolvedValue({
+        items: mockAdmins,
+        totalItems: 2,
+      });
+
+      const service = AdministrationService({
+        administrationRepository: mockAdministrationRepository,
+        authorizationService: mockAuthorizationService,
+      });
+
+      await service.getUserAdministrations({ userId: 'super-admin', isSuperAdmin: true }, 'target-user-123', {
+        page: 1,
+        perPage: 25,
+        sortBy: 'createdAt',
+        sortOrder: 'desc',
+        status: 'active',
+      });
+
+      expect(mockAdministrationRepository.getByIds).toHaveBeenCalledWith(
+        mockAdmins.map((a) => a.id),
+        expect.objectContaining({ status: 'active' }),
+      );
+    });
+
+    it('should throw internal error on database failure', async () => {
+      mockAuthorizationService.listAccessibleObjects.mockRejectedValue(new Error('Database connection lost'));
+
+      const service = AdministrationService({
+        administrationRepository: mockAdministrationRepository,
+        authorizationService: mockAuthorizationService,
+      });
+
+      await expect(
+        service.getUserAdministrations({ userId: 'super-admin', isSuperAdmin: true }, 'target-user-123', {
+          page: 1,
+          perPage: 25,
+          sortBy: 'createdAt',
+          sortOrder: 'desc',
+        }),
+      ).rejects.toMatchObject({
+        statusCode: 500,
+        message: ApiErrorMessage.INTERNAL_SERVER_ERROR,
+        code: ApiErrorCode.DATABASE_QUERY_FAILED,
+      });
+    });
+  });
 });

--- a/apps/backend/src/services/administration/administration.service.test.ts
+++ b/apps/backend/src/services/administration/administration.service.test.ts
@@ -2378,6 +2378,38 @@ describe('AdministrationService', () => {
   });
 
   describe('getUserAdministrations', () => {
+    it('should delegate to list() when user requests their own administrations (self-access)', async () => {
+      const mockAdmins = AdministrationFactory.buildList(2);
+
+      mockAuthorizationService.listAccessibleObjects.mockResolvedValue(mockAdmins.map((a) => `administration:${a.id}`));
+      mockAdministrationRepository.getByIds.mockResolvedValue({
+        items: mockAdmins,
+        totalItems: 2,
+      });
+
+      const service = AdministrationService({
+        administrationRepository: mockAdministrationRepository,
+        authorizationService: mockAuthorizationService,
+      });
+
+      const result = await service.getUserAdministrations({ userId: 'user-123', isSuperAdmin: false }, 'user-123', {
+        page: 1,
+        perPage: 25,
+        sortBy: 'createdAt',
+        sortOrder: 'desc',
+      });
+
+      // Should only call FGA once (for the requester, not separately for target)
+      expect(mockAuthorizationService.listAccessibleObjects).toHaveBeenCalledTimes(1);
+      expect(mockAuthorizationService.listAccessibleObjects).toHaveBeenCalledWith(
+        'user-123',
+        'can_list',
+        'administration',
+      );
+      expect(result.items).toHaveLength(2);
+      expect(result.totalItems).toBe(2);
+    });
+
     it('should return administrations for super admin without filtering by requester permissions', async () => {
       const mockAdmins = AdministrationFactory.buildList(3);
 

--- a/apps/backend/src/services/administration/administration.service.test.ts
+++ b/apps/backend/src/services/administration/administration.service.test.ts
@@ -2412,7 +2412,9 @@ describe('AdministrationService', () => {
 
     it('should return administrations for super admin without filtering by requester permissions', async () => {
       const mockAdmins = AdministrationFactory.buildList(3);
+      const mockUser = UserFactory.build({ id: 'target-user-123' });
 
+      mockUserRepository.getById.mockResolvedValue(mockUser);
       mockAuthorizationService.listAccessibleObjects.mockResolvedValue(mockAdmins.map((a) => `administration:${a.id}`));
       mockAdministrationRepository.getByIds.mockResolvedValue({
         items: mockAdmins,
@@ -2421,6 +2423,7 @@ describe('AdministrationService', () => {
 
       const service = AdministrationService({
         administrationRepository: mockAdministrationRepository,
+        userRepository: mockUserRepository,
         authorizationService: mockAuthorizationService,
       });
 
@@ -2445,7 +2448,9 @@ describe('AdministrationService', () => {
 
     it('should filter administrations by intersection of target and requester permissions for non-super-admin', async () => {
       const mockAdmins = ['admin-2', 'admin-3'].map((id) => AdministrationFactory.build({ id }));
+      const mockUser = UserFactory.build({ id: 'target-user-123' });
 
+      mockUserRepository.getById.mockResolvedValue(mockUser);
       mockAuthorizationService.listAccessibleObjects
         .mockResolvedValueOnce(['admin-1', 'admin-2', 'admin-3'].map((id) => `administration:${id}`))
         .mockResolvedValueOnce(['admin-2', 'admin-3', 'admin-4'].map((id) => `administration:${id}`));
@@ -2457,6 +2462,7 @@ describe('AdministrationService', () => {
 
       const service = AdministrationService({
         administrationRepository: mockAdministrationRepository,
+        userRepository: mockUserRepository,
         authorizationService: mockAuthorizationService,
       });
 
@@ -2488,10 +2494,14 @@ describe('AdministrationService', () => {
     });
 
     it('should return empty result when target user has no accessible administrations', async () => {
+      const mockUser = UserFactory.build({ id: 'target-user-123' });
+
+      mockUserRepository.getById.mockResolvedValue(mockUser);
       mockAuthorizationService.listAccessibleObjects.mockResolvedValue([]);
 
       const service = AdministrationService({
         administrationRepository: mockAdministrationRepository,
+        userRepository: mockUserRepository,
         authorizationService: mockAuthorizationService,
       });
 
@@ -2511,7 +2521,35 @@ describe('AdministrationService', () => {
       expect(result.totalItems).toBe(0);
     });
 
+    it('should throw 404 when target user does not exist', async () => {
+      mockUserRepository.getById.mockResolvedValue(null);
+
+      const service = AdministrationService({
+        userRepository: mockUserRepository,
+        authorizationService: mockAuthorizationService,
+      });
+
+      await expect(
+        service.getUserAdministrations({ userId: 'requester-user-456', isSuperAdmin: false }, 'non-existent-user', {
+          page: 1,
+          perPage: 25,
+          sortBy: 'createdAt',
+          sortOrder: 'desc',
+        }),
+      ).rejects.toMatchObject({
+        statusCode: 404,
+        message: ApiErrorMessage.NOT_FOUND,
+        code: ApiErrorCode.RESOURCE_NOT_FOUND,
+      });
+
+      expect(mockUserRepository.getById).toHaveBeenCalledWith({ id: 'non-existent-user' });
+      expect(mockAuthorizationService.listAccessibleObjects).not.toHaveBeenCalled();
+    });
+
     it('should return empty result when non-super-admin has no common administrations with target user', async () => {
+      const mockUser = UserFactory.build({ id: 'target-user-123' });
+
+      mockUserRepository.getById.mockResolvedValue(mockUser);
       mockAuthorizationService.listAccessibleObjects
         .mockResolvedValueOnce(['admin-1', 'admin-2'].map((id) => `administration:${id}`))
         .mockResolvedValueOnce(['admin-3', 'admin-4'].map((id) => `administration:${id}`));
@@ -2523,6 +2561,7 @@ describe('AdministrationService', () => {
 
       const service = AdministrationService({
         administrationRepository: mockAdministrationRepository,
+        userRepository: mockUserRepository,
         authorizationService: mockAuthorizationService,
       });
 
@@ -2539,7 +2578,9 @@ describe('AdministrationService', () => {
 
     it('should include stats embed for super admin when requested', async () => {
       const mockAdmin = AdministrationFactory.build({ id: 'admin-1' });
+      const mockUser = UserFactory.build({ id: 'target-user-123' });
 
+      mockUserRepository.getById.mockResolvedValue(mockUser);
       mockAuthorizationService.listAccessibleObjects.mockResolvedValue([`administration:${mockAdmin.id}`]);
       mockAdministrationRepository.getByIds.mockResolvedValue({
         items: [mockAdmin],
@@ -2555,6 +2596,7 @@ describe('AdministrationService', () => {
       const service = AdministrationService({
         administrationRepository: mockAdministrationRepository,
         runRepository: mockRunRepository,
+        userRepository: mockUserRepository,
         authorizationService: mockAuthorizationService,
       });
 
@@ -2574,7 +2616,9 @@ describe('AdministrationService', () => {
 
     it('should not include stats embed for non-super-admin even when requested', async () => {
       const mockAdmin = AdministrationFactory.build({ id: 'admin-1' });
+      const mockUser = UserFactory.build({ id: 'target-user-123' });
 
+      mockUserRepository.getById.mockResolvedValue(mockUser);
       mockAuthorizationService.listAccessibleObjects
         .mockResolvedValueOnce([`administration:${mockAdmin.id}`])
         .mockResolvedValueOnce([`administration:${mockAdmin.id}`]);
@@ -2587,6 +2631,7 @@ describe('AdministrationService', () => {
       const service = AdministrationService({
         administrationRepository: mockAdministrationRepository,
         runRepository: mockRunRepository,
+        userRepository: mockUserRepository,
         authorizationService: mockAuthorizationService,
       });
 
@@ -2603,7 +2648,9 @@ describe('AdministrationService', () => {
 
     it('should include tasks embed when requested', async () => {
       const mockAdmin = AdministrationFactory.build({ id: 'admin-1' });
+      const mockUser = UserFactory.build({ id: 'target-user-123' });
 
+      mockUserRepository.getById.mockResolvedValue(mockUser);
       mockAuthorizationService.listAccessibleObjects.mockResolvedValue([`administration:${mockAdmin.id}`]);
       mockAdministrationRepository.getByIds.mockResolvedValue({
         items: [mockAdmin],
@@ -2621,6 +2668,7 @@ describe('AdministrationService', () => {
       const service = AdministrationService({
         administrationRepository: mockAdministrationRepository,
         administrationTaskVariantRepository: mockAdministrationTaskVariantRepository,
+        userRepository: mockUserRepository,
         authorizationService: mockAuthorizationService,
       });
 
@@ -2639,7 +2687,9 @@ describe('AdministrationService', () => {
 
     it('should include both stats and tasks embeds when requested by super admin', async () => {
       const mockAdmin = AdministrationFactory.build({ id: 'admin-1' });
+      const mockUser = UserFactory.build({ id: 'target-user-123' });
 
+      mockUserRepository.getById.mockResolvedValue(mockUser);
       mockAuthorizationService.listAccessibleObjects.mockResolvedValue([`administration:${mockAdmin.id}`]);
       mockAdministrationRepository.getByIds.mockResolvedValue({
         items: [mockAdmin],
@@ -2664,6 +2714,7 @@ describe('AdministrationService', () => {
         administrationRepository: mockAdministrationRepository,
         runRepository: mockRunRepository,
         administrationTaskVariantRepository: mockAdministrationTaskVariantRepository,
+        userRepository: mockUserRepository,
         authorizationService: mockAuthorizationService,
       });
 
@@ -2683,7 +2734,9 @@ describe('AdministrationService', () => {
 
     it('should apply status filter when provided', async () => {
       const mockAdmins = AdministrationFactory.buildList(2);
+      const mockUser = UserFactory.build({ id: 'target-user-123' });
 
+      mockUserRepository.getById.mockResolvedValue(mockUser);
       mockAuthorizationService.listAccessibleObjects.mockResolvedValue(mockAdmins.map((a) => `administration:${a.id}`));
       mockAdministrationRepository.getByIds.mockResolvedValue({
         items: mockAdmins,
@@ -2692,6 +2745,7 @@ describe('AdministrationService', () => {
 
       const service = AdministrationService({
         administrationRepository: mockAdministrationRepository,
+        userRepository: mockUserRepository,
         authorizationService: mockAuthorizationService,
       });
 
@@ -2710,10 +2764,14 @@ describe('AdministrationService', () => {
     });
 
     it('should throw internal error on database failure', async () => {
+      const mockUser = UserFactory.build({ id: 'target-user-123' });
+
+      mockUserRepository.getById.mockResolvedValue(mockUser);
       mockAuthorizationService.listAccessibleObjects.mockRejectedValue(new Error('Database connection lost'));
 
       const service = AdministrationService({
         administrationRepository: mockAdministrationRepository,
+        userRepository: mockUserRepository,
         authorizationService: mockAuthorizationService,
       });
 

--- a/apps/backend/src/services/administration/administration.service.ts
+++ b/apps/backend/src/services/administration/administration.service.ts
@@ -758,7 +758,7 @@ export function AdministrationService({
     const { userId: requesterUserId, isSuperAdmin } = authContext;
 
     if (requesterUserId === userId) {
-      return await list(authContext, options);
+      return list(authContext, options);
     }
 
     try {
@@ -793,7 +793,7 @@ export function AdministrationService({
         return { items: [], totalItems: 0 };
       }
       // Fetch administrations based on user role and authorization
-      let result;
+      let result: PaginatedResult<Administration>;
 
       if (isSuperAdmin) {
         result = await administrationRepository.getByIds(targetUserAdminIds, queryParams);
@@ -803,11 +803,23 @@ export function AdministrationService({
           FgaRelation.CAN_LIST,
           FgaType.ADMINISTRATION,
         );
-        const requesterUserAdminIds = requesterUserAdmins.map(extractFgaObjectId);
-        result = await administrationRepository.getByIds(
-          targetUserAdminIds.filter((id) => requesterUserAdminIds.includes(id)),
-          queryParams,
-        );
+        const requesterUserAdminIds = new Set(requesterUserAdmins.map(extractFgaObjectId));
+        const intersectedIds = targetUserAdminIds.filter((id) => requesterUserAdminIds.has(id));
+
+        if (intersectedIds.length === 0) {
+          logger.warn(
+            { requesterUserId, userId },
+            'User attempted to list administrations for user they have no shared access with',
+          );
+
+          throw new ApiError(ApiErrorMessage.FORBIDDEN, {
+            statusCode: StatusCodes.FORBIDDEN,
+            code: ApiErrorCode.AUTH_FORBIDDEN,
+            context: { requesterUserId, targetUserId: userId },
+          });
+        }
+
+        result = await administrationRepository.getByIds(intersectedIds, queryParams);
       }
 
       // If no embeds requested, return as-is
@@ -826,8 +838,8 @@ export function AdministrationService({
       const shouldEmbedTasks = embedOptions.includes(AdministrationEmbedOption.TASKS);
 
       // Fetch embed data (throws on failure)
-      const statsMap = shouldEmbedStats ? await fetchStatsEmbed(administrationIds, userId) : null;
-      const tasksMap = shouldEmbedTasks ? await fetchTasksEmbed(administrationIds, userId) : null;
+      const statsMap = shouldEmbedStats ? await fetchStatsEmbed(administrationIds, requesterUserId) : null;
+      const tasksMap = shouldEmbedTasks ? await fetchTasksEmbed(administrationIds, requesterUserId) : null;
 
       // Attach embeds to each administration
       const itemsWithEmbeds: AdministrationWithEmbeds[] = result.items.map((admin) => {

--- a/apps/backend/src/services/administration/administration.service.ts
+++ b/apps/backend/src/services/administration/administration.service.ts
@@ -734,6 +734,119 @@ export function AdministrationService({
     }
   }
 
+  /**
+   * List administrations accessible to a requester and target user with pagination, sorting, and optional embeds.
+   *
+   * super_admin users have unrestricted access to all administrations.
+   * Other requesters only see target user's administrations they're also assigned to via org/class/group membership.
+   *
+   * **Embed restrictions:**
+   * - `stats`: Only returned for super_admin users (expensive query, sensitive data).
+   *   Non-super-admins requesting stats will receive results without stats silently.
+   * - `tasks`: Available to all users.
+   *
+   * @param authContext - Authentication context
+   * @param userId - User ID to get administrations for
+   * @param options - List options with pagination and embeds
+   * @returns Paginated result with optional embeds (stats, tasks)
+   */
+  async function getUserAdministrations(
+    authContext: AuthContext,
+    userId: string,
+    options: ListOptions,
+  ): Promise<PaginatedResult<AdministrationWithEmbeds>> {
+    const { userId: requesterUserId, isSuperAdmin } = authContext;
+    try {
+      const queryParams = {
+        page: options.page,
+        perPage: options.perPage,
+        orderBy: {
+          field: options.sortBy,
+          direction: options.sortOrder,
+        },
+        ...(options.status && { status: options.status }),
+      };
+
+      const targetUserAdmins = await authorizationService.listAccessibleObjects(
+        userId,
+        FgaRelation.CAN_LIST,
+        FgaType.ADMINISTRATION,
+      );
+      const targetUserAdminIds = targetUserAdmins.map(extractFgaObjectId);
+
+      if (targetUserAdminIds.length === 0) {
+        return { items: [], totalItems: 0 };
+      }
+      // Fetch administrations based on user role and authorization
+      let result;
+
+      if (isSuperAdmin) {
+        result = await administrationRepository.getByIds(targetUserAdminIds, queryParams);
+      } else {
+        const requesterUserAdmins = await authorizationService.listAccessibleObjects(
+          requesterUserId,
+          FgaRelation.CAN_LIST,
+          FgaType.ADMINISTRATION,
+        );
+        const requesterUserAdminIds = requesterUserAdmins.map(extractFgaObjectId);
+        result = await administrationRepository.getByIds(
+          targetUserAdminIds.filter((id) => requesterUserAdminIds.includes(id)),
+          queryParams,
+        );
+      }
+
+      // If no embeds requested, return as-is
+      const embedOptions = options.embed ?? [];
+      if (embedOptions.length === 0) {
+        return result;
+      }
+
+      // Early return if no items to embed data onto
+      if (result.items.length === 0) {
+        return result;
+      }
+
+      const administrationIds = result.items.map((admin) => admin.id);
+      const shouldEmbedStats = isSuperAdmin && embedOptions.includes(AdministrationEmbedOption.STATS);
+      const shouldEmbedTasks = embedOptions.includes(AdministrationEmbedOption.TASKS);
+
+      // Fetch embed data (throws on failure)
+      const statsMap = shouldEmbedStats ? await fetchStatsEmbed(administrationIds, userId) : null;
+      const tasksMap = shouldEmbedTasks ? await fetchTasksEmbed(administrationIds, userId) : null;
+
+      // Attach embeds to each administration
+      const itemsWithEmbeds: AdministrationWithEmbeds[] = result.items.map((admin) => {
+        const adminWithEmbeds: AdministrationWithEmbeds = { ...admin };
+
+        if (statsMap) {
+          adminWithEmbeds.stats = statsMap.get(admin.id) ?? { assigned: 0, started: 0, completed: 0 };
+        }
+
+        if (tasksMap) {
+          adminWithEmbeds.tasks = tasksMap.get(admin.id) ?? [];
+        }
+
+        return adminWithEmbeds;
+      });
+
+      return {
+        items: itemsWithEmbeds,
+        totalItems: result.totalItems,
+      };
+    } catch (error) {
+      if (error instanceof ApiError) throw error;
+
+      logger.error({ err: error, context: { userId } }, 'Failed to get user administrations');
+
+      throw new ApiError(ApiErrorMessage.INTERNAL_SERVER_ERROR, {
+        statusCode: StatusCodes.INTERNAL_SERVER_ERROR,
+        code: ApiErrorCode.DATABASE_QUERY_FAILED,
+        context: { userId },
+        cause: error,
+      });
+    }
+  }
+
   return {
     verifyAdministrationAccess,
     list,
@@ -742,5 +855,6 @@ export function AdministrationService({
     listTaskVariants,
     listAgreements,
     deleteById,
+    getUserAdministrations,
   };
 }

--- a/apps/backend/src/services/administration/administration.service.ts
+++ b/apps/backend/src/services/administration/administration.service.ts
@@ -762,6 +762,16 @@ export function AdministrationService({
     }
 
     try {
+      // Verify target user exists
+      const targetUser = await userRepository.getById({ id: userId });
+
+      if (!targetUser) {
+        throw new ApiError(ApiErrorMessage.NOT_FOUND, {
+          statusCode: StatusCodes.NOT_FOUND,
+          code: ApiErrorCode.RESOURCE_NOT_FOUND,
+          context: { userId },
+        });
+      }
       const queryParams = {
         page: options.page,
         perPage: options.perPage,

--- a/apps/backend/src/services/administration/administration.service.ts
+++ b/apps/backend/src/services/administration/administration.service.ts
@@ -782,7 +782,7 @@ export function AdministrationService({
    * @returns Paginated result with optional embeds (stats, tasks)
    * @throws {ApiError} NOT_FOUND if target user doesn't exist
    * @throws {ApiError} FORBIDDEN if requester lacks access to target user's administrations
-   * @throws {ApiError} INTERNAL_SERVER_ERROR for unexpected error such as database query failures
+   * @throws {ApiError} INTERNAL_SERVER_ERROR if the database operation fails
    */
   async function getUserAdministrations(
     authContext: AuthContext,

--- a/apps/backend/src/services/administration/administration.service.ts
+++ b/apps/backend/src/services/administration/administration.service.ts
@@ -780,6 +780,9 @@ export function AdministrationService({
    * @param userId - User ID to get administrations for
    * @param options - List options with pagination and embeds
    * @returns Paginated result with optional embeds (stats, tasks)
+   * @throws {ApiError} NOT_FOUND if target user doesn't exist
+   * @throws {ApiError} FORBIDDEN if requester lacks access to target user's administrations
+   * @throws {ApiError} INTERNAL_SERVER_ERROR for unexpected error such as database query failures
    */
   async function getUserAdministrations(
     authContext: AuthContext,

--- a/apps/backend/src/services/administration/administration.service.ts
+++ b/apps/backend/src/services/administration/administration.service.ts
@@ -756,6 +756,11 @@ export function AdministrationService({
     options: ListOptions,
   ): Promise<PaginatedResult<AdministrationWithEmbeds>> {
     const { userId: requesterUserId, isSuperAdmin } = authContext;
+
+    if (requesterUserId === userId) {
+      return await list(authContext, options);
+    }
+
     try {
       const queryParams = {
         page: options.page,

--- a/apps/backend/src/test-support/services/administration.service.ts
+++ b/apps/backend/src/test-support/services/administration.service.ts
@@ -15,6 +15,7 @@ export function createMockAdministrationService(): MockedObject<ReturnType<typeo
     listTaskVariants: vi.fn(),
     listAgreements: vi.fn(),
     deleteById: vi.fn(),
+    getUserAdministrations: vi.fn(),
   } as MockedObject<ReturnType<typeof AdministrationService>>;
 }
 

--- a/packages/api-contract/src/v1/users/contract.ts
+++ b/packages/api-contract/src/v1/users/contract.ts
@@ -108,6 +108,7 @@ export const UsersContract = c.router(
       responses: {
         200: SuccessEnvelopeSchema(AdministrationsListResponseSchema),
         401: ErrorEnvelopeSchema,
+        404: ErrorEnvelopeSchema,
         500: ErrorEnvelopeSchema,
       },
       strictStatusCodes: true,
@@ -115,7 +116,8 @@ export const UsersContract = c.router(
       description:
         'Returns a paginated list of administrations the requester and specified user have access to. ' +
         'Use ?status=active|past|upcoming to filter by date status. ' +
-        'Use ?embed=stats to include assignment stats. Use ?embed=tasks to include task variants.',
+        'Use ?embed=stats to include assignment stats. Use ?embed=tasks to include task variants. ' +
+        'Returns 404 if the specified user does not exist.',
     },
   },
   { pathPrefix: '/users' },

--- a/packages/api-contract/src/v1/users/contract.ts
+++ b/packages/api-contract/src/v1/users/contract.ts
@@ -7,6 +7,7 @@ import {
   RecordUserAgreementRequestBodySchema,
   RecordUserAgreementResponseSchema,
 } from './schema';
+import { AdministrationsListQuerySchema, AdministrationsListResponseSchema } from '../administrations/schema';
 
 const c = initContract();
 
@@ -15,6 +16,7 @@ const c = initContract();
  * Provides access to user related data that an authenticated user can view.
  * Provides the ability to update user profile data for authorized users.
  * Provides the ability to manage user agreements (consent records).
+ * Provides the ability to list administrations for a user.
  */
 export const UsersContract = c.router(
   {
@@ -95,6 +97,25 @@ export const UsersContract = c.router(
         'Returns 404 if the user or agreement version does not exist. ' +
         'Returns 409 if the user has already consented to the given agreement version. ' +
         'Returns 500 if an internal server error occurs.',
+    },
+    listUserAdministrations: {
+      method: 'GET',
+      path: '/:userId/administrations',
+      pathParams: z.object({
+        userId: z.string().uuid(),
+      }),
+      query: AdministrationsListQuerySchema,
+      responses: {
+        200: SuccessEnvelopeSchema(AdministrationsListResponseSchema),
+        401: ErrorEnvelopeSchema,
+        500: ErrorEnvelopeSchema,
+      },
+      strictStatusCodes: true,
+      summary: 'List administrations for a user',
+      description:
+        'Returns a paginated list of administrations the requester and specified user have access to. ' +
+        'Use ?status=active|past|upcoming to filter by date status. ' +
+        'Use ?embed=stats to include assignment stats. Use ?embed=tasks to include task variants.',
     },
   },
   { pathPrefix: '/users' },

--- a/packages/api-contract/src/v1/users/contract.ts
+++ b/packages/api-contract/src/v1/users/contract.ts
@@ -108,6 +108,7 @@ export const UsersContract = c.router(
       responses: {
         200: SuccessEnvelopeSchema(AdministrationsListResponseSchema),
         401: ErrorEnvelopeSchema,
+        403: ErrorEnvelopeSchema,
         404: ErrorEnvelopeSchema,
         500: ErrorEnvelopeSchema,
       },
@@ -117,6 +118,7 @@ export const UsersContract = c.router(
         'Returns a paginated list of administrations the requester and specified user have access to. ' +
         'Use ?status=active|past|upcoming to filter by date status. ' +
         'Use ?embed=stats to include assignment stats. Use ?embed=tasks to include task variants. ' +
+        'Returns 403 if the requester does not have access to any administrations for the specified user. ' +
         'Returns 404 if the specified user does not exist.',
     },
   },

--- a/packages/api-contract/src/v1/users/contract.ts
+++ b/packages/api-contract/src/v1/users/contract.ts
@@ -111,7 +111,7 @@ export const UsersContract = c.router(
         500: ErrorEnvelopeSchema,
       },
       strictStatusCodes: true,
-      summary: 'List administrations for a user',
+      summary: 'List administrations for a specified user',
       description:
         'Returns a paginated list of administrations the requester and specified user have access to. ' +
         'Use ?status=active|past|upcoming to filter by date status. ' +


### PR DESCRIPTION
## Proposed changes

<!--
Describe your changes here. Why are they necessary?

If it fixes a bug or resolves a feature request, be sure to link to that issue.

If appropriate, include images of the expected behavior or user experience.
You can drag and drop images into this text box.
-->
### Summary
This PR implements the `GET /v1/users/:userId/administrations`. Users can request other users’ administrations, limited to those the requester also has access to. Results can be filtered by statuses and include additional information via `embed` params. 

###  Features

- Retrieves administrations accessible to specified `userId` and requestor's `userId`
- Returns all `userId` administrations automatically when the requester is a super-admin or `userId === requesterUserId`. For the latter, early return with `list()`. 
- Move `transformAdministrationBase` and `transformAdministration` from `administration.controller.ts` to shared utils file
- Same query and response shapes as `GET /administrations` 
- Pass `embed=tasks` to get tasks assigned to administrations 
- Pass `embed=stats` to get assignment stats. This is a super admin feature. 
- Filter results with `?status=active|past|upcoming`
- Sort by `createdAt`, `name`, `dateStart`, and `dateEnded` (type `AdministrationSortFieldType`) 
- If user does not have access to any of the requested user's administrations, the endpoint throws a 403 

This resolves [issue 1740](https://github.com/yeatmanlab/roar-project-management/issues/1740)

## Types of changes

What types of changes does this pull request introduce?

<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (non-breaking change that does not add functionality but makes code cleaner or more efficient)
- [ ] Documentation Update
- [ ] Tests (new or updated tests)
- [ ] Style (changes to code styling)
- [ ] CI (continuous integration changes)
- [ ] Repository Maintenance
- [ ] Other (please describe below)

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask.  We're here
to help! This is simply a reminder of what we are going to look for before
merging your code.
-->

- [x] I have read the [guidelines for contributing](https://github.com/yeatmanlab/roar-dashboard/blob/main/.github/CONTRIBUTING.md).
- [x] The changes in this PR are as small as they can be. They represent one and only one fix or enhancement.
- [x] Linting checks pass with my changes.
- [x] Any existing unit tests pass with my changes.
- [x] Any existing end-to-end tests pass with my changes.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] If this PR fixes an existing issue, I have added a unit or end-to-end test that will detect if this issue reoccurs.
- [x] I have added JSDoc comments as appropriate.
- [x] I have added the necessary documentation to the [roar-docs repository](https://github.com/yeatmanlab/roar-docs).
- [x] I have shared this PR on the roar-pr-reviews channel (if I have access)
- [x] I have linked relevant issues (if any)

## Justification of missing checklist items

<!--
If you feel that a checklist item above is not applicable to this PR, please
provide your justification here. Otherwise, delete this section.
-->

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
