### PR TITLE
Add `can_create_users` permission

### DIFF
--- a/.ai/knowledge-base.md
+++ b/.ai/knowledge-base.md
@@ -38,13 +38,15 @@ Administrations represent assessment sessions assigned to entities at any level.
 
 All roles come from the `user_role` database enum, derived into TypeScript via `pgEnumToConst()`.
 
-**All roles:** administrator, aide, counselor, district_administrator, guardian, parent, principal, proctor, relative, site_administrator, student, system_administrator, teacher.
+**All roles (14 total — 13 OneRoster + 1 ROAR-specific):** administrator, aide, counselor, district_administrator, guardian, parent, platform_admin, principal, proctor, relative, site_administrator, student, system_administrator, teacher.
+
+`platform_admin` is not part of the OneRoster standard. It is assigned only to users created via CSV upload or the dashboard user creation form, and grants `can_create_users` in addition to standard admin permissions. External providers (Clever, ClassLink, NYCPS) do not write this role.
 
 ### Supervisory vs. supervised
 
 Roles are classified in `apps/backend/src/constants/role-classifications.ts`:
 
-**Supervisory roles** (can see descendant entities): administrator, aide, counselor, district_administrator, principal, proctor, site_administrator, system_administrator, teacher.
+**Supervisory roles** (can see descendant entities): administrator, aide, counselor, district_administrator, platform_admin, principal, proctor, site_administrator, system_administrator, teacher. (`platform_admin` is ROAR-specific, not a OneRoster role.)
 
 **Supervised roles** (can only see ancestor entities): student, guardian, parent, relative.
 

--- a/apps/backend/migrations/core/0062_young_tomas.sql
+++ b/apps/backend/migrations/core/0062_young_tomas.sql
@@ -1,0 +1,1 @@
+ALTER TYPE "app"."user_role" ADD VALUE 'platform_admin' BEFORE 'principal';

--- a/apps/backend/migrations/core/meta/0062_snapshot.json
+++ b/apps/backend/migrations/core/meta/0062_snapshot.json
@@ -1,0 +1,3843 @@
+{
+  "id": "d81a9b31-7ce1-42df-95dc-7483eb72f0e0",
+  "prevId": "ce3ee450-476f-474b-804d-fbdb7edad111",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "app.administrations": {
+      "name": "administrations",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name_public": {
+          "name": "name_public",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date_start": {
+          "name": "date_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date_end": {
+          "name": "date_end",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_ordered": {
+          "name": "is_ordered",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "excluded_from_research": {
+          "name": "excluded_from_research",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "excluded_from_research_by": {
+          "name": "excluded_from_research_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "excluded_from_research_reason": {
+          "name": "excluded_from_research_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "administrations_name_lower_idx": {
+          "name": "administrations_name_lower_idx",
+          "columns": [
+            {
+              "expression": "lower(\"name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "administrations_name_lower_pattern_idx": {
+          "name": "administrations_name_lower_pattern_idx",
+          "columns": [
+            {
+              "expression": "lower(\"name\") text_pattern_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "administrations_name_public_lower_idx": {
+          "name": "administrations_name_public_lower_idx",
+          "columns": [
+            {
+              "expression": "lower(\"name_public\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "administrations_name_public_lower_pattern_idx": {
+          "name": "administrations_name_public_lower_pattern_idx",
+          "columns": [
+            {
+              "expression": "lower(\"name_public\") text_pattern_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "administrations_created_by_idx": {
+          "name": "administrations_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "administrations_date_end_idx": {
+          "name": "administrations_date_end_idx",
+          "columns": [
+            {
+              "expression": "date_end",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "administrations_date_range_idx": {
+          "name": "administrations_date_range_idx",
+          "columns": [
+            {
+              "expression": "date_start",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date_end",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "administrations_name_unique_idx": {
+          "name": "administrations_name_unique_idx",
+          "columns": [
+            {
+              "expression": "lower(\"name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "administrations_excluded_from_research_by_users_id_fk": {
+          "name": "administrations_excluded_from_research_by_users_id_fk",
+          "tableFrom": "administrations",
+          "tableTo": "users",
+          "schemaTo": "app",
+          "columnsFrom": ["excluded_from_research_by"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "administrations_created_by_users_id_fk": {
+          "name": "administrations_created_by_users_id_fk",
+          "tableFrom": "administrations",
+          "tableTo": "users",
+          "schemaTo": "app",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "administrations_date_start_end_check": {
+          "name": "administrations_date_start_end_check",
+          "value": "(\"app\".\"administrations\".\"date_start\" < \"app\".\"administrations\".\"date_end\")"
+        },
+        "administrations_excluded_from_research_required": {
+          "name": "administrations_excluded_from_research_required",
+          "value": "\"app\".\"administrations\".\"excluded_from_research\" IS NULL OR (\"app\".\"administrations\".\"excluded_from_research_by\" IS NOT NULL AND \"app\".\"administrations\".\"excluded_from_research_reason\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "app.administration_agreements": {
+      "name": "administration_agreements",
+      "schema": "app",
+      "columns": {
+        "administration_id": {
+          "name": "administration_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agreement_id": {
+          "name": "agreement_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "administration_agreements_administration_id_administrations_id_fk": {
+          "name": "administration_agreements_administration_id_administrations_id_fk",
+          "tableFrom": "administration_agreements",
+          "tableTo": "administrations",
+          "schemaTo": "app",
+          "columnsFrom": ["administration_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "administration_agreements_agreement_id_agreements_id_fk": {
+          "name": "administration_agreements_agreement_id_agreements_id_fk",
+          "tableFrom": "administration_agreements",
+          "tableTo": "agreements",
+          "schemaTo": "app",
+          "columnsFrom": ["agreement_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "administration_agreements_pkey": {
+          "name": "administration_agreements_pkey",
+          "columns": ["administration_id", "agreement_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.administration_classes": {
+      "name": "administration_classes",
+      "schema": "app",
+      "columns": {
+        "administration_id": {
+          "name": "administration_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "class_id": {
+          "name": "class_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "administration_classes_administration_id_administrations_id_fk": {
+          "name": "administration_classes_administration_id_administrations_id_fk",
+          "tableFrom": "administration_classes",
+          "tableTo": "administrations",
+          "schemaTo": "app",
+          "columnsFrom": ["administration_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "administration_classes_class_id_classes_id_fk": {
+          "name": "administration_classes_class_id_classes_id_fk",
+          "tableFrom": "administration_classes",
+          "tableTo": "classes",
+          "schemaTo": "app",
+          "columnsFrom": ["class_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "administration_classes_pkey": {
+          "name": "administration_classes_pkey",
+          "columns": ["administration_id", "class_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.administration_groups": {
+      "name": "administration_groups",
+      "schema": "app",
+      "columns": {
+        "administration_id": {
+          "name": "administration_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "administration_groups_administration_id_administrations_id_fk": {
+          "name": "administration_groups_administration_id_administrations_id_fk",
+          "tableFrom": "administration_groups",
+          "tableTo": "administrations",
+          "schemaTo": "app",
+          "columnsFrom": ["administration_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "administration_groups_group_id_groups_id_fk": {
+          "name": "administration_groups_group_id_groups_id_fk",
+          "tableFrom": "administration_groups",
+          "tableTo": "groups",
+          "schemaTo": "app",
+          "columnsFrom": ["group_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "administration_groups_pkey": {
+          "name": "administration_groups_pkey",
+          "columns": ["administration_id", "group_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.administration_orgs": {
+      "name": "administration_orgs",
+      "schema": "app",
+      "columns": {
+        "administration_id": {
+          "name": "administration_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "administration_orgs_administration_id_administrations_id_fk": {
+          "name": "administration_orgs_administration_id_administrations_id_fk",
+          "tableFrom": "administration_orgs",
+          "tableTo": "administrations",
+          "schemaTo": "app",
+          "columnsFrom": ["administration_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "administration_orgs_org_id_orgs_id_fk": {
+          "name": "administration_orgs_org_id_orgs_id_fk",
+          "tableFrom": "administration_orgs",
+          "tableTo": "orgs",
+          "schemaTo": "app",
+          "columnsFrom": ["org_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "administration_orgs_pkey": {
+          "name": "administration_orgs_pkey",
+          "columns": ["administration_id", "org_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.administration_task_variants": {
+      "name": "administration_task_variants",
+      "schema": "app",
+      "columns": {
+        "administration_id": {
+          "name": "administration_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "task_variant_id": {
+          "name": "task_variant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "order_index": {
+          "name": "order_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conditions_assignment": {
+          "name": "conditions_assignment",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "conditions_requirements": {
+          "name": "conditions_requirements",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "administration_task_variants_administration_id_order_index_idx": {
+          "name": "administration_task_variants_administration_id_order_index_idx",
+          "columns": [
+            {
+              "expression": "administration_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "order_index",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "administration_task_variants_task_variant_id_idx": {
+          "name": "administration_task_variants_task_variant_id_idx",
+          "columns": [
+            {
+              "expression": "task_variant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "administration_task_variants_admin_order_unique_idx": {
+          "name": "administration_task_variants_admin_order_unique_idx",
+          "columns": [
+            {
+              "expression": "administration_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "order_index",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "administration_task_variants_administration_id_administrations_id_fk": {
+          "name": "administration_task_variants_administration_id_administrations_id_fk",
+          "tableFrom": "administration_task_variants",
+          "tableTo": "administrations",
+          "schemaTo": "app",
+          "columnsFrom": ["administration_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "administration_task_variants_task_variant_id_task_variants_id_fk": {
+          "name": "administration_task_variants_task_variant_id_task_variants_id_fk",
+          "tableFrom": "administration_task_variants",
+          "tableTo": "task_variants",
+          "schemaTo": "app",
+          "columnsFrom": ["task_variant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "administration_task_variants_pkey": {
+          "name": "administration_task_variants_pkey",
+          "columns": ["administration_id", "task_variant_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.agreements": {
+      "name": "agreements",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agreement_type": {
+          "name": "agreement_type",
+          "type": "agreement_type",
+          "typeSchema": "app",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agreements_name_lower_idx": {
+          "name": "agreements_name_lower_idx",
+          "columns": [
+            {
+              "expression": "lower(\"name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agreements_name_lower_pattern_idx": {
+          "name": "agreements_name_lower_pattern_idx",
+          "columns": [
+            {
+              "expression": "lower(\"name\") text_pattern_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agreements_type_idx": {
+          "name": "agreements_type_idx",
+          "columns": [
+            {
+              "expression": "agreement_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.agreement_versions": {
+      "name": "agreement_versions",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "agreement_id": {
+          "name": "agreement_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_current": {
+          "name": "is_current",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "locale": {
+          "name": "locale",
+          "type": "varchar(5)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "github_filename": {
+          "name": "github_filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "github_org_repo": {
+          "name": "github_org_repo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "github_commit_sha": {
+          "name": "github_commit_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agreement_versions_current_unique_idx": {
+          "name": "agreement_versions_current_unique_idx",
+          "columns": [
+            {
+              "expression": "agreement_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "locale",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"app\".\"agreement_versions\".\"is_current\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agreement_versions_identity_unique_idx": {
+          "name": "agreement_versions_identity_unique_idx",
+          "columns": [
+            {
+              "expression": "agreement_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "locale",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "github_commit_sha",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agreement_versions_agreement_id_idx": {
+          "name": "agreement_versions_agreement_id_idx",
+          "columns": [
+            {
+              "expression": "agreement_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agreement_versions_current_idx": {
+          "name": "agreement_versions_current_idx",
+          "columns": [
+            {
+              "expression": "is_current",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "agreement_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agreement_versions_current_locale_idx": {
+          "name": "agreement_versions_current_locale_idx",
+          "columns": [
+            {
+              "expression": "is_current",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "locale",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "agreement_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agreement_versions_agreement_id_agreements_id_fk": {
+          "name": "agreement_versions_agreement_id_agreements_id_fk",
+          "tableFrom": "agreement_versions",
+          "tableTo": "agreements",
+          "schemaTo": "app",
+          "columnsFrom": ["agreement_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "agreement_versions_locale_format": {
+          "name": "agreement_versions_locale_format",
+          "value": "\"app\".\"agreement_versions\".\"locale\" ~ '^[a-z]{2}(-[A-Z]{2})?$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "app.classes": {
+      "name": "classes",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "district_id": {
+          "name": "district_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "course_id": {
+          "name": "course_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "org_path": {
+          "name": "org_path",
+          "type": "ltree",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "class_type": {
+          "name": "class_type",
+          "type": "class_type",
+          "typeSchema": "app",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "number": {
+          "name": "number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "period": {
+          "name": "period",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "term_id": {
+          "name": "term_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subjects": {
+          "name": "subjects",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grades": {
+          "name": "grades",
+          "type": "grade[]",
+          "typeSchema": "app",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "school_levels": {
+          "name": "school_levels",
+          "type": "school_level[]",
+          "typeSchema": "app",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "app.get_school_levels_from_grades_array(grades)",
+            "type": "stored"
+          }
+        },
+        "rostering_ended": {
+          "name": "rostering_ended",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "classes_district_idx": {
+          "name": "classes_district_idx",
+          "columns": [
+            {
+              "expression": "district_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "classes_course_idx": {
+          "name": "classes_course_idx",
+          "columns": [
+            {
+              "expression": "course_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "classes_org_path_gist_idx": {
+          "name": "classes_org_path_gist_idx",
+          "columns": [
+            {
+              "expression": "org_path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gist",
+          "with": {}
+        },
+        "classes_name_lower_idx": {
+          "name": "classes_name_lower_idx",
+          "columns": [
+            {
+              "expression": "lower(\"name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "classes_name_lower_pattern_idx": {
+          "name": "classes_name_lower_pattern_idx",
+          "columns": [
+            {
+              "expression": "lower(\"name\") text_pattern_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "classes_school_id_orgs_id_fk": {
+          "name": "classes_school_id_orgs_id_fk",
+          "tableFrom": "classes",
+          "tableTo": "orgs",
+          "schemaTo": "app",
+          "columnsFrom": ["school_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "classes_district_id_orgs_id_fk": {
+          "name": "classes_district_id_orgs_id_fk",
+          "tableFrom": "classes",
+          "tableTo": "orgs",
+          "schemaTo": "app",
+          "columnsFrom": ["district_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "classes_course_id_courses_id_fk": {
+          "name": "classes_course_id_courses_id_fk",
+          "tableFrom": "classes",
+          "tableTo": "courses",
+          "schemaTo": "app",
+          "columnsFrom": ["course_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.courses": {
+      "name": "courses",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "number": {
+          "name": "number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "courses_org_name_lower_uniqIdx": {
+          "name": "courses_org_name_lower_uniqIdx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lower(\"name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "courses_org_number_uniqIdx": {
+          "name": "courses_org_number_uniqIdx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "courses_name_lower_idx": {
+          "name": "courses_name_lower_idx",
+          "columns": [
+            {
+              "expression": "lower(\"name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "courses_name_lower_pattern_idx": {
+          "name": "courses_name_lower_pattern_idx",
+          "columns": [
+            {
+              "expression": "lower(\"name\") text_pattern_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "courses_org_id_orgs_id_fk": {
+          "name": "courses_org_id_orgs_id_fk",
+          "tableFrom": "courses",
+          "tableTo": "orgs",
+          "schemaTo": "app",
+          "columnsFrom": ["org_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.families": {
+      "name": "families",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "location_address_line1": {
+          "name": "location_address_line1",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location_address_line2": {
+          "name": "location_address_line2",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location_city": {
+          "name": "location_city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location_state_province": {
+          "name": "location_state_province",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location_postal_code": {
+          "name": "location_postal_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location_country": {
+          "name": "location_country",
+          "type": "varchar(2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location_lat_long": {
+          "name": "location_lat_long",
+          "type": "point",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rostering_ended": {
+          "name": "rostering_ended",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.groups": {
+      "name": "groups",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "abbreviation": {
+          "name": "abbreviation",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_type": {
+          "name": "group_type",
+          "type": "group_type",
+          "typeSchema": "app",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_address_line1": {
+          "name": "location_address_line1",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location_address_line2": {
+          "name": "location_address_line2",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location_city": {
+          "name": "location_city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location_state_province": {
+          "name": "location_state_province",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location_postal_code": {
+          "name": "location_postal_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location_country": {
+          "name": "location_country",
+          "type": "varchar(2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location_lat_long": {
+          "name": "location_lat_long",
+          "type": "point",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rostering_ended": {
+          "name": "rostering_ended",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "groups_name_lower_idx": {
+          "name": "groups_name_lower_idx",
+          "columns": [
+            {
+              "expression": "lower(\"name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "groups_name_lower_pattern_idx": {
+          "name": "groups_name_lower_pattern_idx",
+          "columns": [
+            {
+              "expression": "lower(\"name\") text_pattern_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "groups_abbreviation_format": {
+          "name": "groups_abbreviation_format",
+          "value": "\"app\".\"groups\".\"abbreviation\" ~ '^[A-Za-z0-9]+$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "app.invitation_codes": {
+      "name": "invitation_codes",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "valid_from": {
+          "name": "valid_from",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "valid_to": {
+          "name": "valid_to",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "invitation_codes_group_idx": {
+          "name": "invitation_codes_group_idx",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invitation_codes_group_id_groups_id_fk": {
+          "name": "invitation_codes_group_id_groups_id_fk",
+          "tableFrom": "invitation_codes",
+          "tableTo": "groups",
+          "schemaTo": "app",
+          "columnsFrom": ["group_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "invitation_codes_code_unique": {
+          "name": "invitation_codes_code_unique",
+          "nullsNotDistinct": false,
+          "columns": ["code"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "invitation_codes_valid_range": {
+          "name": "invitation_codes_valid_range",
+          "value": "\"app\".\"invitation_codes\".\"valid_to\" IS NULL OR \"app\".\"invitation_codes\".\"valid_to\" > \"app\".\"invitation_codes\".\"valid_from\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "app.run_demographics": {
+      "name": "run_demographics",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status_ell": {
+          "name": "status_ell",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_frl": {
+          "name": "status_frl",
+          "type": "free_reduced_lunch_status",
+          "typeSchema": "app",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_iep": {
+          "name": "status_iep",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gender": {
+          "name": "gender",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "race": {
+          "name": "race",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hispanic_ethnicity": {
+          "name": "hispanic_ethnicity",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "home_language": {
+          "name": "home_language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "age_in_months": {
+          "name": "age_in_months",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grade": {
+          "name": "grade",
+          "type": "grade",
+          "typeSchema": "app",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "school_level": {
+          "name": "school_level",
+          "type": "school_level",
+          "typeSchema": "app",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "app.get_school_level_from_grade(grade)",
+            "type": "stored"
+          }
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "run_demographics_runId_unique": {
+          "name": "run_demographics_runId_unique",
+          "nullsNotDistinct": false,
+          "columns": ["run_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.rostering_runs": {
+      "name": "rostering_runs",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "rostering_provider": {
+          "name": "rostering_provider",
+          "type": "rostering_provider",
+          "typeSchema": "app",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_type": {
+          "name": "run_type",
+          "type": "rostering_run_type",
+          "typeSchema": "app",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sync_started": {
+          "name": "sync_started",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "sync_ended": {
+          "name": "sync_ended",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "rostering_runs_provider_idx": {
+          "name": "rostering_runs_provider_idx",
+          "columns": [
+            {
+              "expression": "rostering_provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "rostering_runs_provider_running_idx": {
+          "name": "rostering_runs_provider_running_idx",
+          "columns": [
+            {
+              "expression": "rostering_provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"app\".\"rostering_runs\".\"sync_ended\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.rostering_run_entities": {
+      "name": "rostering_run_entities",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "rostering_run_id": {
+          "name": "rostering_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "rostering_entity_type",
+          "typeSchema": "app",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "rostering_entity_status",
+          "typeSchema": "app",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "exceptions": {
+          "name": "exceptions",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "rostering_run_entities_run_id_idx": {
+          "name": "rostering_run_entities_run_id_idx",
+          "columns": [
+            {
+              "expression": "rostering_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "rostering_run_entities_provider_id_idx": {
+          "name": "rostering_run_entities_provider_id_idx",
+          "columns": [
+            {
+              "expression": "provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "rostering_run_entities_run_status_idx": {
+          "name": "rostering_run_entities_run_status_idx",
+          "columns": [
+            {
+              "expression": "rostering_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "rostering_run_entities_rostering_run_id_rostering_runs_id_fk": {
+          "name": "rostering_run_entities_rostering_run_id_rostering_runs_id_fk",
+          "tableFrom": "rostering_run_entities",
+          "tableTo": "rostering_runs",
+          "schemaTo": "app",
+          "columnsFrom": ["rostering_run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.rostering_provider_ids": {
+      "name": "rostering_provider_ids",
+      "schema": "app",
+      "columns": {
+        "provider_type": {
+          "name": "provider_type",
+          "type": "rostering_provider",
+          "typeSchema": "app",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "partner_id": {
+          "name": "partner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "rostering_entity_type",
+          "typeSchema": "app",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "rostering_provider_ids_entity_unique_idx": {
+          "name": "rostering_provider_ids_entity_unique_idx",
+          "columns": [
+            {
+              "expression": "provider_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "rostering_provider_ids_entity_idx": {
+          "name": "rostering_provider_ids_entity_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "rostering_provider_ids_pk": {
+          "name": "rostering_provider_ids_pk",
+          "columns": ["provider_type", "partner_id", "provider_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.tasks": {
+      "name": "tasks",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name_simple": {
+          "name": "name_simple",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name_technical": {
+          "name": "name_technical",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tutorial_video": {
+          "name": "tutorial_video",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "task_config": {
+          "name": "task_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "tasks_slug_unique_idx": {
+          "name": "tasks_slug_unique_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tasks_slug_lower_idx": {
+          "name": "tasks_slug_lower_idx",
+          "columns": [
+            {
+              "expression": "lower(\"slug\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tasks_name_lower_idx": {
+          "name": "tasks_name_lower_idx",
+          "columns": [
+            {
+              "expression": "lower(\"name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "tasks_slug_format": {
+          "name": "tasks_slug_format",
+          "value": "\"app\".\"tasks\".\"slug\" ~ '^[a-z0-9]+(-[a-z0-9]+)*$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "app.task_variants": {
+      "name": "task_variants",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "task_variant_status",
+          "typeSchema": "app",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "task_variants_task_name_unique_idx": {
+          "name": "task_variants_task_name_unique_idx",
+          "columns": [
+            {
+              "expression": "task_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lower(\"name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"app\".\"task_variants\".\"name\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_variants_task_id_status_idx": {
+          "name": "task_variants_task_id_status_idx",
+          "columns": [
+            {
+              "expression": "task_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "task_variants_task_id_tasks_id_fk": {
+          "name": "task_variants_task_id_tasks_id_fk",
+          "tableFrom": "task_variants",
+          "tableTo": "tasks",
+          "schemaTo": "app",
+          "columnsFrom": ["task_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.task_variant_parameters": {
+      "name": "task_variant_parameters",
+      "schema": "app",
+      "columns": {
+        "task_variant_id": {
+          "name": "task_variant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "task_variant_parameters_task_variant_id_task_variants_id_fk": {
+          "name": "task_variant_parameters_task_variant_id_task_variants_id_fk",
+          "tableFrom": "task_variant_parameters",
+          "tableTo": "task_variants",
+          "schemaTo": "app",
+          "columnsFrom": ["task_variant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "task_variant_parameters_pkey": {
+          "name": "task_variant_parameters_pkey",
+          "columns": ["task_variant_id", "name"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.task_bundles": {
+      "name": "task_bundles",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "task_bundles_slug_lower_idx": {
+          "name": "task_bundles_slug_lower_idx",
+          "columns": [
+            {
+              "expression": "lower(\"slug\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_bundles_name_lower_idx": {
+          "name": "task_bundles_name_lower_idx",
+          "columns": [
+            {
+              "expression": "lower(\"name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "task_bundles_slug_unique": {
+          "name": "task_bundles_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": ["slug"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "tasks_slug_format": {
+          "name": "tasks_slug_format",
+          "value": "\"app\".\"task_bundles\".\"slug\" ~ '^[a-z0-9]+(-[a-z0-9]+)*$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "app.task_bundle_variants": {
+      "name": "task_bundle_variants",
+      "schema": "app",
+      "columns": {
+        "task_bundle_id": {
+          "name": "task_bundle_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "task_variant_id": {
+          "name": "task_variant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "task_bundle_variants_task_bundle_id_idx": {
+          "name": "task_bundle_variants_task_bundle_id_idx",
+          "columns": [
+            {
+              "expression": "task_bundle_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_bundle_variants_task_variant_id_idx": {
+          "name": "task_bundle_variants_task_variant_id_idx",
+          "columns": [
+            {
+              "expression": "task_variant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_bundle_variants_task_bundle_id_sort_order_idx": {
+          "name": "task_bundle_variants_task_bundle_id_sort_order_idx",
+          "columns": [
+            {
+              "expression": "task_bundle_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sort_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "task_bundle_variants_task_bundle_id_task_bundles_id_fk": {
+          "name": "task_bundle_variants_task_bundle_id_task_bundles_id_fk",
+          "tableFrom": "task_bundle_variants",
+          "tableTo": "task_bundles",
+          "schemaTo": "app",
+          "columnsFrom": ["task_bundle_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "task_bundle_variants_task_variant_id_task_variants_id_fk": {
+          "name": "task_bundle_variants_task_variant_id_task_variants_id_fk",
+          "tableFrom": "task_bundle_variants",
+          "tableTo": "task_variants",
+          "schemaTo": "app",
+          "columnsFrom": ["task_variant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "task_bundle_variants_task_bundle_id_task_variant_id_pkey": {
+          "name": "task_bundle_variants_task_bundle_id_task_variant_id_pkey",
+          "columns": ["task_bundle_id", "task_variant_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.orgs": {
+      "name": "orgs",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "abbreviation": {
+          "name": "abbreviation",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_type": {
+          "name": "org_type",
+          "type": "org_type",
+          "typeSchema": "app",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_org_id": {
+          "name": "parent_org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "path": {
+          "name": "path",
+          "type": "ltree",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_address_line1": {
+          "name": "location_address_line1",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location_address_line2": {
+          "name": "location_address_line2",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location_city": {
+          "name": "location_city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location_state_province": {
+          "name": "location_state_province",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location_postal_code": {
+          "name": "location_postal_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location_country": {
+          "name": "location_country",
+          "type": "varchar(2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location_lat_long": {
+          "name": "location_lat_long",
+          "type": "point",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mdr_number": {
+          "name": "mdr_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "nces_id": {
+          "name": "nces_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state_id": {
+          "name": "state_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "school_number": {
+          "name": "school_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_rostering_root_org": {
+          "name": "is_rostering_root_org",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "rostering_ended": {
+          "name": "rostering_ended",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "orgs_type_idx": {
+          "name": "orgs_type_idx",
+          "columns": [
+            {
+              "expression": "org_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "orgs_parent_idx": {
+          "name": "orgs_parent_idx",
+          "columns": [
+            {
+              "expression": "parent_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "orgs_parent_type_idx": {
+          "name": "orgs_parent_type_idx",
+          "columns": [
+            {
+              "expression": "parent_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "org_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "orgs_path_gist_idx": {
+          "name": "orgs_path_gist_idx",
+          "columns": [
+            {
+              "expression": "path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gist",
+          "with": {}
+        },
+        "orgs_name_lower_idx": {
+          "name": "orgs_name_lower_idx",
+          "columns": [
+            {
+              "expression": "lower(\"name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "orgs_name_lower_pattern_idx": {
+          "name": "orgs_name_lower_pattern_idx",
+          "columns": [
+            {
+              "expression": "lower(\"name\") text_pattern_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "orgs_parent_org_id_orgs_id_fk": {
+          "name": "orgs_parent_org_id_orgs_id_fk",
+          "tableFrom": "orgs",
+          "tableTo": "orgs",
+          "schemaTo": "app",
+          "columnsFrom": ["parent_org_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "orgs_abbreviation_format": {
+          "name": "orgs_abbreviation_format",
+          "value": "\"app\".\"orgs\".\"abbreviation\" ~ '^[A-Za-z0-9]+$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "app.users": {
+      "name": "users",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "assessment_pid": {
+          "name": "assessment_pid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auth_provider": {
+          "name": "auth_provider",
+          "type": "auth_provider[]",
+          "typeSchema": "app",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auth_id": {
+          "name": "auth_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name_first": {
+          "name": "name_first",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name_middle": {
+          "name": "name_middle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name_last": {
+          "name": "name_last",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_type": {
+          "name": "user_type",
+          "type": "user_type",
+          "typeSchema": "app",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dob": {
+          "name": "dob",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grade": {
+          "name": "grade",
+          "type": "grade",
+          "typeSchema": "app",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "school_level": {
+          "name": "school_level",
+          "type": "school_level",
+          "typeSchema": "app",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "app.get_school_level_from_grade(grade)",
+            "type": "stored"
+          }
+        },
+        "status_ell": {
+          "name": "status_ell",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_frl": {
+          "name": "status_frl",
+          "type": "free_reduced_lunch_status",
+          "typeSchema": "app",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_iep": {
+          "name": "status_iep",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sis_id": {
+          "name": "sis_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state_id": {
+          "name": "state_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "local_id": {
+          "name": "local_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gender": {
+          "name": "gender",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "race": {
+          "name": "race",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hispanic_ethnicity": {
+          "name": "hispanic_ethnicity",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "home_language": {
+          "name": "home_language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_super_admin": {
+          "name": "is_super_admin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "rostering_ended": {
+          "name": "rostering_ended",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_email_lower_uniqIdx": {
+          "name": "users_email_lower_uniqIdx",
+          "columns": [
+            {
+              "expression": "lower(\"email\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"app\".\"users\".\"email\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_assessmentPid_unique": {
+          "name": "users_assessmentPid_unique",
+          "nullsNotDistinct": false,
+          "columns": ["assessment_pid"]
+        },
+        "users_authId_unique": {
+          "name": "users_authId_unique",
+          "nullsNotDistinct": false,
+          "columns": ["auth_id"]
+        },
+        "users_username_unique": {
+          "name": "users_username_unique",
+          "nullsNotDistinct": false,
+          "columns": ["username"]
+        },
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "users_dob_in_past": {
+          "name": "users_dob_in_past",
+          "value": "\"app\".\"users\".\"dob\" IS NULL OR \"app\".\"users\".\"dob\" <= now()::date"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "app.user_agreements": {
+      "name": "user_agreements",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agreement_version_id": {
+          "name": "agreement_version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agreement_timestamp": {
+          "name": "agreement_timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_agreements_user_idx": {
+          "name": "user_agreements_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_agreements_user_agreement_idx": {
+          "name": "user_agreements_user_agreement_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "agreement_version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_agreements_agreement_version_idx": {
+          "name": "user_agreements_agreement_version_idx",
+          "columns": [
+            {
+              "expression": "agreement_version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_agreements_user_id_users_id_fk": {
+          "name": "user_agreements_user_id_users_id_fk",
+          "tableFrom": "user_agreements",
+          "tableTo": "users",
+          "schemaTo": "app",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_agreements_agreement_version_id_agreement_versions_id_fk": {
+          "name": "user_agreements_agreement_version_id_agreement_versions_id_fk",
+          "tableFrom": "user_agreements",
+          "tableTo": "agreement_versions",
+          "schemaTo": "app",
+          "columnsFrom": ["agreement_version_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.user_classes": {
+      "name": "user_classes",
+      "schema": "app",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "class_id": {
+          "name": "class_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "app",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enrollment_start": {
+          "name": "enrollment_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enrollment_end": {
+          "name": "enrollment_end",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_classes_class_idx": {
+          "name": "user_classes_class_idx",
+          "columns": [
+            {
+              "expression": "class_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_classes_user_id_users_id_fk": {
+          "name": "user_classes_user_id_users_id_fk",
+          "tableFrom": "user_classes",
+          "tableTo": "users",
+          "schemaTo": "app",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_classes_class_id_classes_id_fk": {
+          "name": "user_classes_class_id_classes_id_fk",
+          "tableFrom": "user_classes",
+          "tableTo": "classes",
+          "schemaTo": "app",
+          "columnsFrom": ["class_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_classes_pk": {
+          "name": "user_classes_pk",
+          "columns": ["user_id", "class_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "user_classes_enrollment_dates_valid": {
+          "name": "user_classes_enrollment_dates_valid",
+          "value": "\"app\".\"user_classes\".\"enrollment_end\" IS NULL OR \"app\".\"user_classes\".\"enrollment_start\" < \"app\".\"user_classes\".\"enrollment_end\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "app.user_families": {
+      "name": "user_families",
+      "schema": "app",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "family_id": {
+          "name": "family_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "user_family_role",
+          "typeSchema": "app",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "joined_on": {
+          "name": "joined_on",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "left_on": {
+          "name": "left_on",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_families_family_idx": {
+          "name": "user_families_family_idx",
+          "columns": [
+            {
+              "expression": "family_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_families_user_id_users_id_fk": {
+          "name": "user_families_user_id_users_id_fk",
+          "tableFrom": "user_families",
+          "tableTo": "users",
+          "schemaTo": "app",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_families_family_id_families_id_fk": {
+          "name": "user_families_family_id_families_id_fk",
+          "tableFrom": "user_families",
+          "tableTo": "families",
+          "schemaTo": "app",
+          "columnsFrom": ["family_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_families_pk": {
+          "name": "user_families_pk",
+          "columns": ["user_id", "family_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "user_families_membership_dates_valid": {
+          "name": "user_families_membership_dates_valid",
+          "value": "\"app\".\"user_families\".\"left_on\" IS NULL OR \"app\".\"user_families\".\"joined_on\" < \"app\".\"user_families\".\"left_on\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "app.user_groups": {
+      "name": "user_groups",
+      "schema": "app",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "app",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enrollment_start": {
+          "name": "enrollment_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enrollment_end": {
+          "name": "enrollment_end",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_groups_group_idx": {
+          "name": "user_groups_group_idx",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_groups_user_id_users_id_fk": {
+          "name": "user_groups_user_id_users_id_fk",
+          "tableFrom": "user_groups",
+          "tableTo": "users",
+          "schemaTo": "app",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_groups_group_id_groups_id_fk": {
+          "name": "user_groups_group_id_groups_id_fk",
+          "tableFrom": "user_groups",
+          "tableTo": "groups",
+          "schemaTo": "app",
+          "columnsFrom": ["group_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_groups_pk": {
+          "name": "user_groups_pk",
+          "columns": ["user_id", "group_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "user_groups_enrollment_dates_valid": {
+          "name": "user_groups_enrollment_dates_valid",
+          "value": "\"app\".\"user_groups\".\"enrollment_end\" IS NULL OR \"app\".\"user_groups\".\"enrollment_start\" < \"app\".\"user_groups\".\"enrollment_end\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "app.user_orgs": {
+      "name": "user_orgs",
+      "schema": "app",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "app",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enrollment_start": {
+          "name": "enrollment_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enrollment_end": {
+          "name": "enrollment_end",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_orgs_org_idx": {
+          "name": "user_orgs_org_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_orgs_user_id_users_id_fk": {
+          "name": "user_orgs_user_id_users_id_fk",
+          "tableFrom": "user_orgs",
+          "tableTo": "users",
+          "schemaTo": "app",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_orgs_org_id_orgs_id_fk": {
+          "name": "user_orgs_org_id_orgs_id_fk",
+          "tableFrom": "user_orgs",
+          "tableTo": "orgs",
+          "schemaTo": "app",
+          "columnsFrom": ["org_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_orgs_pk": {
+          "name": "user_orgs_pk",
+          "columns": ["user_id", "org_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "user_orgs_enrollment_dates_valid": {
+          "name": "user_orgs_enrollment_dates_valid",
+          "value": "\"app\".\"user_orgs\".\"enrollment_end\" IS NULL OR \"app\".\"user_orgs\".\"enrollment_start\" < \"app\".\"user_orgs\".\"enrollment_end\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "app.user_research_exclusions": {
+      "name": "user_research_exclusions",
+      "schema": "app",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "exclude_from": {
+          "name": "exclude_from",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "exclude_until": {
+          "name": "exclude_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "excluded_by": {
+          "name": "excluded_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "exclusion_reason": {
+          "name": "exclusion_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_research_exclusions_user_id_users_id_fk": {
+          "name": "user_research_exclusions_user_id_users_id_fk",
+          "tableFrom": "user_research_exclusions",
+          "tableTo": "users",
+          "schemaTo": "app",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_research_exclusions_excluded_by_users_id_fk": {
+          "name": "user_research_exclusions_excluded_by_users_id_fk",
+          "tableFrom": "user_research_exclusions",
+          "tableTo": "users",
+          "schemaTo": "app",
+          "columnsFrom": ["excluded_by"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_research_exclusions_user_id_exclude_from_pk": {
+          "name": "user_research_exclusions_user_id_exclude_from_pk",
+          "columns": ["user_id", "exclude_from"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "user_research_exclusions_dates_valid": {
+          "name": "user_research_exclusions_dates_valid",
+          "value": "\"app\".\"user_research_exclusions\".\"exclude_from\" < \"app\".\"user_research_exclusions\".\"exclude_until\""
+        }
+      },
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "app.agreement_type": {
+      "name": "agreement_type",
+      "schema": "app",
+      "values": ["tos", "assent", "consent"]
+    },
+    "app.assessment_stage": {
+      "name": "assessment_stage",
+      "schema": "app",
+      "values": ["practice", "test"]
+    },
+    "app.assignment_progress": {
+      "name": "assignment_progress",
+      "schema": "app",
+      "values": ["assigned", "started", "completed"]
+    },
+    "app.auth_provider": {
+      "name": "auth_provider",
+      "schema": "app",
+      "values": ["password", "google", "oidc.clever", "oidc.classlink", "oidc.nycps"]
+    },
+    "app.class_type": {
+      "name": "class_type",
+      "schema": "app",
+      "values": ["homeroom", "scheduled", "other"]
+    },
+    "app.free_reduced_lunch_status": {
+      "name": "free_reduced_lunch_status",
+      "schema": "app",
+      "values": ["Free", "Reduced", "Paid"]
+    },
+    "app.grade": {
+      "name": "grade",
+      "schema": "app",
+      "values": [
+        "1",
+        "2",
+        "3",
+        "4",
+        "5",
+        "6",
+        "7",
+        "8",
+        "9",
+        "10",
+        "11",
+        "12",
+        "13",
+        "PreKindergarten",
+        "TransitionalKindergarten",
+        "Kindergarten",
+        "InfantToddler",
+        "Preschool",
+        "PostGraduate",
+        "Ungraded",
+        "Other",
+        ""
+      ]
+    },
+    "app.group_type": {
+      "name": "group_type",
+      "schema": "app",
+      "values": ["cohort", "community", "business"]
+    },
+    "app.org_type": {
+      "name": "org_type",
+      "schema": "app",
+      "values": ["national", "state", "local", "district", "school", "department"]
+    },
+    "app.rostering_entity_status": {
+      "name": "rostering_entity_status",
+      "schema": "app",
+      "values": ["enrolled", "unenrolled", "failed", "skipped"]
+    },
+    "app.rostering_entity_type": {
+      "name": "rostering_entity_type",
+      "schema": "app",
+      "values": ["org", "class", "course", "user"]
+    },
+    "app.rostering_provider": {
+      "name": "rostering_provider",
+      "schema": "app",
+      "values": ["classlink", "clever", "dashboard", "nycps", "csv"]
+    },
+    "app.rostering_run_type": {
+      "name": "rostering_run_type",
+      "schema": "app",
+      "values": ["full", "incremental", "retry"]
+    },
+    "app.school_level": {
+      "name": "school_level",
+      "schema": "app",
+      "values": ["early_childhood", "elementary", "middle", "high", "postsecondary"]
+    },
+    "app.score_type": {
+      "name": "score_type",
+      "schema": "app",
+      "values": ["computed", "raw"]
+    },
+    "app.task_variant_status": {
+      "name": "task_variant_status",
+      "schema": "app",
+      "values": ["draft", "published", "deprecated"]
+    },
+    "app.trial_interaction_type": {
+      "name": "trial_interaction_type",
+      "schema": "app",
+      "values": ["focus", "blur", "fullscreen_enter", "fullscreen_exit"]
+    },
+    "app.user_family_role": {
+      "name": "user_family_role",
+      "schema": "app",
+      "values": ["parent", "child"]
+    },
+    "app.user_role": {
+      "name": "user_role",
+      "schema": "app",
+      "values": [
+        "administrator",
+        "aide",
+        "counselor",
+        "district_administrator",
+        "guardian",
+        "parent",
+        "platform_admin",
+        "principal",
+        "proctor",
+        "relative",
+        "site_administrator",
+        "student",
+        "system_administrator",
+        "teacher"
+      ]
+    },
+    "app.user_type": {
+      "name": "user_type",
+      "schema": "app",
+      "values": ["student", "educator", "caregiver", "admin"]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/backend/migrations/core/meta/_journal.json
+++ b/apps/backend/migrations/core/meta/_journal.json
@@ -435,6 +435,13 @@
       "when": 1774906256554,
       "tag": "0061_drop_classes_school_name_unique_index",
       "breakpoints": true
+    },
+    {
+      "idx": 62,
+      "version": "7",
+      "when": 1777405259677,
+      "tag": "0062_young_tomas",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/backend/src/constants/role-classifications.ts
+++ b/apps/backend/src/constants/role-classifications.ts
@@ -69,3 +69,17 @@ export const SUPERVISED_ROLES: UserRole[] = ['student', 'guardian', 'parent', 'r
  * that are in their children's organizations or classes
  */
 export const CARETAKER_ROLES: UserRole[] = ['guardian', 'parent', 'relative'];
+
+/**
+ * TODO (#1778): https://github.com/yeatmanlab/roar-project-management/issues/1778
+ *
+ * When the sync pipeline refactor lands, define an `EXTERNAL_PROVIDER_ASSIGNABLE_ROLES`
+ * constant here — an explicit allowlist of of roles that external roster providers
+ * (Clever, ClassLink, NYCPS) are permittedto write to `user_orgs`.
+ * `platform_admin` must be excluded from that list.
+ *
+ * Until then, protection is passive: external providers use the OneRoster role
+ * spec and do not know `platform_admin` exists, so they will not write it.
+ * A guard here ensures a future sync pipeline change cannot accidentally grant
+ * `platform_admin` to an externally-rostered user.
+ */

--- a/apps/backend/src/constants/role-classifications.ts
+++ b/apps/backend/src/constants/role-classifications.ts
@@ -21,6 +21,7 @@ import type { UserRole } from '../enums/user-role.enum';
 export const HIERARCHICAL_USER_ACCESS_ROLES: UserRole[] = [
   'administrator',
   'district_administrator',
+  'platform_admin',
   'principal',
   'site_administrator',
   'system_administrator',
@@ -42,6 +43,7 @@ export const SUPERVISORY_ROLES: UserRole[] = [
   'aide',
   'counselor',
   'district_administrator',
+  'platform_admin',
   'principal',
   'proctor',
   'site_administrator',

--- a/apps/backend/src/constants/role-permissions.test.ts
+++ b/apps/backend/src/constants/role-permissions.test.ts
@@ -9,12 +9,13 @@ describe('role-permissions', () => {
     it('should return all roles with administrations.* or administrations.list for administrations.list', () => {
       const roles = rolesForPermission(Permissions.Administrations.LIST);
 
-      // All 13 roles have either administrations.* or administrations.list
+      // All 14 roles have either administrations.* or administrations.list
       expect(roles).toContain(UserRole.SITE_ADMINISTRATOR);
       expect(roles).toContain(UserRole.ADMINISTRATOR);
+      expect(roles).toContain(UserRole.PLATFORM_ADMIN);
       expect(roles).toContain(UserRole.TEACHER);
       expect(roles).toContain(UserRole.STUDENT);
-      expect(roles).toHaveLength(13);
+      expect(roles).toHaveLength(14);
     });
 
     it('should throw for administrations.create since no role has it explicitly', () => {
@@ -26,15 +27,16 @@ describe('role-permissions', () => {
     it('should handle wildcard matching for nested permissions', () => {
       const roles = rolesForPermission(Permissions.Reports.Score.READ);
 
-      // siteAdmin, admin, educator have reports.score.* (ALL)
+      // siteAdmin, admin, platform_admin, educator have reports.score.* (ALL)
       // caregiver has reports.score.read directly
       // student does not have reports access
       expect(roles).toContain(UserRole.SITE_ADMINISTRATOR);
       expect(roles).toContain(UserRole.ADMINISTRATOR);
+      expect(roles).toContain(UserRole.PLATFORM_ADMIN);
       expect(roles).toContain(UserRole.TEACHER);
       expect(roles).toContain(UserRole.GUARDIAN);
       expect(roles).not.toContain(UserRole.STUDENT);
-      expect(roles).toHaveLength(12);
+      expect(roles).toHaveLength(13);
     });
 
     it('should throw error for unknown permission', () => {
@@ -86,6 +88,16 @@ describe('role-permissions', () => {
       expect(RolePermissions[UserRole.STUDENT]).toBeDefined();
       expect(RolePermissions[UserRole.STUDENT]).toContain(Permissions.Administrations.LIST);
       expect(RolePermissions[UserRole.STUDENT]).toContain(Permissions.Tasks.LAUNCH);
+    });
+
+    it('should define permissions for platform_admin including Users.CREATE', () => {
+      expect(RolePermissions[UserRole.PLATFORM_ADMIN]).toBeDefined();
+      expect(RolePermissions[UserRole.PLATFORM_ADMIN]).toContain(Permissions.Administrations.LIST);
+      expect(RolePermissions[UserRole.PLATFORM_ADMIN]).toContain(Permissions.Administrations.READ);
+      expect(RolePermissions[UserRole.PLATFORM_ADMIN]).toContain(Permissions.Users.CREATE);
+      // admin_tier (OneRoster roles) should NOT have Users.CREATE
+      expect(RolePermissions[UserRole.ADMINISTRATOR]).not.toContain(Permissions.Users.CREATE);
+      expect(RolePermissions[UserRole.DISTRICT_ADMINISTRATOR]).not.toContain(Permissions.Users.CREATE);
     });
   });
 

--- a/apps/backend/src/constants/role-permissions.ts
+++ b/apps/backend/src/constants/role-permissions.ts
@@ -102,12 +102,15 @@ export const RolePermissions: Record<UserRoleType, readonly Permission[]> = (() 
     Permissions.Tasks.LAUNCH,
   ];
 
+  const platformAdmin: readonly Permission[] = [...admin, Permissions.Users.CREATE];
+
   // ── Role → tier mapping ─────────────────────────────────────────────
   return {
     [UserRole.SYSTEM_ADMINISTRATOR]: siteAdmin,
     [UserRole.SITE_ADMINISTRATOR]: siteAdmin,
     [UserRole.DISTRICT_ADMINISTRATOR]: admin,
     [UserRole.ADMINISTRATOR]: admin,
+    [UserRole.PLATFORM_ADMIN]: platformAdmin,
     [UserRole.PRINCIPAL]: educator,
     [UserRole.COUNSELOR]: educator,
     [UserRole.TEACHER]: educator,

--- a/apps/backend/src/db/schema/enums.ts
+++ b/apps/backend/src/db/schema/enums.ts
@@ -206,6 +206,12 @@ export const userFamilyRoleEnum = db.enum('user_family_role', ['parent', 'child'
  * OneRoster v1.1 roles: administrator, aide, guardian, parent, proctor, relative, student, teacher
  * OneRoster v1.2 roles: aide, counselor, districtAdministrator, guardian, parent, principal,
  *                       proctor, relative, siteAdministrator, student, systemAdministrator, teacher
+ *
+ * `platform_admin` is a ROAR-specific role, not part of the OneRoster standard.
+ * Granted exclusively to CSV/dashboard-created users (research partners and users
+ * requiring direct platform control). External rostering providers naturally overwrite
+ * this role during sync — transitioning to an external provider intentionally
+ * surrenders platform management.
  */
 export const userRoleEnum = db.enum('user_role', [
   'administrator',
@@ -214,6 +220,7 @@ export const userRoleEnum = db.enum('user_role', [
   'district_administrator',
   'guardian',
   'parent',
+  'platform_admin',
   'principal',
   'proctor',
   'relative',

--- a/apps/backend/src/services/authorization/fga-constants.ts
+++ b/apps/backend/src/services/authorization/fga-constants.ts
@@ -88,6 +88,7 @@ export const FGA_CLASS_VALID_ROLES: ReadonlySet<UserRole> = new Set([
   UserRole.GUARDIAN,
   UserRole.PARENT,
   UserRole.RELATIVE,
+  // platform_admin intentionally excluded — it cascades to classes via parent_org, not direct class assignment
 ]);
 
 /**

--- a/apps/backend/src/services/authorization/fga-constants.ts
+++ b/apps/backend/src/services/authorization/fga-constants.ts
@@ -58,6 +58,7 @@ export const FgaRelation = {
   CAN_DELETE: 'can_delete',
   CAN_LIST_CLASSES: 'can_list_classes',
   CAN_LIST_USERS: 'can_list_users',
+  CAN_CREATE_USERS: 'can_create_users',
   CAN_READ_SCORES: 'can_read_scores',
   CAN_READ_PROGRESS: 'can_read_progress',
   CAN_CREATE_RUN: 'can_create_run',

--- a/packages/api-contract/src/v1/common/user.ts
+++ b/packages/api-contract/src/v1/common/user.ts
@@ -8,6 +8,7 @@ export const UserRoleSchema = z.enum([
   'district_administrator',
   'guardian',
   'parent',
+  'platform_admin',
   'principal',
   'proctor',
   'relative',

--- a/packages/authz/README.md
+++ b/packages/authz/README.md
@@ -130,9 +130,9 @@ Shared across org types to simplify permission definitions:
 
 Permissions are defined as computed relations in each type in `authorization-model.fga`. See the model for the authoritative mapping of which role tiers grant which permissions. CUD permissions (`can_create`, `can_update`, `can_delete`) resolve to `no_one` — they are super-admin-only, enforced in the app layer.
 
-User creation is an exception to the CUD restrictions under the current model. A user with the computed role `admin_tier` has the permission `can_create_users` on entity types `district`, `school`, and `group`. This permission is still enforced in the app layer by first checking the requesting user for super-admin status to allow for authorization bypass, and then checking `can_create_users` for each entity type present in the `memberhips` field of the request body.
+User creation is an exception to the CUD restrictions under the current model. A user with the computed role `admin_tier` has the permission `can_create_users` on entity types `district`, `school`, and `group`. This permission is still enforced in the app layer by first checking the requesting user for super-admin status to allow for authorization bypass, and then checking `can_create_users` for each entity type present in the `memberships` field of the request body.
 
-For `class` entities, this means that a user with the `admin_tier` computed role can create users in a class only if that uses possess the `can_create_users` permissions on the parent school of the class.
+For `class` entities, this means that a user with the `admin_tier` computed role can create users in a class only if that user possess the `can_create_users` permissions on the parent school of the class.
 
 For `family` entities, no computed user tier is currently allowed to create users, and implementation of the `can_create_users` permission on `family` entities is planned for a future enhancement.
 

--- a/packages/authz/README.md
+++ b/packages/authz/README.md
@@ -66,15 +66,15 @@ npm run test -w packages/authz
 
 ### Entity types
 
-| Type | Represents | Source table |
-|------|-----------|-------------|
-| `user` | A ROAR platform user | `app.users` |
-| `district` | A district org | `app.orgs` (orgType=district) |
-| `school` | A school org | `app.orgs` (orgType=school) |
-| `class` | A class | `app.classes` |
-| `group` | A group (ROAR at Home) | `app.groups` |
-| `family` | A family unit | `app.families` |
-| `administration` | An assessment administration | `app.administrations` |
+| Type             | Represents                   | Source table                  |
+| ---------------- | ---------------------------- | ----------------------------- |
+| `user`           | A ROAR platform user         | `app.users`                   |
+| `district`       | A district org               | `app.orgs` (orgType=district) |
+| `school`         | A school org                 | `app.orgs` (orgType=school)   |
+| `class`          | A class                      | `app.classes`                 |
+| `group`          | A group (ROAR at Home)       | `app.groups`                  |
+| `family`         | A family unit                | `app.families`                |
+| `administration` | An assessment administration | `app.administrations`         |
 
 **Excluded types:** Tasks, task variants, and runs inherit access from their administration. Courses, agreements, and invitation codes have no access control. These are checked in the service layer by verifying access to the parent administration.
 
@@ -98,21 +98,21 @@ define can_delete: no_one
 
 Each role is modeled as its own FGA relation — no tier mapping. Tuples use the role name directly from Postgres.
 
-| Role | FGA relation | Tier | Cascading |
-|------|-------------|------|-----------|
-| `system_administrator` | `system_administrator` | siteAdmin | Down + subtree (supervisory) |
-| `site_administrator` | `site_administrator` | siteAdmin | Down + subtree |
-| `district_administrator` | `district_administrator` | admin | Down + subtree |
-| `administrator` | `administrator` | admin | Down + subtree |
-| `principal` | `principal` | educator | Down + subtree |
-| `counselor` | `counselor` | educator | Down + subtree |
-| `teacher` | `teacher` | educator | Down + subtree |
-| `aide` | `aide` | educator | Down + subtree |
-| `proctor` | `proctor` | educator | Down + subtree |
-| `student` | `student` | student | Up (supervised) |
-| `guardian` | `guardian` | caregiver | Up |
-| `parent` | `parent` | caregiver | Up |
-| `relative` | `relative` | caregiver | Up |
+| Role                     | FGA relation             | Tier      | Cascading                    |
+| ------------------------ | ------------------------ | --------- | ---------------------------- |
+| `system_administrator`   | `system_administrator`   | siteAdmin | Down + subtree (supervisory) |
+| `site_administrator`     | `site_administrator`     | siteAdmin | Down + subtree               |
+| `district_administrator` | `district_administrator` | admin     | Down + subtree               |
+| `administrator`          | `administrator`          | admin     | Down + subtree               |
+| `principal`              | `principal`              | educator  | Down + subtree               |
+| `counselor`              | `counselor`              | educator  | Down + subtree               |
+| `teacher`                | `teacher`                | educator  | Down + subtree               |
+| `aide`                   | `aide`                   | educator  | Down + subtree               |
+| `proctor`                | `proctor`                | educator  | Down + subtree               |
+| `student`                | `student`                | student   | Up (supervised)              |
+| `guardian`               | `guardian`               | caregiver | Up                           |
+| `parent`                 | `parent`                 | caregiver | Up                           |
+| `relative`               | `relative`               | caregiver | Up                           |
 
 > **No `parent` rename needed:** The hierarchy links use `parent_org` (e.g., `define parent_org: [district]` on `school`), so there is no conflict with the `parent` role relation. Tuples use `parent` directly.
 
@@ -130,8 +130,15 @@ Shared across org types to simplify permission definitions:
 
 Permissions are defined as computed relations in each type in `authorization-model.fga`. See the model for the authoritative mapping of which role tiers grant which permissions. CUD permissions (`can_create`, `can_update`, `can_delete`) resolve to `no_one` — they are super-admin-only, enforced in the app layer.
 
+User creation is an exception to the CUD restrictions under the current model. A user with the computed role `admin_tier` has the permission `can_create_users` on entity types `district`, `school`, and `group`. This permission is still enforced in the app layer by first checking the requesting user for super-admin status to allow for authorization bypass, and then checking `can_create_users` for each entity type present in the `memberhips` field of the request body.
+
+For `class` entities, this means that a user with the `admin_tier` computed role can create users in a class only if that uses possess the `can_create_users` permissions on the parent school of the class.
+
+For `family` entities, no computed user tier is currently allowed to create users, and implementation of the `can_create_users` permission on `family` entities is planned for a future enhancement.
+
 **Design notes:**
 
+- **`can_create_users`**: Gated on `admin_tier` computed role for `district`, `school`, and `group` entities only.
 - **`can_list_users` on family:** Gated on `parent` — only parents can list family members. Children cannot.
 - **Groups have the full role model:** `user_groups` has a `role` column like `user_orgs`, so groups define all 13 roles with `active_membership` conditions, not just flat `member`.
 - **Groups are standalone — no org hierarchy cascading:** Groups have no `parent_org` link, so org-level roles (e.g., district admin) do not cascade into groups. A user must be an explicit member of a group to see it. This is intentional — groups are independent of the org tree.
@@ -161,6 +168,7 @@ define student: [user with active_membership] or student from child_school
 ```
 
 FGA resolution for "is user:X a student of district:D?":
+
 1. Check direct `student` tuples on `district:D`
 2. Follow `child_school` to find `school:A`
 3. Check `student` tuples on `school:A` (which in turn follows `child_class` to `class:X`)
@@ -193,11 +201,11 @@ define supervisory_tier_group: admin_tier or educator_tier
 
 This gives the correct behavior:
 
-| User | District entity | District-assigned administration |
-|------|----------------|----------------------------------|
-| District admin | `can_list: true` | `can_list: true` |
-| School teacher | `can_list: false` (org isolation preserved) | `can_list: true` (via subtree) |
-| Class teacher | `can_list: false` | `can_list: true` (via subtree, two hops) |
+| User           | District entity                             | District-assigned administration         |
+| -------------- | ------------------------------------------- | ---------------------------------------- |
+| District admin | `can_list: true`                            | `can_list: true`                         |
+| School teacher | `can_list: false` (org isolation preserved) | `can_list: true` (via subtree)           |
+| Class teacher  | `can_list: false`                           | `can_list: true` (via subtree, two hops) |
 
 The key invariant: `subtree_supervisory_tier_group` is **never referenced by org permissions** (`can_list`, `can_read`, etc. still use `supervisory_tier_group`). It only flows into the administration type, so school/class isolation is preserved.
 
@@ -222,9 +230,9 @@ Enrollment dates are enforced at check time using the `active_membership` [CEL c
 
 ```typescript
 const { allowed } = await fga.check({
-  user: 'user:student-x',
-  relation: 'can_read',
-  object: 'administration:admin-1',
+  user: "user:student-x",
+  relation: "can_read",
+  object: "administration:admin-1",
   context: { current_time: new Date().toISOString() },
 });
 ```
@@ -278,12 +286,19 @@ No tuple migration needed — individual roles are already modeled.
 ```typescript
 async function create(authContext, body) {
   // Call 1: 6-path SQL UNION to check access
-  await administrationService.verifyAdministrationAccess(authContext, body.administrationId);
+  await administrationService.verifyAdministrationAccess(
+    authContext,
+    body.administrationId,
+  );
   // Call 2: Another UNION to check role permissions
   if (!isSuperAdmin) {
-    const userRoles = await accessControls.getUserRolesForAdministration(userId, adminId);
+    const userRoles = await accessControls.getUserRolesForAdministration(
+      userId,
+      adminId,
+    );
     const allowedRoles = rolesForPermission(Permissions.Runs.CREATE);
-    if (!userRoles.some(role => allowedRoles.includes(role))) throw new ApiError(/* 403 */);
+    if (!userRoles.some((role) => allowedRoles.includes(role)))
+      throw new ApiError(/* 403 */);
   }
 }
 ```
@@ -292,13 +307,15 @@ async function create(authContext, body) {
 
 ```typescript
 async function create(authContext, body) {
-  const admin = await administrationRepository.getById({ id: body.administrationId });
+  const admin = await administrationRepository.getById({
+    id: body.administrationId,
+  });
   if (!admin) throw new ApiError(/* 404 */);
   if (!isSuperAdmin) {
     // Single FGA call: encodes BOTH relationship access AND permission check
     const { allowed } = await fga.check({
       user: `user:${userId}`,
-      relation: 'can_create_run',
+      relation: "can_create_run",
       object: `administration:${body.administrationId}`,
       context: { current_time: new Date().toISOString() },
     });
@@ -322,12 +339,12 @@ fga model validate --file authorization-model.fga
 
 ## Test files
 
-| File | Covers |
-|------|--------|
-| `administration-permissions.fga.yaml` | Administration access via all assignment types, all role tiers, list_objects |
-| `org-permissions.fga.yaml` | District/school permissions, ancestor/descendant access, cross-org isolation |
-| `class-permissions.fga.yaml` | Class permissions, school inheritance, caregiver access, sibling isolation |
-| `group-permissions.fga.yaml` | Group membership, administration access via groups |
-| `family-permissions.fga.yaml` | Parent/child relationships, cross-family isolation |
-| `enrollment-dates.fga.yaml` | Before-start denial, during-active, after-end denial, null-end sentinel, org/class/group boundaries |
-| `hierarchy-cascading.fga.yaml` | Supervisory down-cascading, supervised up-bubbling, no reverse cascading |
+| File                                  | Covers                                                                                              |
+| ------------------------------------- | --------------------------------------------------------------------------------------------------- |
+| `administration-permissions.fga.yaml` | Administration access via all assignment types, all role tiers, list_objects                        |
+| `org-permissions.fga.yaml`            | District/school permissions, ancestor/descendant access, cross-org isolation                        |
+| `class-permissions.fga.yaml`          | Class permissions, school inheritance, caregiver access, sibling isolation                          |
+| `group-permissions.fga.yaml`          | Group membership, administration access via groups                                                  |
+| `family-permissions.fga.yaml`         | Parent/child relationships, cross-family isolation                                                  |
+| `enrollment-dates.fga.yaml`           | Before-start denial, during-active, after-end denial, null-end sentinel, org/class/group boundaries |
+| `hierarchy-cascading.fga.yaml`        | Supervisory down-cascading, supervised up-bubbling, no reverse cascading                            |

--- a/packages/authz/README.md
+++ b/packages/authz/README.md
@@ -98,22 +98,22 @@ define can_delete: no_one
 
 Each role is modeled as its own FGA relation — no tier mapping. Tuples use the role name directly from Postgres.
 
-| Role                     | FGA relation             | Tier           | Cascading                    |
-| ------------------------ | ------------------------ | -------------- | ---------------------------- |
-| `system_administrator`   | `system_administrator`   | siteAdmin      | Down + subtree (supervisory) |
-| `site_administrator`     | `site_administrator`     | siteAdmin      | Down + subtree               |
-| `district_administrator` | `district_administrator` | admin          | Down + subtree               |
-| `administrator`          | `administrator`          | admin          | Down + subtree               |
-| `platform_admin`         | `platform_admin`         | platformAdmin  | Down + subtree (supervisory) |
-| `principal`              | `principal`              | educator       | Down + subtree               |
-| `counselor`              | `counselor`              | educator       | Down + subtree               |
-| `teacher`                | `teacher`                | educator       | Down + subtree               |
-| `aide`                   | `aide`                   | educator       | Down + subtree               |
-| `proctor`                | `proctor`                | educator       | Down + subtree               |
-| `student`                | `student`                | student        | Up (supervised)              |
-| `guardian`               | `guardian`               | caregiver      | Up                           |
-| `parent`                 | `parent`                 | caregiver      | Up                           |
-| `relative`               | `relative`               | caregiver      | Up                           |
+| Role                     | FGA relation             | Tier          | Cascading                    |
+| ------------------------ | ------------------------ | ------------- | ---------------------------- |
+| `system_administrator`   | `system_administrator`   | siteAdmin     | Down + subtree (supervisory) |
+| `site_administrator`     | `site_administrator`     | siteAdmin     | Down + subtree               |
+| `district_administrator` | `district_administrator` | admin         | Down + subtree               |
+| `administrator`          | `administrator`          | admin         | Down + subtree               |
+| `platform_admin`         | `platform_admin`         | platformAdmin | Down + subtree (supervisory) |
+| `principal`              | `principal`              | educator      | Down + subtree               |
+| `counselor`              | `counselor`              | educator      | Down + subtree               |
+| `teacher`                | `teacher`                | educator      | Down + subtree               |
+| `aide`                   | `aide`                   | educator      | Down + subtree               |
+| `proctor`                | `proctor`                | educator      | Down + subtree               |
+| `student`                | `student`                | student       | Up (supervised)              |
+| `guardian`               | `guardian`               | caregiver     | Up                           |
+| `parent`                 | `parent`                 | caregiver     | Up                           |
+| `relative`               | `relative`               | caregiver     | Up                           |
 
 > **`platform_admin` is ROAR-specific** — not part of the OneRoster v1.1/v1.2 standard. Assigned only to users created via CSV upload or the dashboard user creation form. External rostering providers (Clever, ClassLink, NYCPS) do not know this role exists, so it is naturally overwritten when an org transitions to an external provider.
 
@@ -143,8 +143,7 @@ For `family` entities, no computed user tier is currently allowed to create user
 
 - **`can_create_users`**: Gated on `platform_admin` role for `district`, `school`, and `group` entities only. `admin_tier` (OneRoster roles) intentionally excluded — externally-rostered administrators cannot create users.
 - **`can_list_users` on family:** Gated on `parent` — only parents can list family members. Children cannot.
-- **Groups have the full role model:** `user_groups` has a `role` column like `user_orgs`, so groups define all 13 roles with `active_membership` conditions, not just flat `member`.
-- **Groups are standalone — no org hierarchy cascading:** Groups have no `parent_org` link, so org-level roles (e.g., district admin) do not cascade into groups. A user must be an explicit member of a group to see it. This is intentional — groups are independent of the org tree.
+- **Groups have the full role model:** `user_groups` has a `role` column like `user_orgs`, so groups define all 14 roles (13 OneRoster + 1 ROAR-specific) with `active_membership` conditions, not just flat `member`.
 
 ## Bidirectional hierarchy
 

--- a/packages/authz/README.md
+++ b/packages/authz/README.md
@@ -132,7 +132,7 @@ Permissions are defined as computed relations in each type in `authorization-mod
 
 User creation is an exception to the CUD restrictions under the current model. A user with the computed role `admin_tier` has the permission `can_create_users` on entity types `district`, `school`, and `group`. This permission is still enforced in the app layer by first checking the requesting user for super-admin status to allow for authorization bypass, and then checking `can_create_users` for each entity type present in the `memberships` field of the request body.
 
-For `class` entities, this means that a user with the `admin_tier` computed role can create users in a class only if that user possess the `can_create_users` permissions on the parent school of the class.
+For `class` entities, this means that a user with the `admin_tier` computed role can create users in a class only if that user possesses the `can_create_users` permissions on the parent school of the class.
 
 For `family` entities, no computed user tier is currently allowed to create users, and implementation of the `can_create_users` permission on `family` entities is planned for a future enhancement.
 

--- a/packages/authz/README.md
+++ b/packages/authz/README.md
@@ -94,25 +94,28 @@ define can_list: member
 define can_delete: no_one
 ```
 
-### All 13 OneRoster roles
+### All 14 roles (13 OneRoster + 1 ROAR-specific)
 
 Each role is modeled as its own FGA relation — no tier mapping. Tuples use the role name directly from Postgres.
 
-| Role                     | FGA relation             | Tier      | Cascading                    |
-| ------------------------ | ------------------------ | --------- | ---------------------------- |
-| `system_administrator`   | `system_administrator`   | siteAdmin | Down + subtree (supervisory) |
-| `site_administrator`     | `site_administrator`     | siteAdmin | Down + subtree               |
-| `district_administrator` | `district_administrator` | admin     | Down + subtree               |
-| `administrator`          | `administrator`          | admin     | Down + subtree               |
-| `principal`              | `principal`              | educator  | Down + subtree               |
-| `counselor`              | `counselor`              | educator  | Down + subtree               |
-| `teacher`                | `teacher`                | educator  | Down + subtree               |
-| `aide`                   | `aide`                   | educator  | Down + subtree               |
-| `proctor`                | `proctor`                | educator  | Down + subtree               |
-| `student`                | `student`                | student   | Up (supervised)              |
-| `guardian`               | `guardian`               | caregiver | Up                           |
-| `parent`                 | `parent`                 | caregiver | Up                           |
-| `relative`               | `relative`               | caregiver | Up                           |
+| Role                     | FGA relation             | Tier           | Cascading                    |
+| ------------------------ | ------------------------ | -------------- | ---------------------------- |
+| `system_administrator`   | `system_administrator`   | siteAdmin      | Down + subtree (supervisory) |
+| `site_administrator`     | `site_administrator`     | siteAdmin      | Down + subtree               |
+| `district_administrator` | `district_administrator` | admin          | Down + subtree               |
+| `administrator`          | `administrator`          | admin          | Down + subtree               |
+| `platform_admin`         | `platform_admin`         | platformAdmin  | Down + subtree (supervisory) |
+| `principal`              | `principal`              | educator       | Down + subtree               |
+| `counselor`              | `counselor`              | educator       | Down + subtree               |
+| `teacher`                | `teacher`                | educator       | Down + subtree               |
+| `aide`                   | `aide`                   | educator       | Down + subtree               |
+| `proctor`                | `proctor`                | educator       | Down + subtree               |
+| `student`                | `student`                | student        | Up (supervised)              |
+| `guardian`               | `guardian`               | caregiver      | Up                           |
+| `parent`                 | `parent`                 | caregiver      | Up                           |
+| `relative`               | `relative`               | caregiver      | Up                           |
+
+> **`platform_admin` is ROAR-specific** — not part of the OneRoster v1.1/v1.2 standard. Assigned only to users created via CSV upload or the dashboard user creation form. External rostering providers (Clever, ClassLink, NYCPS) do not know this role exists, so it is naturally overwritten when an org transitions to an external provider.
 
 > **No `parent` rename needed:** The hierarchy links use `parent_org` (e.g., `define parent_org: [district]` on `school`), so there is no conflict with the `parent` role relation. Tuples use `parent` directly.
 
@@ -123,22 +126,22 @@ Shared across org types to simplify permission definitions:
 - **`admin_tier`** — siteAdmin + admin roles (system_administrator, site_administrator, district_administrator, administrator)
 - **`educator_tier`** — educator roles (principal, counselor, teacher, aide, proctor)
 - **`caregiver_tier`** — caregiver roles (guardian, parent, relative)
-- **`supervisory_tier_group`** — all supervisory roles (`admin_tier` + `educator_tier`)
+- **`supervisory_tier_group`** — all supervisory roles (`admin_tier` + `platform_admin` + `school_admin_tier` + `educator_tier`)
 - **`member`** — all roles (`supervisory_tier_group` + student + `caregiver_tier`)
 
 ### Permissions
 
 Permissions are defined as computed relations in each type in `authorization-model.fga`. See the model for the authoritative mapping of which role tiers grant which permissions. CUD permissions (`can_create`, `can_update`, `can_delete`) resolve to `no_one` — they are super-admin-only, enforced in the app layer.
 
-User creation is an exception to the CUD restrictions under the current model. A user with the computed role `admin_tier` has the permission `can_create_users` on entity types `district`, `school`, and `group`. This permission is still enforced in the app layer by first checking the requesting user for super-admin status to allow for authorization bypass, and then checking `can_create_users` for each entity type present in the `memberships` field of the request body.
+User creation is an exception to the CUD restrictions under the current model. A user with the `platform_admin` role has the permission `can_create_users` on entity types `district`, `school`, and `group`. This permission is still enforced in the app layer by first checking the requesting user for super-admin status to allow for authorization bypass, and then checking `can_create_users` for each entity type present in the `memberships` field of the request body.
 
-For `class` entities, this means that a user with the `admin_tier` computed role can create users in a class only if that user possesses the `can_create_users` permissions on the parent school of the class.
+For `class` entities, this means that a user with the `platform_admin` role can create users in a class only if that user possesses the `can_create_users` permission on the parent school of the class.
 
 For `family` entities, no computed user tier is currently allowed to create users, and implementation of the `can_create_users` permission on `family` entities is planned for a future enhancement.
 
 **Design notes:**
 
-- **`can_create_users`**: Gated on `admin_tier` computed role for `district`, `school`, and `group` entities only.
+- **`can_create_users`**: Gated on `platform_admin` role for `district`, `school`, and `group` entities only. `admin_tier` (OneRoster roles) intentionally excluded — externally-rostered administrators cannot create users.
 - **`can_list_users` on family:** Gated on `parent` — only parents can list family members. Children cannot.
 - **Groups have the full role model:** `user_groups` has a `role` column like `user_orgs`, so groups define all 13 roles with `active_membership` conditions, not just flat `member`.
 - **Groups are standalone — no org hierarchy cascading:** Groups have no `parent_org` link, so org-level roles (e.g., district admin) do not cascade into groups. A user must be an explicit member of a group to see it. This is intentional — groups are independent of the org tree.

--- a/packages/authz/authorization-model.fga
+++ b/packages/authz/authorization-model.fga
@@ -79,7 +79,6 @@ type district
     define can_list_users: admin_tier
     define can_read_scores: admin_tier
     define can_read_progress: admin_tier
-    # User creation is allowed by admin_tier only
     define can_create_users: admin_tier
 
 # ────────────────────────────────────────────────────────────────────────────────
@@ -154,7 +153,8 @@ type school
     define can_list_users: admin_tier or school_admin_tier
     define can_read_scores: admin_tier or school_admin_tier
     define can_read_progress: admin_tier or school_admin_tier
-    # User creation is allowed by admin_tier only
+    # User creation requires higher privilege than listing/reading — school_admin_tier
+    # (principals, counselors) can view users but may not create them.
     define can_create_users: admin_tier
 
 # ────────────────────────────────────────────────────────────────────────────────

--- a/packages/authz/authorization-model.fga
+++ b/packages/authz/authorization-model.fga
@@ -32,6 +32,10 @@ type district
     define site_administrator: [user with active_membership]
     define district_administrator: [user with active_membership]
     define administrator: [user with active_membership]
+    # ROAR-specific role for CSV/dashboard-created users with elevated create privileges.
+    # Not part of the OneRoster standard. External providers naturally overwrite this role
+    # on sync — transitioning to an external provider intentionally surrenders platform management.
+    define platform_admin: [user with active_membership]
 
     define principal: [user with active_membership]
     define counselor: [user with active_membership]
@@ -50,7 +54,7 @@ type district
     define school_admin_tier: principal or counselor
     define educator_tier: teacher or aide or proctor
     define caregiver_tier: guardian or parent or relative
-    define supervisory_tier_group: admin_tier or school_admin_tier or educator_tier
+    define supervisory_tier_group: admin_tier or platform_admin or school_admin_tier or educator_tier
     define member: supervisory_tier_group or caregiver_tier or student
 
     # Subtree membership — aggregates supervisory users from the district's
@@ -76,10 +80,12 @@ type district
     # User/score/progress visibility at the district level is restricted to
     # admin roles. A mis-rostered teacher at the district level should not
     # gain access to student data across the entire district.
-    define can_list_users: admin_tier
-    define can_read_scores: admin_tier
-    define can_read_progress: admin_tier
-    define can_create_users: admin_tier
+    define can_list_users: admin_tier or platform_admin
+    define can_read_scores: admin_tier or platform_admin
+    define can_read_progress: admin_tier or platform_admin
+    # Only platform_admin can create users — admin_tier (OneRoster roles) cannot,
+    # ensuring create-user capability is never granted to externally-rostered users.
+    define can_create_users: platform_admin
 
 # ────────────────────────────────────────────────────────────────────────────────
 # school — mid-level org, child of district, parent of classes
@@ -109,6 +115,7 @@ type school
     define site_administrator: [user with active_membership] or site_administrator from parent_org
     define district_administrator: [user with active_membership] or district_administrator from parent_org
     define administrator: [user with active_membership] or administrator from parent_org
+    define platform_admin: [user with active_membership] or platform_admin from parent_org
 
     define principal: [user with active_membership]
     define counselor: [user with active_membership]
@@ -127,7 +134,7 @@ type school
     define school_admin_tier: principal or counselor
     define educator_tier: teacher or aide or proctor
     define caregiver_tier: guardian or parent or relative
-    define supervisory_tier_group: admin_tier or school_admin_tier or educator_tier
+    define supervisory_tier_group: admin_tier or platform_admin or school_admin_tier or educator_tier
     define member: supervisory_tier_group or caregiver_tier or student
 
     # Subtree membership — aggregates supervisory users from the school's
@@ -149,13 +156,13 @@ type school
     # to see student data. School-level educators should not see a list of
     # classes they cannot interact with (UI bloat). Only admin and school_admin
     # tiers can list classes at the school level.
-    define can_list_classes: admin_tier or school_admin_tier
-    define can_list_users: admin_tier or school_admin_tier
-    define can_read_scores: admin_tier or school_admin_tier
-    define can_read_progress: admin_tier or school_admin_tier
-    # User creation requires higher privilege than listing/reading — school_admin_tier
-    # (principals, counselors) can view users but may not create them.
-    define can_create_users: admin_tier
+    define can_list_classes: admin_tier or platform_admin or school_admin_tier
+    define can_list_users: admin_tier or platform_admin or school_admin_tier
+    define can_read_scores: admin_tier or platform_admin or school_admin_tier
+    define can_read_progress: admin_tier or platform_admin or school_admin_tier
+    # Only platform_admin can create users — admin_tier (OneRoster roles) cannot,
+    # ensuring create-user capability is never granted to externally-rostered users.
+    define can_create_users: platform_admin
 
 # ────────────────────────────────────────────────────────────────────────────────
 # class — leaf-level entity, child of school
@@ -177,6 +184,7 @@ type class
     define site_administrator: [user with active_membership] or site_administrator from parent_org
     define district_administrator: [user with active_membership] or district_administrator from parent_org
     define administrator: [user with active_membership] or administrator from parent_org
+    define platform_admin: [user with active_membership] or platform_admin from parent_org
 
     define principal: [user with active_membership] or principal from parent_org
     define counselor: [user with active_membership] or counselor from parent_org
@@ -195,7 +203,7 @@ type class
     define school_admin_tier: principal or counselor
     define educator_tier: teacher or aide or proctor
     define caregiver_tier: guardian or parent or relative
-    define supervisory_tier_group: admin_tier or school_admin_tier or educator_tier
+    define supervisory_tier_group: admin_tier or platform_admin or school_admin_tier or educator_tier
     define member: supervisory_tier_group or caregiver_tier or student
 
     # Permissions
@@ -253,6 +261,7 @@ type group
     define site_administrator: [user with active_membership]
     define district_administrator: [user with active_membership]
     define administrator: [user with active_membership]
+    define platform_admin: [user with active_membership]
 
     define principal: [user with active_membership]
     define counselor: [user with active_membership]
@@ -271,7 +280,7 @@ type group
     define school_admin_tier: principal or counselor
     define educator_tier: teacher or aide or proctor
     define caregiver_tier: guardian or parent or relative
-    define supervisory_tier_group: admin_tier or school_admin_tier or educator_tier
+    define supervisory_tier_group: admin_tier or platform_admin or school_admin_tier or educator_tier
     define member: supervisory_tier_group or caregiver_tier or student
 
     # Permissions
@@ -284,8 +293,9 @@ type group
     define can_list: supervisory_tier_group
     define can_read: supervisory_tier_group
     define can_list_users: supervisory_tier_group
-    # User creation is allowed by admin_tier only
-    define can_create_users: admin_tier
+    # Only platform_admin can create users — admin_tier (OneRoster roles) cannot,
+    # ensuring create-user capability is never granted to externally-rostered users.
+    define can_create_users: platform_admin
 
 # ────────────────────────────────────────────────────────────────────────────────
 # administration — an assessment administration assigned to orgs, classes,
@@ -315,6 +325,7 @@ type administration
     define site_administrator: site_administrator from assigned_district or site_administrator from assigned_school or site_administrator from assigned_class or site_administrator from assigned_group
     define district_administrator: district_administrator from assigned_district or district_administrator from assigned_school or district_administrator from assigned_class or district_administrator from assigned_group
     define administrator: administrator from assigned_district or administrator from assigned_school or administrator from assigned_class or administrator from assigned_group
+    define platform_admin: platform_admin from assigned_district or platform_admin from assigned_school or platform_admin from assigned_class or platform_admin from assigned_group
 
     define principal: principal from assigned_district or principal from assigned_school or principal from assigned_class or principal from assigned_group
     define counselor: counselor from assigned_district or counselor from assigned_school or counselor from assigned_class or counselor from assigned_group
@@ -331,7 +342,7 @@ type administration
     define school_admin_tier: principal or counselor
     define educator_tier: teacher or aide or proctor
     define caregiver_tier: guardian or parent or relative
-    define supervisory_tier_group: admin_tier or school_admin_tier or educator_tier or subtree_supervisory_tier_group from assigned_district or subtree_supervisory_tier_group from assigned_school or supervisory_tier_group from assigned_class or supervisory_tier_group from assigned_group
+    define supervisory_tier_group: admin_tier or platform_admin or school_admin_tier or educator_tier or subtree_supervisory_tier_group from assigned_district or subtree_supervisory_tier_group from assigned_school or supervisory_tier_group from assigned_class or supervisory_tier_group from assigned_group
 
     # Permissions
     define no_one: [user]

--- a/packages/authz/authorization-model.fga
+++ b/packages/authz/authorization-model.fga
@@ -79,6 +79,8 @@ type district
     define can_list_users: admin_tier
     define can_read_scores: admin_tier
     define can_read_progress: admin_tier
+    # User creation is allowed by admin_tier only
+    define can_create_users: admin_tier
 
 # ────────────────────────────────────────────────────────────────────────────────
 # school — mid-level org, child of district, parent of classes
@@ -152,6 +154,8 @@ type school
     define can_list_users: admin_tier or school_admin_tier
     define can_read_scores: admin_tier or school_admin_tier
     define can_read_progress: admin_tier or school_admin_tier
+    # User creation is allowed by admin_tier only
+    define can_create_users: admin_tier
 
 # ────────────────────────────────────────────────────────────────────────────────
 # class — leaf-level entity, child of school
@@ -223,7 +227,7 @@ type family
     define can_create: no_one
     define can_update: no_one
     define can_delete: no_one
-    
+
     define can_list: parent
     define can_read: parent
     define can_list_users: parent
@@ -280,6 +284,8 @@ type group
     define can_list: supervisory_tier_group
     define can_read: supervisory_tier_group
     define can_list_users: supervisory_tier_group
+    # User creation is allowed by admin_tier only
+    define can_create_users: admin_tier
 
 # ────────────────────────────────────────────────────────────────────────────────
 # administration — an assessment administration assigned to orgs, classes,
@@ -309,7 +315,7 @@ type administration
     define site_administrator: site_administrator from assigned_district or site_administrator from assigned_school or site_administrator from assigned_class or site_administrator from assigned_group
     define district_administrator: district_administrator from assigned_district or district_administrator from assigned_school or district_administrator from assigned_class or district_administrator from assigned_group
     define administrator: administrator from assigned_district or administrator from assigned_school or administrator from assigned_class or administrator from assigned_group
-    
+
     define principal: principal from assigned_district or principal from assigned_school or principal from assigned_class or principal from assigned_group
     define counselor: counselor from assigned_district or counselor from assigned_school or counselor from assigned_class or counselor from assigned_group
     define teacher: teacher from assigned_district or teacher from assigned_school or teacher from assigned_class or teacher from assigned_group

--- a/packages/authz/tests/group-permissions.fga.yaml
+++ b/packages/authz/tests/group-permissions.fga.yaml
@@ -27,6 +27,14 @@ tuples:
       context:
         grant_start: "2020-01-01T00:00:00Z"
         grant_end: "9999-12-31T23:59:59Z"
+  - user: user:group-admin
+    relation: administrator
+    object: group:group-a
+    condition:
+      name: active_membership
+      context:
+        grant_start: "2020-01-01T00:00:00Z"
+        grant_end: "9999-12-31T23:59:59Z"
 
   # ─── Administration assigned to group ──────────────────────────────
   - user: group:group-a
@@ -83,6 +91,59 @@ tests:
           can_list: false
           can_read: false
           can_list_users: false
+
+  # ─── can_create_users ─────────────────────────────────────────────
+
+  - name: Group admin can list/read group and create users but not CUD
+    check:
+      - user: user:group-admin
+        object: group:group-a
+        context:
+          current_time: "2025-06-15T12:00:00Z"
+        assertions:
+          can_list: true
+          can_read: true
+          can_list_users: true
+          can_create_users: true
+          can_create: false
+          can_update: false
+          can_delete: false
+
+  - name: Group teacher cannot create users in their group (educator tier)
+    check:
+      - user: user:group-teacher
+        object: group:group-a
+        context:
+          current_time: "2025-06-15T12:00:00Z"
+        assertions:
+          can_create_users: false
+
+  - name: Group student cannot create users in their group
+    check:
+      - user: user:group-student
+        object: group:group-a
+        context:
+          current_time: "2025-06-15T12:00:00Z"
+        assertions:
+          can_create_users: false
+
+  - name: Group guardian cannot create users in their group
+    check:
+      - user: user:group-guardian
+        object: group:group-a
+        context:
+          current_time: "2025-06-15T12:00:00Z"
+        assertions:
+          can_create_users: false
+
+  - name: Non-member cannot create users in group
+    check:
+      - user: user:nobody
+        object: group:group-a
+        context:
+          current_time: "2025-06-15T12:00:00Z"
+        assertions:
+          can_create_users: false
 
   - name: Group student can list/read and create runs on group-assigned administration
     check:

--- a/packages/authz/tests/group-permissions.fga.yaml
+++ b/packages/authz/tests/group-permissions.fga.yaml
@@ -35,6 +35,14 @@ tuples:
       context:
         grant_start: "2020-01-01T00:00:00Z"
         grant_end: "9999-12-31T23:59:59Z"
+  - user: user:group-platform-admin
+    relation: platform_admin
+    object: group:group-a
+    condition:
+      name: active_membership
+      context:
+        grant_start: "2020-01-01T00:00:00Z"
+        grant_end: "9999-12-31T23:59:59Z"
 
   # ─── Administration assigned to group ──────────────────────────────
   - user: group:group-a
@@ -94,9 +102,24 @@ tests:
 
   # ─── can_create_users ─────────────────────────────────────────────
 
-  - name: Group admin can list/read group and create users but not CUD
+  - name: Group admin (OneRoster role) can list/read group but cannot create users
     check:
       - user: user:group-admin
+        object: group:group-a
+        context:
+          current_time: "2025-06-15T12:00:00Z"
+        assertions:
+          can_list: true
+          can_read: true
+          can_list_users: true
+          can_create_users: false
+          can_create: false
+          can_update: false
+          can_delete: false
+
+  - name: Group platform admin can create users in their group
+    check:
+      - user: user:group-platform-admin
         object: group:group-a
         context:
           current_time: "2025-06-15T12:00:00Z"

--- a/packages/authz/tests/org-permissions.fga.yaml
+++ b/packages/authz/tests/org-permissions.fga.yaml
@@ -177,6 +177,15 @@ tests:
           can_read_scores: true
           can_read_progress: true
 
+  - name: District admin can create users in their district
+    check:
+      - user: user:district-admin
+        object: district:district-a
+        context:
+          current_time: "2025-06-15T12:00:00Z"
+        assertions:
+          can_create_users: true
+
   - name: District admin cannot see other district
     check:
       - user: user:district-admin
@@ -209,6 +218,15 @@ tests:
           can_update: false
           can_delete: false
 
+  - name: District teacher cannot create users in their district
+    check:
+      - user: user:district-teacher
+        object: district:district-a
+        context:
+          current_time: "2025-06-15T12:00:00Z"
+        assertions:
+          can_create_users: false
+
   - name: District student cannot list/read their district (supervisory only)
     check:
       - user: user:district-student
@@ -223,6 +241,33 @@ tests:
           can_delete: false
           can_list_users: false
           can_read_scores: false
+
+  - name: District student cannot create users in their district
+    check:
+      - user: user:district-student
+        object: district:district-a
+        context:
+          current_time: "2025-06-15T12:00:00Z"
+        assertions:
+          can_create_users: false
+
+  - name: Guardian in district cannot create users in their district
+    check:
+      - user: user:guardian-in-school
+        object: district:district-a
+        context:
+          current_time: "2025-06-15T12:00:00Z"
+        assertions:
+          can_create_users: false
+
+  - name: District admin cannot create users in another district
+    check:
+      - user: user:district-admin
+        object: district:district-b
+        context:
+          current_time: "2025-06-15T12:00:00Z"
+        assertions:
+          can_create_users: false
 
   - name: School principal can list/read parent district (ancestor visibilty via subtree)
     check:
@@ -240,6 +285,15 @@ tests:
           supervisory_tier_group: false
           subtree_supervisory_tier_group: true
 
+  - name: School principal cannot create users in their school
+    check:
+      - user: user:school-principal
+        object: school:school-a
+        context:
+          current_time: "2025-06-15T12:00:00Z"
+        assertions:
+          can_create_users: false
+
   - name: School teacher can list/read parent district (ancestor visibility via subtree)
     check:
       - user: user:school-teacher
@@ -256,6 +310,15 @@ tests:
           supervisory_tier_group: false
           subtree_supervisory_tier_group: true
 
+  - name: School teacher cannot create users in their school
+    check:
+      - user: user:school-teacher
+        object: school:school-a
+        context:
+          current_time: "2025-06-15T12:00:00Z"
+        assertions:
+          can_create_users: false
+
   - name: Class teacher can list/read parent district (ancestor visibility via subtree, two hops)
     check:
       - user: user:class-teacher
@@ -269,6 +332,15 @@ tests:
           can_list_users: false
           can_read_scores: false
           can_read_progress: false
+
+  - name: Class teacher cannot create users in parent school (class has no can_create_users — checked via parent school)
+    check:
+      - user: user:class-teacher
+        object: school:school-a
+        context:
+          current_time: "2025-06-15T12:00:00Z"
+        assertions:
+          can_create_users: false
 
   - name: Student in school cannot list/read parent district (supervisory only)
     check:
@@ -345,6 +417,42 @@ tests:
           can_create: false
           can_update: false
           can_delete: false
+
+  - name: District admin can create users in sibling school (same district)
+    check:
+      - user: user:district-admin
+        object: school:school-b
+        context:
+          current_time: "2025-06-15T12:00:00Z"
+        assertions:
+          can_create_users: true
+
+  - name: District admin can create users in descendant school
+    check:
+      - user: user:district-admin
+        object: school:school-a
+        context:
+          current_time: "2025-06-15T12:00:00Z"
+        assertions:
+          can_create_users: true
+
+  - name: School counselor cannot create users in their school
+    check:
+      - user: user:school-counselor
+        object: school:school-a
+        context:
+          current_time: "2025-06-15T12:00:00Z"
+        assertions:
+          can_create_users: false
+
+  - name: Student in school cannot create users in their school
+    check:
+      - user: user:student-in-school
+        object: school:school-a
+        context:
+          current_time: "2025-06-15T12:00:00Z"
+        assertions:
+          can_create_users: false
 
   - name: School principal can list/read school and classes and can access student data (supervisory_tier_group)
     check:
@@ -509,6 +617,7 @@ tests:
         assertions:
           can_list: false
           can_read: false
+          can_create_users: false
 
   - name: Admin in tree A cannot see class in tree B
     check:

--- a/packages/authz/tests/org-permissions.fga.yaml
+++ b/packages/authz/tests/org-permissions.fga.yaml
@@ -31,6 +31,14 @@ tuples:
       context:
         grant_start: "2020-01-01T00:00:00Z"
         grant_end: "9999-12-31T23:59:59Z"
+  - user: user:district-platform-admin
+    relation: platform_admin
+    object: district:district-a
+    condition:
+      name: active_membership
+      context:
+        grant_start: "2020-01-01T00:00:00Z"
+        grant_end: "9999-12-31T23:59:59Z"
   - user: user:district-teacher
     relation: teacher
     object: district:district-a
@@ -177,14 +185,14 @@ tests:
           can_read_scores: true
           can_read_progress: true
 
-  - name: District admin can create users in their district
+  - name: District admin (OneRoster role) cannot create users in their district
     check:
       - user: user:district-admin
         object: district:district-a
         context:
           current_time: "2025-06-15T12:00:00Z"
         assertions:
-          can_create_users: true
+          can_create_users: false
 
   - name: District admin cannot see other district
     check:
@@ -418,23 +426,23 @@ tests:
           can_update: false
           can_delete: false
 
-  - name: District admin can create users in sibling school (same district)
+  - name: District admin (OneRoster role) cannot create users in sibling school
     check:
       - user: user:district-admin
         object: school:school-b
         context:
           current_time: "2025-06-15T12:00:00Z"
         assertions:
-          can_create_users: true
+          can_create_users: false
 
-  - name: District admin can create users in descendant school
+  - name: District admin (OneRoster role) cannot create users in descendant school
     check:
       - user: user:district-admin
         object: school:school-a
         context:
           current_time: "2025-06-15T12:00:00Z"
         assertions:
-          can_create_users: true
+          can_create_users: false
 
   - name: School counselor cannot create users in their school
     check:
@@ -781,6 +789,7 @@ tests:
           can_list:
             users:
               - user:district-admin
+              - user:district-platform-admin
               - user:district-teacher
               - user:school-principal
               - user:principal-in-tree-a
@@ -803,8 +812,54 @@ tests:
           can_list:
             users:
               - user:district-admin
+              - user:district-platform-admin
               - user:school-principal
               - user:principal-in-tree-a
               - user:school-counselor
               - user:school-teacher
               - user:teacher-in-tree-a
+
+  # ─── platform_admin permissions ───────────────────────────────────────
+
+  - name: Platform admin has full supervisory permissions and can create users in their district
+    check:
+      - user: user:district-platform-admin
+        object: district:district-a
+        context:
+          current_time: "2025-06-15T12:00:00Z"
+        assertions:
+          can_list: true
+          can_read: true
+          can_list_users: true
+          can_read_scores: true
+          can_read_progress: true
+          can_create_users: true
+          can_create: false
+          can_update: false
+          can_delete: false
+
+  - name: Platform admin can create users in descendant school (cascade via parent_org)
+    check:
+      - user: user:district-platform-admin
+        object: school:school-a
+        context:
+          current_time: "2025-06-15T12:00:00Z"
+        assertions:
+          can_list: true
+          can_read: true
+          can_list_users: true
+          can_read_scores: true
+          can_read_progress: true
+          can_list_classes: true
+          can_create_users: true
+
+  - name: Platform admin cannot access another district
+    check:
+      - user: user:district-platform-admin
+        object: district:district-b
+        context:
+          current_time: "2025-06-15T12:00:00Z"
+        assertions:
+          can_list: false
+          can_read: false
+          can_create_users: false

--- a/packages/authz/tests/org-permissions.fga.yaml
+++ b/packages/authz/tests/org-permissions.fga.yaml
@@ -55,6 +55,14 @@ tuples:
       context:
         grant_start: "2020-01-01T00:00:00Z"
         grant_end: "9999-12-31T23:59:59Z"
+  - user: user:school-platform-admin
+    relation: platform_admin
+    object: school:school-a
+    condition:
+      name: active_membership
+      context:
+        grant_start: "2020-01-01T00:00:00Z"
+        grant_end: "9999-12-31T23:59:59Z"
   - user: user:school-principal
     relation: principal
     object: school:school-a
@@ -791,6 +799,7 @@ tests:
               - user:district-admin
               - user:district-platform-admin
               - user:district-teacher
+              - user:school-platform-admin
               - user:school-principal
               - user:principal-in-tree-a
               - user:school-counselor
@@ -813,6 +822,7 @@ tests:
             users:
               - user:district-admin
               - user:district-platform-admin
+              - user:school-platform-admin
               - user:school-principal
               - user:principal-in-tree-a
               - user:school-counselor
@@ -857,6 +867,35 @@ tests:
     check:
       - user: user:district-platform-admin
         object: district:district-b
+        context:
+          current_time: "2025-06-15T12:00:00Z"
+        assertions:
+          can_list: false
+          can_read: false
+          can_create_users: false
+
+  - name: School-directly-rostered platform admin has full permissions at that school
+    check:
+      - user: user:school-platform-admin
+        object: school:school-a
+        context:
+          current_time: "2025-06-15T12:00:00Z"
+        assertions:
+          can_list: true
+          can_read: true
+          can_list_users: true
+          can_read_scores: true
+          can_read_progress: true
+          can_list_classes: true
+          can_create_users: true
+          can_create: false
+          can_update: false
+          can_delete: false
+
+  - name: School-directly-rostered platform admin cannot access sibling school
+    check:
+      - user: user:school-platform-admin
+        object: school:school-b
         context:
           current_time: "2025-06-15T12:00:00Z"
         assertions:


### PR DESCRIPTION
## Proposed changes

## Summary

> [!IMPORTANT] 
> After this PR merges, run `npm run db:migrate -w apps/backend` to apply the `platform_admin` enum addition to your local database.
                                                                                                                                                                              
This PR introduces `platform_admin`, a new ROAR-specific role for CSV/dashboard-created users (research partners and users requiring direct platform control), and grants `can_create_users` exclusively to this role. Externally-rostered users (Clever, ClassLink, NYCPS) are intentionally excluded — they receive standard OneRoster roles         (administrator, teacher, etc.) which do not carry can_create_users.
                                                                                                                                                                              
## Design decisions           

### Why a new role instead of granting `admin_tier` `can_create_users`                                                                                                              
   
The original approach granted `can_create_users` to admin_tier (all OneRoster administrator roles). After team discussion, this was rejected because it would allow externally-rostered administrators to create users, bypassing the intent that user creation is a ROAR platform capability only available to users whose source of truth is ROAR itself. `platform_admin` is not part of the OneRoster v1.1/v1.2 standard. It is assigned only to users created via CSV upload or the dashboard user creation form. The role is documented in `userRoleEnum` with a comment explaining its semantics.
                                                                                                                                                                              
### External provider overwrites are intentional

When an org transitions from CSV to an external provider (Clever, ClassLink, etc.), the provider's sync naturally overwrites platform_admin with the corresponding OneRoster role during roster ingestion. This is by design: transitioning to an external provider surrenders platform management. No sync guard or revocation logic is needed. A TODO note is placed in the authorization model for when the refactored sync pipeline lands.                                                                                      
                             
### user_orgs primary key constraint                                                                                                                                            
   
`user_orgs` has a (`userId`, `orgId`) primary key — one role per user per org. `platform_admin` therefore replaces administrator in `user_orgs` rather than coexisting alongside it. This is semantically correct: `platform_admin` is administrator-equivalent plus the ability to create users. Nothing is lost by the substitution.
                                                                                                                                                                              
### Cascade behavior           

`platform_admin` cascades down the org hierarchy identically to administrator:                                                                                                
  - District `platform_admin` → school (via `platform_admin` from `parent_org`) → class (via `platform_admin` from `parent_org`)
  - Groups have a direct `platform_admin` relation (no hierarchy)                                                                                                               
  - class has no `can_create_users` — the service layer checks the parent school, consistent with how `FGA_CLASS_VALID_ROLES` already excludes admin-tier roles
                                                                                                                                                                              
### `supervisory_tier_group` membership                                                                                                                                           
                                                                                                                                                                              
`platform_admin` is added to `supervisory_tier_group` on all entity types (district, school, class, group, administration). This grants it `can_list`, `can_read`, `can_list_users`, `can_read_scores`, and `can_read_progress` without requiring individual permission entries. `can_create_users` is defined separately as `platform_admin` only.                      
                                                                                                                                                                              
## Changes                                                                                                                                                                     
   
### Schema and enums:                                                                                                                                                           
  - apps/backend/src/db/schema/enums.ts — adds `platform_admin` to `userRoleEnum` with documentation
  - packages/api-contract/src/v1/common/user.ts — adds 'platform_admin' to UserRoleSchema (rebuilt dist)                                                                      
                                                                                                        
### Role classifications and permissions:                                                                                                                                       
  - apps/backend/src/constants/role-classifications.ts — adds `platform_admin` to `HIERARCHICAL_USER_ACCESS_ROLES` and `SUPERVISORY_ROLES`                                          
  - apps/backend/src/constants/role-permissions.ts — adds `platform_admin` permission tier (admin permissions + `Users.CREATE`); OneRoster admin roles do NOT have `Users.CREATE`   
  - apps/backend/src/constants/role-permissions.test.ts — updates role counts; adds `platform_admin` coverage test                                                              
                                                                                                                                                                              
### FGA authorization model:                                                                                                                                                    
  - packages/authz/authorization-model.fga — adds `platform_admin` relation to district, school, class, group, and administration types; changes `can_create_users` from `admin_tier` → `platform_admin` on all entity types; adds `platform_admin` to `supervisory_tier_group` everywhere; updates `can_list_users`, `can_read_scores`, `can_read_progress`, `can_list_classes` at district/school to `admin_tier` or `platform_admin`                                                                                                   
  - apps/backend/src/services/authorization/fga-constants.ts — adds comment explaining why `platform_admin` is excluded from `FGA_CLASS_VALID_ROLES` (cascades via `parent_org`, not direct class assignment)  
                                                                                                                                                                              
### FGA tests:
  - packages/authz/tests/org-permissions.fga.yaml — adds `user:district-platform-admin` tuple; rewrites 3 admin `can_create_users: true` tests to false; updates 2 `list_users` assertions; adds 3 new `platform_admin` tests                                                                                                                                 
  - packages/authz/tests/group-permissions.fga.yaml — adds `user:group-platform-admin` tuple; rewrites group admin `can_create_user`s test to false; adds group `platform_admin` test                                                                                                                                                                        
                                                                                                                                                                              
### Not in this PR (deferred):                                                                                                
  - Data backfill updating existing CSV admins' user_orgs.role from administrator to platform_admin

<!--
Describe your changes here. Why are they necessary?

If it fixes a bug or resolves a feature request, be sure to link to that issue.

If appropriate, include images of the expected behavior or user experience.
You can drag and drop images into this text box.
-->

## Types of changes

What types of changes does this pull request introduce?

<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (non-breaking change that does not add functionality but makes code cleaner or more efficient)
- [x] Documentation Update
- [x] Tests (new or updated tests)
- [ ] Style (changes to code styling)
- [ ] CI (continuous integration changes)
- [ ] Repository Maintenance
- [ ] Other (please describe below)

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask.  We're here
to help! This is simply a reminder of what we are going to look for before
merging your code.
-->

- [x] I have read the [guidelines for contributing](https://github.com/yeatmanlab/roar-dashboard/blob/main/.github/CONTRIBUTING.md).
- [x] The changes in this PR are as small as they can be. They represent one and only one fix or enhancement.
- [x] Linting checks pass with my changes.
- [x] Any existing unit tests pass with my changes.
- [x] Any existing end-to-end tests pass with my changes.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] If this PR fixes an existing issue, I have added a unit or end-to-end test that will detect if this issue reoccurs.
- [x] I have added JSDoc comments as appropriate.
- [ ] I have added the necessary documentation to the [roar-docs repository](https://github.com/yeatmanlab/roar-docs).
- [x] I have shared this PR on the roar-pr-reviews channel (if I have access)
- [x] I have linked relevant issues (if any)

## Justification of missing checklist items

<!--
If you feel that a checklist item above is not applicable to this PR, please
provide your justification here. Otherwise, delete this section.
-->

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
