### PR TITLE
`enh` Create `rostering_provider_id` entity when creating a new user

### DIFF
--- a/apps/backend/src/db/clients.ts
+++ b/apps/backend/src/db/clients.ts
@@ -33,6 +33,18 @@ type CoreDbClientType = NodePgDatabase<typeof CoreDbSchema> & { $client: Pool };
 /** Drizzle ORM client type for the assessment database with full schema. */
 type AssessmentDbClientType = NodePgDatabase<typeof AssessmentDbSchema> & { $client: Pool };
 
+/**
+ * The transaction proxy type produced by `CoreDbClient.transaction()`. Use this
+ * instead of `NodePgDatabase<any>` when accepting a transaction as a parameter.
+ *
+ * Derived from the callback signature of `CoreDbClientType.transaction` so it
+ * always stays in sync with the actual driver and schema without hard-coding
+ * the internal Drizzle generic parameters.
+ */
+export type CoreTransaction = Parameters<CoreDbClientType['transaction']>[0] extends (tx: infer T) => unknown
+  ? T
+  : never;
+
 let corePool: Pool | null = null;
 let assessmentPool: Pool | null = null;
 let initialized = false;

--- a/apps/backend/src/repositories/base.repository.integration.test.ts
+++ b/apps/backend/src/repositories/base.repository.integration.test.ts
@@ -229,7 +229,7 @@ describe('BaseRepository', () => {
       });
 
       expect(result).not.toBeNull();
-      expect(result.id).toBe(user.id);
+      expect(result!.id).toBe(user.id);
 
       // Verify committed
       const fetched = await repository.getById({ id: user.id });

--- a/apps/backend/src/repositories/base.repository.ts
+++ b/apps/backend/src/repositories/base.repository.ts
@@ -241,8 +241,9 @@ export abstract class BaseRepository<TEntity extends Record<string, unknown>, TT
    * Deletes an entity by ID.
    */
   async delete(params: BaseDeleteParams): Promise<void> {
+    const db = params.transaction ?? this.db;
     const idColumn = this.typedTable.id as Parameters<typeof eq>[0];
-    await this.db.delete(this.typedTable).where(eq(idColumn, params.id));
+    await db.delete(this.typedTable).where(eq(idColumn, params.id));
   }
 
   /**

--- a/apps/backend/src/repositories/base.repository.ts
+++ b/apps/backend/src/repositories/base.repository.ts
@@ -193,6 +193,8 @@ export abstract class BaseRepository<TEntity extends Record<string, unknown>, TT
 
     const [entity] = await db.insert(this.typedTable).values(params.data).returning({ id: this.typedTable.id });
 
+    if (!entity) throw new Error('Insert returned no rows');
+
     return entity;
   }
 

--- a/apps/backend/src/repositories/class.repository.integration.test.ts
+++ b/apps/backend/src/repositories/class.repository.integration.test.ts
@@ -331,4 +331,53 @@ describe('ClassRepository', () => {
       });
     });
   });
+
+  describe('getDistinctRootIds', () => {
+    // Base fixture class → district mapping:
+    //   classInSchoolA  → schoolA  → district
+    //   classInSchoolB  → schoolB  → district
+    //   classInDistrictB → schoolInDistrictB → districtB
+
+    it('returns empty array when called with no ids', async () => {
+      const result = await repository.getDistinctRootIds([]);
+
+      expect(result).toEqual([]);
+    });
+
+    it('returns the district for a single class', async () => {
+      const result = await repository.getDistinctRootIds([baseFixture.classInSchoolA.id]);
+
+      expect(result).toHaveLength(1);
+      expect(result[0]!.id).toBe(baseFixture.district.id);
+    });
+
+    it('deduplicates when multiple classes share the same district', async () => {
+      // classInSchoolA and classInSchoolB both fall under district via different schools
+      const result = await repository.getDistinctRootIds([
+        baseFixture.classInSchoolA.id,
+        baseFixture.classInSchoolB.id,
+      ]);
+
+      expect(result).toHaveLength(1);
+      expect(result[0]!.id).toBe(baseFixture.district.id);
+    });
+
+    it('returns multiple districts when classes span different roots', async () => {
+      const result = await repository.getDistinctRootIds([
+        baseFixture.classInSchoolA.id,
+        baseFixture.classInDistrictB.id,
+      ]);
+
+      const ids = result.map((r) => r.id);
+      expect(ids).toHaveLength(2);
+      expect(ids).toContain(baseFixture.district.id);
+      expect(ids).toContain(baseFixture.districtB.id);
+    });
+
+    it('returns empty array for a non-existent class id', async () => {
+      const result = await repository.getDistinctRootIds(['00000000-0000-0000-0000-000000000000']);
+
+      expect(result).toEqual([]);
+    });
+  });
 });

--- a/apps/backend/src/repositories/class.repository.integration.test.ts
+++ b/apps/backend/src/repositories/class.repository.integration.test.ts
@@ -332,20 +332,20 @@ describe('ClassRepository', () => {
     });
   });
 
-  describe('getDistinctRootIds', () => {
+  describe('getDistinctRootOrgIds', () => {
     // Base fixture class → district mapping:
     //   classInSchoolA  → schoolA  → district
     //   classInSchoolB  → schoolB  → district
     //   classInDistrictB → schoolInDistrictB → districtB
 
     it('returns empty array when called with no ids', async () => {
-      const result = await repository.getDistinctRootIds([]);
+      const result = await repository.getDistinctRootOrgIds([]);
 
       expect(result).toEqual([]);
     });
 
     it('returns the district for a single class', async () => {
-      const result = await repository.getDistinctRootIds([baseFixture.classInSchoolA.id]);
+      const result = await repository.getDistinctRootOrgIds([baseFixture.classInSchoolA.id]);
 
       expect(result).toHaveLength(1);
       expect(result[0]!.id).toBe(baseFixture.district.id);
@@ -353,7 +353,7 @@ describe('ClassRepository', () => {
 
     it('deduplicates when multiple classes share the same district', async () => {
       // classInSchoolA and classInSchoolB both fall under district via different schools
-      const result = await repository.getDistinctRootIds([
+      const result = await repository.getDistinctRootOrgIds([
         baseFixture.classInSchoolA.id,
         baseFixture.classInSchoolB.id,
       ]);
@@ -363,7 +363,7 @@ describe('ClassRepository', () => {
     });
 
     it('returns multiple districts when classes span different roots', async () => {
-      const result = await repository.getDistinctRootIds([
+      const result = await repository.getDistinctRootOrgIds([
         baseFixture.classInSchoolA.id,
         baseFixture.classInDistrictB.id,
       ]);
@@ -375,7 +375,7 @@ describe('ClassRepository', () => {
     });
 
     it('returns empty array for a non-existent class id', async () => {
-      const result = await repository.getDistinctRootIds(['00000000-0000-0000-0000-000000000000']);
+      const result = await repository.getDistinctRootOrgIds(['00000000-0000-0000-0000-000000000000']);
 
       expect(result).toEqual([]);
     });

--- a/apps/backend/src/repositories/class.repository.ts
+++ b/apps/backend/src/repositories/class.repository.ts
@@ -1,9 +1,9 @@
 import type { SchoolClassSortFieldType } from '@roar-dashboard/api-contract';
 import { SortOrder } from '@roar-dashboard/api-contract';
 import type { Column, SQL } from 'drizzle-orm';
-import { and, asc, count, desc, eq, inArray, isNull, sql } from 'drizzle-orm';
+import { and, asc, count, desc, eq, isNull, sql } from 'drizzle-orm';
 import type { NodePgDatabase } from 'drizzle-orm/node-postgres';
-import { alias } from 'drizzle-orm/pg-core';
+
 import { CoreDbClient } from '../db/clients';
 import type { Class } from '../db/schema';
 import { classes, orgs, userClasses, users } from '../db/schema';
@@ -230,41 +230,5 @@ export class ClassRepository extends LtreeRepository<Class, typeof classes> {
       items: dataResult,
       totalItems,
     };
-  }
-
-  /**
-   * Returns the distinct root IDs for a set of nodes in an ltree-based hierarchy.
-   *
-   * For each input ID, the node's "root" is the ancestor whose path is the first
-   * label of that node's path (i.e. `subpath(path, 0, 1)`). This method joins
-   * back to the ancestor table to resolve those root labels into actual rows
-   * and returns the unique set.
-   *
-   * The ancestor table may differ from the node's own table — for example, a
-   * `ClassesRepository` resolves its roots against the `orgs` table, since a
-   * class's path is composed of org labels. By default, the ancestor table is
-   * the same table as the node (e.g. `orgs` rooted in `orgs`).
-   *
-   * Notes:
-   * - Roots are returned without preserving the input→root mapping. If you need
-   *   to know which input maps to which root, use a non-distinct variant.
-   * - If a node's root label has no corresponding row in the ancestor table
-   *   (orphan path), it is silently dropped by the inner join. Switch to a
-   *   left join if you need to surface those.
-   * - An empty `ids` array short-circuits to `[]` without hitting the database.
-   *
-   * @param ids - The IDs of the nodes whose roots should be resolved.
-   * @returns The distinct set of root rows, each with an `id` field.
-   */
-  async getDistinctRootIds(ids: string[]) {
-    if (ids.length === 0) return [];
-
-    const root = alias(classes, 'root');
-
-    return this.db
-      .selectDistinct({ id: orgs.id })
-      .from(root)
-      .innerJoin(orgs, sql`${orgs.path} = subpath(${root.orgPath}, 0, 1)`)
-      .where(inArray(root.id, ids));
   }
 }

--- a/apps/backend/src/repositories/class.repository.ts
+++ b/apps/backend/src/repositories/class.repository.ts
@@ -1,8 +1,9 @@
 import type { SchoolClassSortFieldType } from '@roar-dashboard/api-contract';
 import { SortOrder } from '@roar-dashboard/api-contract';
 import type { Column, SQL } from 'drizzle-orm';
-import { and, asc, count, desc, eq, isNull, sql } from 'drizzle-orm';
+import { and, asc, count, desc, eq, inArray, isNull, sql } from 'drizzle-orm';
 import type { NodePgDatabase } from 'drizzle-orm/node-postgres';
+import { alias } from 'drizzle-orm/pg-core';
 import { CoreDbClient } from '../db/clients';
 import type { Class } from '../db/schema';
 import { classes, orgs, userClasses, users } from '../db/schema';
@@ -229,5 +230,41 @@ export class ClassRepository extends LtreeRepository<Class, typeof classes> {
       items: dataResult,
       totalItems,
     };
+  }
+
+  /**
+   * Returns the distinct root IDs for a set of nodes in an ltree-based hierarchy.
+   *
+   * For each input ID, the node's "root" is the ancestor whose path is the first
+   * label of that node's path (i.e. `subpath(path, 0, 1)`). This method joins
+   * back to the ancestor table to resolve those root labels into actual rows
+   * and returns the unique set.
+   *
+   * The ancestor table may differ from the node's own table — for example, a
+   * `ClassesRepository` resolves its roots against the `orgs` table, since a
+   * class's path is composed of org labels. By default, the ancestor table is
+   * the same table as the node (e.g. `orgs` rooted in `orgs`).
+   *
+   * Notes:
+   * - Roots are returned without preserving the input→root mapping. If you need
+   *   to know which input maps to which root, use a non-distinct variant.
+   * - If a node's root label has no corresponding row in the ancestor table
+   *   (orphan path), it is silently dropped by the inner join. Switch to a
+   *   left join if you need to surface those.
+   * - An empty `ids` array short-circuits to `[]` without hitting the database.
+   *
+   * @param ids - The IDs of the nodes whose roots should be resolved.
+   * @returns The distinct set of root rows, each with an `id` field.
+   */
+  async getDistinctRootIds(ids: string[]) {
+    if (ids.length === 0) return [];
+
+    const root = alias(classes, 'root');
+
+    return this.db
+      .selectDistinct({ id: orgs.id })
+      .from(root)
+      .innerJoin(orgs, sql`${orgs.path} = subpath(${root.orgPath}, 0, 1)`)
+      .where(inArray(root.id, ids));
   }
 }

--- a/apps/backend/src/repositories/interfaces/base.repository.interface.ts
+++ b/apps/backend/src/repositories/interfaces/base.repository.interface.ts
@@ -1,11 +1,12 @@
 import type { SQL } from 'drizzle-orm';
+import type { CoreTransaction } from '../../db/clients';
 
 /**
- * Generic transaction type for database operations.
- * This will be implemented by specific database adapters (e.g., Drizzle).
+ * Transaction type for repository operations. Typed as the Drizzle transaction
+ * proxy produced by `CoreDbClient.transaction()` so all transaction-accepting
+ * repository methods carry real type information.
  */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export type Transaction = any;
+export type Transaction = CoreTransaction;
 
 /**
  * Base parameters for repository operations.

--- a/apps/backend/src/repositories/roster-provider-id.repository.integration.test.ts
+++ b/apps/backend/src/repositories/roster-provider-id.repository.integration.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Integration tests for RosterProviderIdRepository.
+ *
+ * Exercises both branches of the `transaction ?? this.db` pattern in `create()`
+ * and `deleteByEntityId()`:
+ *   - Without a transaction: uses the repository's own `this.db` connection.
+ *   - With a transaction: executes inside a caller-supplied transaction, which
+ *     can be rolled back to prove atomicity.
+ *
+ * A fresh user is created for each test to satisfy the `validate_rostering_entity_fk`
+ * trigger (which verifies that `entity_id` exists in `app.users` for entity_type = 'user').
+ */
+import { describe, it, expect, beforeAll } from 'vitest';
+import { eq, and } from 'drizzle-orm';
+import { RosterProviderIdRepository } from './roster-provider-id.repository';
+import { RosteringProvider } from '../enums/rostering-provider.enum';
+import { RosteringEntityType } from '../enums/rostering-entity-type.enum';
+import { UserFactory } from '../test-support/factories/user.factory';
+import { CoreDbClient } from '../test-support/db';
+import { rosteringProviderIds } from '../db/schema';
+import { baseFixture } from '../test-support/fixtures';
+
+describe('RosterProviderIdRepository', () => {
+  let repository: RosterProviderIdRepository;
+
+  beforeAll(() => {
+    repository = new RosterProviderIdRepository();
+  });
+
+  /** Build a minimal valid insert payload for a given user ID. */
+  function makeRecord(userId: string) {
+    return {
+      providerType: RosteringProvider.DASHBOARD,
+      providerId: userId,
+      partnerId: baseFixture.district.id,
+      entityType: RosteringEntityType.USER,
+      entityId: userId,
+    };
+  }
+
+  /** Query the row back directly to verify it was written or removed. */
+  async function findRecord(entityId: string) {
+    const [row] = await CoreDbClient.select()
+      .from(rosteringProviderIds)
+      .where(
+        and(
+          eq(rosteringProviderIds.entityId, entityId),
+          eq(rosteringProviderIds.providerType, RosteringProvider.DASHBOARD),
+        ),
+      );
+    return row ?? null;
+  }
+
+  // ── create() ──────────────────────────────────────────────────────────────
+
+  describe('create()', () => {
+    it('inserts a record using this.db when no transaction is supplied', async () => {
+      const user = await UserFactory.create();
+
+      await repository.create({ data: makeRecord(user.id) });
+
+      const row = await findRecord(user.id);
+      expect(row).not.toBeNull();
+      expect(row!.providerId).toBe(user.id);
+      expect(row!.partnerId).toBe(baseFixture.district.id);
+      expect(row!.entityType).toBe(RosteringEntityType.USER);
+    });
+
+    it('inserts a record within a supplied transaction and commits on success', async () => {
+      const user = await UserFactory.create();
+
+      await CoreDbClient.transaction(async (tx) => {
+        await repository.create({ data: makeRecord(user.id), transaction: tx });
+      });
+
+      const row = await findRecord(user.id);
+      expect(row).not.toBeNull();
+    });
+
+    it('does not insert when the supplied transaction is rolled back', async () => {
+      const user = await UserFactory.create();
+
+      await CoreDbClient.transaction(async (tx) => {
+        await repository.create({ data: makeRecord(user.id), transaction: tx });
+        await tx.rollback();
+      }).catch(() => {
+        // tx.rollback() throws; swallow the intentional abort
+      });
+
+      expect(await findRecord(user.id)).toBeNull();
+    });
+  });
+
+  // ── deleteByEntityId() ────────────────────────────────────────────────────
+
+  describe('deleteByEntityId()', () => {
+    it('removes the record using this.db when no transaction is supplied', async () => {
+      const user = await UserFactory.create();
+      await repository.create({ data: makeRecord(user.id) });
+
+      await repository.deleteByEntityId(user.id);
+
+      expect(await findRecord(user.id)).toBeNull();
+    });
+
+    it('removes the record within a supplied transaction and commits on success', async () => {
+      const user = await UserFactory.create();
+      await repository.create({ data: makeRecord(user.id) });
+
+      await CoreDbClient.transaction(async (tx) => {
+        await repository.deleteByEntityId(user.id, tx);
+      });
+
+      expect(await findRecord(user.id)).toBeNull();
+    });
+
+    it('does not remove the record when the supplied transaction is rolled back', async () => {
+      const user = await UserFactory.create();
+      await repository.create({ data: makeRecord(user.id) });
+
+      await CoreDbClient.transaction(async (tx) => {
+        await repository.deleteByEntityId(user.id, tx);
+        await tx.rollback();
+      }).catch(() => {
+        // tx.rollback() throws; swallow the intentional abort
+      });
+
+      // Row must still exist — the transaction rolled back
+      expect(await findRecord(user.id)).not.toBeNull();
+    });
+  });
+});

--- a/apps/backend/src/repositories/roster-provider-id.repository.ts
+++ b/apps/backend/src/repositories/roster-provider-id.repository.ts
@@ -1,5 +1,7 @@
+import type { InferInsertModel } from 'drizzle-orm';
 import type { NodePgDatabase } from 'drizzle-orm/node-postgres';
 import { BaseRepository } from './base.repository';
+import type { BaseCreateParams } from './interfaces/base.repository.interface';
 import { rosteringProviderIds, type RosterProviderId } from '../db/schema';
 import type * as CoreDbSchema from '../db/schema/core';
 import { CoreDbClient } from '../db/clients';
@@ -7,11 +9,29 @@ import { CoreDbClient } from '../db/clients';
 /**
  * Rostering Provider IDs Repository
  *
- * Provides datea access methods for the rostering_provider_ids table.
- * Extends BaseRepository for standard CRUD operations.
+ * Provides data access methods for the rostering_provider_ids table.
+ *
+ * Note: this table has no surrogate `id` column — its primary key is composite
+ * (providerType, partnerId, providerId). create() is overridden to omit the
+ * RETURNING id clause that BaseRepository.create() would otherwise generate.
  */
 export class RosterProviderIdRepository extends BaseRepository<RosterProviderId, typeof rosteringProviderIds> {
   constructor(db: NodePgDatabase<typeof CoreDbSchema> = CoreDbClient) {
     super(db, rosteringProviderIds);
+  }
+
+  /**
+   * Insert a new roster provider ID record.
+   *
+   * Overrides BaseRepository.create() because the base implementation selects
+   * RETURNING { id } which does not exist on this composite-keyed table.
+   * Returns entityId as a proxy to satisfy the { id: string } return contract.
+   */
+  override async create(
+    params: BaseCreateParams<InferInsertModel<typeof rosteringProviderIds>>,
+  ): Promise<{ id: string }> {
+    const db = params.transaction ?? this.db;
+    await db.insert(rosteringProviderIds).values(params.data);
+    return { id: params.data.entityId };
   }
 }

--- a/apps/backend/src/repositories/roster-provider-id.repository.ts
+++ b/apps/backend/src/repositories/roster-provider-id.repository.ts
@@ -1,4 +1,5 @@
 import type { InferInsertModel } from 'drizzle-orm';
+import { eq } from 'drizzle-orm';
 import type { NodePgDatabase } from 'drizzle-orm/node-postgres';
 import { BaseRepository } from './base.repository';
 import type { BaseCreateParams } from './interfaces/base.repository.interface';
@@ -33,5 +34,18 @@ export class RosterProviderIdRepository extends BaseRepository<RosterProviderId,
     const db = params.transaction ?? this.db;
     await db.insert(rosteringProviderIds).values(params.data);
     return { id: params.data.entityId };
+  }
+
+  /**
+   * Delete all roster provider ID records for a given entity.
+   *
+   * Must be called before deleting the entity row itself — the
+   * `prevent_rostered_entity_delete` trigger blocks DELETE on `users` (and
+   * other entity tables) while a matching `rostering_provider_ids` row exists.
+   *
+   * @param entityId - The UUID of the entity whose roster provider rows should be removed.
+   */
+  async deleteByEntityId(entityId: string): Promise<void> {
+    await this.db.delete(rosteringProviderIds).where(eq(rosteringProviderIds.entityId, entityId));
   }
 }

--- a/apps/backend/src/repositories/roster-provider-id.repository.ts
+++ b/apps/backend/src/repositories/roster-provider-id.repository.ts
@@ -1,5 +1,6 @@
 import type { InferInsertModel } from 'drizzle-orm';
 import { eq } from 'drizzle-orm';
+import type { CoreTransaction } from '../db/clients';
 import type { NodePgDatabase } from 'drizzle-orm/node-postgres';
 import { BaseRepository } from './base.repository';
 import type { BaseCreateParams } from './interfaces/base.repository.interface';
@@ -43,9 +44,14 @@ export class RosterProviderIdRepository extends BaseRepository<RosterProviderId,
    * `prevent_rostered_entity_delete` trigger blocks DELETE on `users` (and
    * other entity tables) while a matching `rostering_provider_ids` row exists.
    *
+   * Pass the same `transaction` used for the subsequent entity row delete so
+   * both operations are atomic.
+   *
    * @param entityId - The UUID of the entity whose roster provider rows should be removed.
+   * @param transaction - Optional transaction to execute within.
    */
-  async deleteByEntityId(entityId: string): Promise<void> {
-    await this.db.delete(rosteringProviderIds).where(eq(rosteringProviderIds.entityId, entityId));
+  async deleteByEntityId(entityId: string, transaction?: CoreTransaction): Promise<void> {
+    const db = transaction ?? this.db;
+    await db.delete(rosteringProviderIds).where(eq(rosteringProviderIds.entityId, entityId));
   }
 }

--- a/apps/backend/src/repositories/roster-provider-id.repository.ts
+++ b/apps/backend/src/repositories/roster-provider-id.repository.ts
@@ -1,0 +1,17 @@
+import type { NodePgDatabase } from 'drizzle-orm/node-postgres';
+import { BaseRepository } from './base.repository';
+import { rosteringProviderIds, type RosterProviderId } from '../db/schema';
+import type * as CoreDbSchema from '../db/schema/core';
+import { CoreDbClient } from '../db/clients';
+
+/**
+ * Rostering Provider IDs Repository
+ *
+ * Provides datea access methods for the rostering_provider_ids table.
+ * Extends BaseRepository for standard CRUD operations.
+ */
+export class RosterProviderIdRepository extends BaseRepository<RosterProviderId, typeof rosteringProviderIds> {
+  constructor(db: NodePgDatabase<typeof CoreDbSchema> = CoreDbClient) {
+    super(db, rosteringProviderIds);
+  }
+}

--- a/apps/backend/src/repositories/school.repository.integration.test.ts
+++ b/apps/backend/src/repositories/school.repository.integration.test.ts
@@ -866,20 +866,20 @@ describe('SchoolRepository', () => {
     });
   });
 
-  describe('getDistinctRootIds', () => {
+  describe('getDistinctRootOrgIds', () => {
     // Base fixture school → district mapping:
     //   schoolA          → district
     //   schoolB          → district
     //   schoolInDistrictB → districtB
 
     it('returns empty array when called with no ids', async () => {
-      const result = await repository.getDistinctRootIds([]);
+      const result = await repository.getDistinctRootOrgIds([]);
 
       expect(result).toEqual([]);
     });
 
     it('returns the district for a single school', async () => {
-      const result = await repository.getDistinctRootIds([baseFixture.schoolA.id]);
+      const result = await repository.getDistinctRootOrgIds([baseFixture.schoolA.id]);
 
       expect(result).toHaveLength(1);
       expect(result[0]!.id).toBe(baseFixture.district.id);
@@ -887,14 +887,14 @@ describe('SchoolRepository', () => {
 
     it('deduplicates when multiple schools share the same district', async () => {
       // schoolA and schoolB both belong to district
-      const result = await repository.getDistinctRootIds([baseFixture.schoolA.id, baseFixture.schoolB.id]);
+      const result = await repository.getDistinctRootOrgIds([baseFixture.schoolA.id, baseFixture.schoolB.id]);
 
       expect(result).toHaveLength(1);
       expect(result[0]!.id).toBe(baseFixture.district.id);
     });
 
     it('returns multiple districts when schools span different roots', async () => {
-      const result = await repository.getDistinctRootIds([baseFixture.schoolA.id, baseFixture.schoolInDistrictB.id]);
+      const result = await repository.getDistinctRootOrgIds([baseFixture.schoolA.id, baseFixture.schoolInDistrictB.id]);
 
       const ids = result.map((r) => r.id);
       expect(ids).toHaveLength(2);
@@ -903,7 +903,7 @@ describe('SchoolRepository', () => {
     });
 
     it('returns empty array for a non-existent school id', async () => {
-      const result = await repository.getDistinctRootIds(['00000000-0000-0000-0000-000000000000']);
+      const result = await repository.getDistinctRootOrgIds(['00000000-0000-0000-0000-000000000000']);
 
       expect(result).toEqual([]);
     });

--- a/apps/backend/src/repositories/school.repository.integration.test.ts
+++ b/apps/backend/src/repositories/school.repository.integration.test.ts
@@ -865,4 +865,47 @@ describe('SchoolRepository', () => {
       });
     });
   });
+
+  describe('getDistinctRootIds', () => {
+    // Base fixture school → district mapping:
+    //   schoolA          → district
+    //   schoolB          → district
+    //   schoolInDistrictB → districtB
+
+    it('returns empty array when called with no ids', async () => {
+      const result = await repository.getDistinctRootIds([]);
+
+      expect(result).toEqual([]);
+    });
+
+    it('returns the district for a single school', async () => {
+      const result = await repository.getDistinctRootIds([baseFixture.schoolA.id]);
+
+      expect(result).toHaveLength(1);
+      expect(result[0]!.id).toBe(baseFixture.district.id);
+    });
+
+    it('deduplicates when multiple schools share the same district', async () => {
+      // schoolA and schoolB both belong to district
+      const result = await repository.getDistinctRootIds([baseFixture.schoolA.id, baseFixture.schoolB.id]);
+
+      expect(result).toHaveLength(1);
+      expect(result[0]!.id).toBe(baseFixture.district.id);
+    });
+
+    it('returns multiple districts when schools span different roots', async () => {
+      const result = await repository.getDistinctRootIds([baseFixture.schoolA.id, baseFixture.schoolInDistrictB.id]);
+
+      const ids = result.map((r) => r.id);
+      expect(ids).toHaveLength(2);
+      expect(ids).toContain(baseFixture.district.id);
+      expect(ids).toContain(baseFixture.districtB.id);
+    });
+
+    it('returns empty array for a non-existent school id', async () => {
+      const result = await repository.getDistinctRootIds(['00000000-0000-0000-0000-000000000000']);
+
+      expect(result).toEqual([]);
+    });
+  });
 });

--- a/apps/backend/src/repositories/school.repository.ts
+++ b/apps/backend/src/repositories/school.repository.ts
@@ -1,21 +1,21 @@
-import { eq, countDistinct, and, isNull, sql, inArray, asc, desc } from 'drizzle-orm';
-import type { SQL } from 'drizzle-orm';
-import type { NodePgDatabase } from 'drizzle-orm/node-postgres';
-import type { PaginatedResult } from './base.repository';
-import { LtreeRepository } from './ltree.repository';
-import { alias } from 'drizzle-orm/pg-core';
-import type { Org } from '../db/schema';
-import { orgs, userOrgs, classes, userClasses, users } from '../db/schema';
-import { CoreDbClient } from '../db/clients';
-import type * as CoreDbSchema from '../db/schema/core';
 import type { SchoolSortFieldType } from '@roar-dashboard/api-contract';
 import { SortOrder } from '@roar-dashboard/api-contract';
+import type { SQL } from 'drizzle-orm';
+import { and, asc, countDistinct, desc, eq, inArray, isNull, sql } from 'drizzle-orm';
+import type { NodePgDatabase } from 'drizzle-orm/node-postgres';
+
+import { CoreDbClient } from '../db/clients';
+import type { Org } from '../db/schema';
+import { classes, orgs, userClasses, userOrgs, users } from '../db/schema';
+import type * as CoreDbSchema from '../db/schema/core';
 import { OrgType } from '../enums/org-type.enum';
 import type { UserRole } from '../enums/user-role.enum';
 import type { EnrolledUserEntity, ListEnrolledUsersOptions } from '../types/user';
+import type { PaginatedResult } from './base.repository';
+import { LtreeRepository } from './ltree.repository';
 import {
-  getEnrolledUsersFilterConditions,
   ENROLLED_USERS_SORT_COLUMNS,
+  getEnrolledUsersFilterConditions,
   UserJunctionTable,
 } from './utils/enrolled-users-query.utils';
 import { isEnrollmentActive } from './utils/enrollment.utils';
@@ -507,41 +507,5 @@ export class SchoolRepository extends LtreeRepository<School, typeof orgs> {
       })),
       totalItems,
     };
-  }
-
-  /**
-   * Returns the distinct root IDs for a set of nodes in an ltree-based hierarchy.
-   *
-   * For each input ID, the node's "root" is the ancestor whose path is the first
-   * label of that node's path (i.e. `subpath(path, 0, 1)`). This method joins
-   * back to the ancestor table to resolve those root labels into actual rows
-   * and returns the unique set.
-   *
-   * The ancestor table may differ from the node's own table — for example, a
-   * `ClassesRepository` resolves its roots against the `orgs` table, since a
-   * class's path is composed of org labels. By default, the ancestor table is
-   * the same table as the node (e.g. `orgs` rooted in `orgs`).
-   *
-   * Notes:
-   * - Roots are returned without preserving the input→root mapping. If you need
-   *   to know which input maps to which root, use a non-distinct variant.
-   * - If a node's root label has no corresponding row in the ancestor table
-   *   (orphan path), it is silently dropped by the inner join. Switch to a
-   *   left join if you need to surface those.
-   * - An empty `ids` array short-circuits to `[]` without hitting the database.
-   *
-   * @param ids - The IDs of the nodes whose roots should be resolved.
-   * @returns The distinct set of root rows, each with an `id` field.
-   */
-  async getDistinctRootIds(ids: string[]) {
-    if (ids.length === 0) return [];
-
-    const root = alias(orgs, 'root');
-
-    return this.db
-      .selectDistinct({ id: root.id })
-      .from(orgs)
-      .innerJoin(root, sql`${root.path} = subpath(${orgs.path}, 0, 1)`)
-      .where(inArray(orgs.id, ids));
   }
 }

--- a/apps/backend/src/repositories/school.repository.ts
+++ b/apps/backend/src/repositories/school.repository.ts
@@ -3,6 +3,7 @@ import type { SQL } from 'drizzle-orm';
 import type { NodePgDatabase } from 'drizzle-orm/node-postgres';
 import type { PaginatedResult } from './base.repository';
 import { LtreeRepository } from './ltree.repository';
+import { alias } from 'drizzle-orm/pg-core';
 import type { Org } from '../db/schema';
 import { orgs, userOrgs, classes, userClasses, users } from '../db/schema';
 import { CoreDbClient } from '../db/clients';
@@ -506,5 +507,41 @@ export class SchoolRepository extends LtreeRepository<School, typeof orgs> {
       })),
       totalItems,
     };
+  }
+
+  /**
+   * Returns the distinct root IDs for a set of nodes in an ltree-based hierarchy.
+   *
+   * For each input ID, the node's "root" is the ancestor whose path is the first
+   * label of that node's path (i.e. `subpath(path, 0, 1)`). This method joins
+   * back to the ancestor table to resolve those root labels into actual rows
+   * and returns the unique set.
+   *
+   * The ancestor table may differ from the node's own table — for example, a
+   * `ClassesRepository` resolves its roots against the `orgs` table, since a
+   * class's path is composed of org labels. By default, the ancestor table is
+   * the same table as the node (e.g. `orgs` rooted in `orgs`).
+   *
+   * Notes:
+   * - Roots are returned without preserving the input→root mapping. If you need
+   *   to know which input maps to which root, use a non-distinct variant.
+   * - If a node's root label has no corresponding row in the ancestor table
+   *   (orphan path), it is silently dropped by the inner join. Switch to a
+   *   left join if you need to surface those.
+   * - An empty `ids` array short-circuits to `[]` without hitting the database.
+   *
+   * @param ids - The IDs of the nodes whose roots should be resolved.
+   * @returns The distinct set of root rows, each with an `id` field.
+   */
+  async getDistinctRootIds(ids: string[]) {
+    if (ids.length === 0) return [];
+
+    const root = alias(orgs, 'root');
+
+    return this.db
+      .selectDistinct({ id: root.id })
+      .from(orgs)
+      .innerJoin(root, sql`${root.path} = subpath(${orgs.path}, 0, 1)`)
+      .where(inArray(orgs.id, ids));
   }
 }

--- a/apps/backend/src/repositories/task-variant-parameter.repository.ts
+++ b/apps/backend/src/repositories/task-variant-parameter.repository.ts
@@ -1,11 +1,17 @@
-import type { NodePgDatabase } from 'drizzle-orm/node-postgres';
 import { eq, inArray } from 'drizzle-orm';
-import type { TaskVariantParameter, NewTaskVariantParameter } from '../db/schema';
-import { taskVariantParameters } from '../db/schema';
+import type { NodePgDatabase } from 'drizzle-orm/node-postgres';
 import { CoreDbClient } from '../db/clients';
+import type { NewTaskVariantParameter, TaskVariantParameter } from '../db/schema';
+import { taskVariantParameters } from '../db/schema';
 import type * as CoreDbSchema from '../db/schema/core';
 import { BaseRepository } from './base.repository';
-import { BaseCreateManyParams } from './interfaces/base.repository.interface';
+import type { Transaction } from './interfaces/base.repository.interface';
+
+/** Parameters for creating multiple task variant parameters in optional transaction. */
+interface TaskVariantParameterCreateManyParams {
+  data: NewTaskVariantParameter[];
+  transaction?: Transaction;
+}
 
 /**
  * Repository for task variant parameter-related database operations.
@@ -83,9 +89,10 @@ export class TaskVariantParameterRepository extends BaseRepository<TaskVariantPa
    * Creates multiple task variant parameters.
    *
    * Overrides base createMany because this table uses a composite primary key (taskVariantId, name)
-   * instead of a single id column. Returns placeholder objects to satisfy the base interface.
+   * instead of a single id column and all fields are required in the database model.
+   * Returns placeholder objects to satisfy the base interface.
    */
-  override async createMany(params: BaseCreateManyParams<NewTaskVariantParameter>): Promise<{ id: string }[]> {
+  override async createMany(params: TaskVariantParameterCreateManyParams): Promise<{ id: string }[]> {
     const { transaction } = params;
     const db = transaction ?? this.db;
 

--- a/apps/backend/src/repositories/user.repository.integration.test.ts
+++ b/apps/backend/src/repositories/user.repository.integration.test.ts
@@ -208,21 +208,25 @@ describe('UserRepository', () => {
     it('creates user row and org memberships atomically', async () => {
       const email = `create-with-orgs-${Date.now()}@example.com`;
 
-      const result = await repository.createWithMemberships(
-        {
-          email,
-          assessmentPid: `pid-${email}`,
-          authId: `firebase-uid-${email}`,
-          authProvider: [AuthProvider.PASSWORD],
-          nameFirst: 'Test',
-          nameLast: 'User',
-          userType: UserType.STUDENT,
-        },
-        [{ orgId: baseFixture.district.id, role: UserRole.STUDENT as UserRole, enrollmentStart }],
-        [],
-        [],
-        [],
-      );
+      const result = await repository.runTransaction({
+        fn: (tx) =>
+          repository.createWithMemberships(
+            {
+              email,
+              assessmentPid: `pid-${email}`,
+              authId: `firebase-uid-${email}`,
+              authProvider: [AuthProvider.PASSWORD],
+              nameFirst: 'Test',
+              nameLast: 'User',
+              userType: UserType.STUDENT,
+            },
+            [{ orgId: baseFixture.district.id, role: UserRole.STUDENT as UserRole, enrollmentStart }],
+            [],
+            [],
+            [],
+            tx,
+          ),
+      });
 
       expect(result.id).toBeDefined();
 
@@ -239,20 +243,24 @@ describe('UserRepository', () => {
       const email = `create-multi-${Date.now()}@example.com`;
       const group = await GroupFactory.create();
 
-      const result = await repository.createWithMemberships(
-        {
-          email,
-          assessmentPid: `pid-${email}`,
-          authProvider: [AuthProvider.PASSWORD],
-          nameFirst: 'Multi',
-          nameLast: 'Member',
-          userType: UserType.STUDENT,
-        },
-        [],
-        [{ classId: baseFixture.classInSchoolA.id, role: UserRole.STUDENT as UserRole, enrollmentStart }],
-        [{ groupId: group.id, role: UserRole.STUDENT as UserRole, enrollmentStart }],
-        [],
-      );
+      const result = await repository.runTransaction({
+        fn: (tx) =>
+          repository.createWithMemberships(
+            {
+              email,
+              assessmentPid: `pid-${email}`,
+              authProvider: [AuthProvider.PASSWORD],
+              nameFirst: 'Multi',
+              nameLast: 'Member',
+              userType: UserType.STUDENT,
+            },
+            [],
+            [{ classId: baseFixture.classInSchoolA.id, role: UserRole.STUDENT as UserRole, enrollmentStart }],
+            [{ groupId: group.id, role: UserRole.STUDENT as UserRole, enrollmentStart }],
+            [],
+            tx,
+          ),
+      });
 
       expect(result.id).toBeDefined();
 
@@ -269,20 +277,24 @@ describe('UserRepository', () => {
       const group = await GroupFactory.create();
       const family = await FamilyFactory.create();
 
-      const result = await repository.createWithMemberships(
-        {
-          email,
-          assessmentPid: `pid-${email}`,
-          authProvider: [AuthProvider.PASSWORD],
-          nameFirst: 'All',
-          nameLast: 'Types',
-          userType: UserType.STUDENT,
-        },
-        [{ orgId: baseFixture.district.id, role: UserRole.STUDENT as UserRole, enrollmentStart }],
-        [{ classId: baseFixture.classInSchoolA.id, role: UserRole.STUDENT as UserRole, enrollmentStart }],
-        [{ groupId: group.id, role: UserRole.STUDENT as UserRole, enrollmentStart }],
-        [{ familyId: family.id, role: 'child', joinedOn: enrollmentStart, leftOn: null }],
-      );
+      const result = await repository.runTransaction({
+        fn: (tx) =>
+          repository.createWithMemberships(
+            {
+              email,
+              assessmentPid: `pid-${email}`,
+              authProvider: [AuthProvider.PASSWORD],
+              nameFirst: 'All',
+              nameLast: 'Types',
+              userType: UserType.STUDENT,
+            },
+            [{ orgId: baseFixture.district.id, role: UserRole.STUDENT as UserRole, enrollmentStart }],
+            [{ classId: baseFixture.classInSchoolA.id, role: UserRole.STUDENT as UserRole, enrollmentStart }],
+            [{ groupId: group.id, role: UserRole.STUDENT as UserRole, enrollmentStart }],
+            [{ familyId: family.id, role: 'child', joinedOn: enrollmentStart, leftOn: null }],
+            tx,
+          ),
+      });
 
       expect(result.id).toBeDefined();
 
@@ -298,20 +310,24 @@ describe('UserRepository', () => {
       const email = `rollback-test-${Date.now()}@example.com`;
 
       await expect(
-        repository.createWithMemberships(
-          {
-            email,
-            assessmentPid: `pid-${email}`,
-            authProvider: [AuthProvider.PASSWORD],
-            nameFirst: 'Rollback',
-            nameLast: 'Test',
-            userType: UserType.STUDENT,
-          },
-          [{ orgId: '00000000-0000-0000-0000-000000000099', role: UserRole.STUDENT as UserRole, enrollmentStart }],
-          [],
-          [],
-          [],
-        ),
+        repository.runTransaction({
+          fn: (tx) =>
+            repository.createWithMemberships(
+              {
+                email,
+                assessmentPid: `pid-${email}`,
+                authProvider: [AuthProvider.PASSWORD],
+                nameFirst: 'Rollback',
+                nameLast: 'Test',
+                userType: UserType.STUDENT,
+              },
+              [{ orgId: '00000000-0000-0000-0000-000000000099', role: UserRole.STUDENT as UserRole, enrollmentStart }],
+              [],
+              [],
+              [],
+              tx,
+            ),
+        }),
       ).rejects.toThrow();
 
       // The user row must NOT exist — transaction rolled back
@@ -328,20 +344,24 @@ describe('UserRepository', () => {
       const email = baseFixture.districtAdmin.email!;
 
       await expect(
-        repository.createWithMemberships(
-          {
-            email,
-            assessmentPid: `pid-unique-${Date.now()}`,
-            authProvider: [AuthProvider.PASSWORD],
-            nameFirst: 'Dup',
-            nameLast: 'Email',
-            userType: UserType.STUDENT,
-          },
-          [],
-          [],
-          [],
-          [],
-        ),
+        repository.runTransaction({
+          fn: (tx) =>
+            repository.createWithMemberships(
+              {
+                email,
+                assessmentPid: `pid-unique-${Date.now()}`,
+                authProvider: [AuthProvider.PASSWORD],
+                nameFirst: 'Dup',
+                nameLast: 'Email',
+                userType: UserType.STUDENT,
+              },
+              [],
+              [],
+              [],
+              [],
+              tx,
+            ),
+        }),
       ).rejects.toThrow();
     });
   });

--- a/apps/backend/src/repositories/user.repository.ts
+++ b/apps/backend/src/repositories/user.repository.ts
@@ -4,6 +4,7 @@ import type { User, NewUser, NewUserOrg, NewUserClass, NewUserGroup, NewUserFami
 import { EntityType } from '../types/entity-type';
 import { users, userOrgs, userClasses, userGroups, userFamilies, orgs, classes } from '../db/schema';
 import { CoreDbClient } from '../db/clients';
+import type { CoreTransaction } from '../db/clients';
 import type * as CoreDbSchema from '../db/schema/core';
 import { BaseRepository } from './base.repository';
 import { isEnrollmentActive, isActiveInFamily } from './utils/enrollment.utils';
@@ -129,14 +130,25 @@ export class UserRepository extends BaseRepository<User, typeof users> {
    * Create a user row and all junction-table memberships in a single DB transaction.
    *
    * Inserts the `users` row and all `user_orgs`, `user_classes`, `user_groups`, and
-   * `user_families` rows atomically. The caller (service layer) is responsible for
-   * Firebase Auth creation and FGA tuple writes — those happen outside this transaction.
+   * `user_families` rows within the supplied transaction.
+   *
+   * The caller is responsible for managing the transaction lifecycle. Use
+   * `runTransaction` to open one:
+   *
+   * ```typescript
+   * await repository.runTransaction({
+   *   fn: (tx) => repository.createWithMemberships(userData, orgs, classes, groups, families, tx),
+   * });
+   * ```
+   *
+   * Firebase Auth creation and FGA tuple writes always happen outside this method.
    *
    * @param userData - The user fields to insert (excluding system-managed fields)
    * @param orgMemberships - Rows to insert into `user_orgs`
    * @param classMemberships - Rows to insert into `user_classes`
    * @param groupMemberships - Rows to insert into `user_groups`
    * @param familyMemberships - Rows to insert into `user_families`
+   * @param transaction - The active transaction to execute writes within
    * @returns The newly created user's ID
    */
   async createWithMemberships(
@@ -145,34 +157,33 @@ export class UserRepository extends BaseRepository<User, typeof users> {
     classMemberships: Omit<NewUserClass, 'userId'>[],
     groupMemberships: Omit<NewUserGroup, 'userId'>[],
     familyMemberships: Omit<NewUserFamily, 'userId'>[],
+    transaction: CoreTransaction,
   ): Promise<{ id: string }> {
-    return this.db.transaction(async (tx) => {
-      const [created] = await tx.insert(users).values(userData).returning({ id: users.id });
+    const [created] = await transaction.insert(users).values(userData).returning({ id: users.id });
 
-      if (!created) {
-        throw new Error('User insert returned no rows');
-      }
+    if (!created) {
+      throw new Error('User insert returned no rows');
+    }
 
-      const { id: userId } = created;
+    const { id: userId } = created;
 
-      if (orgMemberships.length > 0) {
-        await tx.insert(userOrgs).values(orgMemberships.map((m) => ({ ...m, userId })));
-      }
+    if (orgMemberships.length > 0) {
+      await transaction.insert(userOrgs).values(orgMemberships.map((m) => ({ ...m, userId })));
+    }
 
-      if (classMemberships.length > 0) {
-        await tx.insert(userClasses).values(classMemberships.map((m) => ({ ...m, userId })));
-      }
+    if (classMemberships.length > 0) {
+      await transaction.insert(userClasses).values(classMemberships.map((m) => ({ ...m, userId })));
+    }
 
-      if (groupMemberships.length > 0) {
-        await tx.insert(userGroups).values(groupMemberships.map((m) => ({ ...m, userId })));
-      }
+    if (groupMemberships.length > 0) {
+      await transaction.insert(userGroups).values(groupMemberships.map((m) => ({ ...m, userId })));
+    }
 
-      if (familyMemberships.length > 0) {
-        await tx.insert(userFamilies).values(familyMemberships.map((m) => ({ ...m, userId })));
-      }
+    if (familyMemberships.length > 0) {
+      await transaction.insert(userFamilies).values(familyMemberships.map((m) => ({ ...m, userId })));
+    }
 
-      return { id: userId };
-    });
+    return { id: userId };
   }
 
   /**

--- a/apps/backend/src/routes/users.integration.test.ts
+++ b/apps/backend/src/routes/users.integration.test.ts
@@ -64,6 +64,8 @@ import { UserRole } from '../enums/user-role.enum';
 import { UserRepository } from '../repositories/user.repository';
 import { FirebaseAuthClient } from '../clients/firebase-auth.clients';
 import { EntityType } from '../types/entity-type';
+import { RosteringProvider } from '../enums/rostering-provider.enum';
+import { RosteringEntityType } from '../enums/rostering-entity-type.enum';
 
 // ═══════════════════════════════════════════════════════════════════════════
 // Test setup
@@ -2013,7 +2015,24 @@ describe('POST /v1/users', () => {
         .withBody(validBodyForDistrict('resolver-district'))
         .toReturn(StatusCodes.CREATED);
 
-      expect(await getPartnerId(res.body.data.id)).toBe(baseFixture.district.id);
+      const userId: string = res.body.data.id;
+
+      // Full record assertion — the only test in this suite that verifies every field
+      // written to rostering_provider_ids, not just partnerId.
+      const { rosteringProviderIds } = await import('../db/schema');
+      const { eq } = await import('drizzle-orm');
+      const { CoreDbClient } = await import('../test-support/db');
+      const [record] = await CoreDbClient.select()
+        .from(rosteringProviderIds)
+        .where(eq(rosteringProviderIds.entityId, userId));
+
+      expect(record).toMatchObject({
+        providerType: RosteringProvider.DASHBOARD,
+        entityType: RosteringEntityType.USER,
+        entityId: userId,
+        providerId: userId, // DASHBOARD provider uses the user's own ID as the external provider ID
+        partnerId: baseFixture.district.id,
+      });
     });
 
     it('school-only membership → partnerId resolves to parent district via ltree', async () => {
@@ -2058,16 +2077,32 @@ describe('POST /v1/users', () => {
       expect(await getPartnerId(res.body.data.id)).toBe(baseFixture.group.id);
     });
 
-    it('district takes priority over class and school when all three are present', async () => {
-      // validBodyForClassInSchoolInDistrict includes district + school + class memberships.
-      // The resolver should return on the district branch without touching the school
-      // or class ltree paths.
+    it('consistent district + school + class memberships → partnerId is the shared district', async () => {
+      // All three org membership types point to the same district.
+      // The resolver collects all evidence, confirms one unique root, and returns it.
       const res = await expectRoute('POST', '/v1/users')
         .as(tiers.superAdmin)
-        .withBody(validBodyForClassInSchoolInDistrict('resolver-priority'))
+        .withBody(validBodyForClassInSchoolInDistrict('resolver-consistent'))
         .toReturn(StatusCodes.CREATED);
 
       expect(await getPartnerId(res.body.data.id)).toBe(baseFixture.district.id);
+    });
+
+    it('explicit district_A + class in district_B → 422 (cross-district inconsistency)', async () => {
+      // Previously undefined behaviour: the resolver returned district_A without
+      // checking that the class belongs there. Now all sources are validated together.
+      await expectRoute('POST', '/v1/users')
+        .as(tiers.superAdmin)
+        .withBody({
+          email: makeEmail('resolver-district-class-mismatch'),
+          password: 'Password123!',
+          name: { first: 'Test', last: 'User' },
+          memberships: [
+            { entityType: 'district', entityId: baseFixture.district.id, role: 'student' },
+            { entityType: 'class', entityId: baseFixture.classInDistrictB.id, role: 'student' },
+          ],
+        })
+        .toReturn(StatusCodes.UNPROCESSABLE_ENTITY);
     });
 
     it('class memberships spanning two districts → 422 (cross-district ambiguity)', async () => {
@@ -2084,6 +2119,39 @@ describe('POST /v1/users', () => {
           memberships: [
             { entityType: 'class', entityId: baseFixture.classInSchoolA.id, role: 'student' },
             { entityType: 'class', entityId: baseFixture.classInDistrictB.id, role: 'student' },
+          ],
+        })
+        .toReturn(StatusCodes.UNPROCESSABLE_ENTITY);
+    });
+
+    it('family-only membership → partnerId is the family ID (direct fallback)', async () => {
+      // Family memberships fall through all org/class/school/group branches and resolve
+      // to the family ID directly. sharedFamily is set up in the POST /v1/users beforeAll.
+      const res = await expectRoute('POST', '/v1/users')
+        .as(tiers.superAdmin)
+        .withBody({
+          email: makeEmail('resolver-family'),
+          password: 'Password123!',
+          name: { first: 'Test', last: 'User' },
+          memberships: [{ entityType: 'family', entityId: sharedFamily.id, role: 'parent' }],
+        })
+        .toReturn(StatusCodes.CREATED);
+
+      expect(await getPartnerId(res.body.data.id)).toBe(sharedFamily.id);
+    });
+
+    it('school memberships spanning two districts → 422 (cross-district ambiguity)', async () => {
+      // schoolA is under district; schoolInDistrictB is under districtB.
+      // Symmetric to the class cross-district case — the same multi-root guard fires.
+      await expectRoute('POST', '/v1/users')
+        .as(tiers.superAdmin)
+        .withBody({
+          email: makeEmail('resolver-school-cross-district'),
+          password: 'Password123!',
+          name: { first: 'Test', last: 'User' },
+          memberships: [
+            { entityType: 'school', entityId: baseFixture.schoolA.id, role: 'student' },
+            { entityType: 'school', entityId: baseFixture.schoolInDistrictB.id, role: 'student' },
           ],
         })
         .toReturn(StatusCodes.UNPROCESSABLE_ENTITY);

--- a/apps/backend/src/routes/users.integration.test.ts
+++ b/apps/backend/src/routes/users.integration.test.ts
@@ -63,6 +63,7 @@ import { AgreementVersionFactory } from '../test-support/factories/agreement-ver
 import { UserRole } from '../enums/user-role.enum';
 import { UserRepository } from '../repositories/user.repository';
 import { FirebaseAuthClient } from '../clients/firebase-auth.clients';
+import { EntityType } from '../types/entity-type';
 
 // ═══════════════════════════════════════════════════════════════════════════
 // Test setup
@@ -1418,7 +1419,7 @@ describe('POST /v1/users', () => {
     email: makeEmail(suffix),
     password: 'Password123!',
     name: { first: 'Test', last: 'User' },
-    memberships: [{ entityType: 'district', entityId: baseFixture.district.id, role: 'student' }],
+    memberships: [{ entityType: EntityType.DISTRICT, entityId: baseFixture.district.id, role: 'student' }],
   });
 
   const validBodyForSchoolInDistrict = (suffix: string) => ({
@@ -1426,8 +1427,8 @@ describe('POST /v1/users', () => {
     password: 'Password123!',
     name: { first: 'Test', last: 'User' },
     memberships: [
-      { entityType: 'district', entityId: baseFixture.district.id, role: 'student' },
-      { entityType: 'school', entityId: baseFixture.schoolA.id, role: 'student' },
+      { entityType: EntityType.DISTRICT, entityId: baseFixture.district.id, role: 'student' },
+      { entityType: EntityType.SCHOOL, entityId: baseFixture.schoolA.id, role: 'student' },
     ],
   });
 
@@ -1436,9 +1437,9 @@ describe('POST /v1/users', () => {
     password: 'Password123!',
     name: { first: 'Test', last: 'User' },
     memberships: [
-      { entityType: 'district', entityId: baseFixture.district.id, role: 'student' },
-      { entityType: 'school', entityId: baseFixture.schoolA.id, role: 'student' },
-      { entityType: 'class', entityId: baseFixture.classInSchoolA.id, role: 'student' },
+      { entityType: EntityType.DISTRICT, entityId: baseFixture.district.id, role: 'student' },
+      { entityType: EntityType.SCHOOL, entityId: baseFixture.schoolA.id, role: 'student' },
+      { entityType: EntityType.CLASS, entityId: baseFixture.classInSchoolA.id, role: 'student' },
     ],
   });
 
@@ -1447,8 +1448,8 @@ describe('POST /v1/users', () => {
     password: 'Password123!',
     name: { first: 'Test', last: 'User' },
     memberships: [
-      { entityType: 'district', entityId: baseFixture.district.id, role: 'student' },
-      { entityType: 'group', entityId: baseFixture.group.id, role: 'student' },
+      { entityType: EntityType.DISTRICT, entityId: baseFixture.district.id, role: 'student' },
+      { entityType: EntityType.GROUP, entityId: baseFixture.group.id, role: 'student' },
     ],
   });
 
@@ -1459,8 +1460,8 @@ describe('POST /v1/users', () => {
     password: 'Password123!',
     name: { first: 'Test', last: 'User' },
     memberships: [
-      { entityType: 'district', entityId: baseFixture.district.id, role: 'student' },
-      { entityType: 'family', entityId: sharedFamily.id, role: 'parent' },
+      { entityType: EntityType.DISTRICT, entityId: baseFixture.district.id, role: 'student' },
+      { entityType: EntityType.FAMILY, entityId: sharedFamily.id, role: 'parent' },
     ],
   });
 
@@ -1985,6 +1986,107 @@ describe('POST /v1/users', () => {
         .as(tiers.superAdmin)
         .withBody({ ...validBodyForDistrict('short-pass'), password: '1234567' })
         .toReturn(StatusCodes.BAD_REQUEST);
+    });
+  });
+
+  // ── Roster provider ID resolution ────────────────────────────────────────
+
+  describe('roster provider ID resolution', () => {
+    // resolveRootOrgProviderFromMemberships is only observable via the partnerId
+    // written to rostering_provider_ids after a successful create.
+    // superAdmin is used throughout so authorization never interferes with the
+    // resolver path being exercised.
+
+    async function getPartnerId(userId: string): Promise<string | null> {
+      const { rosteringProviderIds } = await import('../db/schema');
+      const { eq, and } = await import('drizzle-orm');
+      const { CoreDbClient } = await import('../test-support/db');
+      const [record] = await CoreDbClient.select({ partnerId: rosteringProviderIds.partnerId })
+        .from(rosteringProviderIds)
+        .where(and(eq(rosteringProviderIds.entityId, userId)));
+      return record?.partnerId ?? null;
+    }
+
+    it('district membership → partnerId is the district ID (direct, no DB lookup)', async () => {
+      const res = await expectRoute('POST', '/v1/users')
+        .as(tiers.superAdmin)
+        .withBody(validBodyForDistrict('resolver-district'))
+        .toReturn(StatusCodes.CREATED);
+
+      expect(await getPartnerId(res.body.data.id)).toBe(baseFixture.district.id);
+    });
+
+    it('school-only membership → partnerId resolves to parent district via ltree', async () => {
+      const res = await expectRoute('POST', '/v1/users')
+        .as(tiers.superAdmin)
+        .withBody({
+          email: makeEmail('resolver-school'),
+          password: 'Password123!',
+          name: { first: 'Test', last: 'User' },
+          memberships: [{ entityType: 'school', entityId: baseFixture.schoolA.id, role: 'student' }],
+        })
+        .toReturn(StatusCodes.CREATED);
+
+      expect(await getPartnerId(res.body.data.id)).toBe(baseFixture.district.id);
+    });
+
+    it('class-only membership → partnerId resolves to ancestor district via ltree', async () => {
+      const res = await expectRoute('POST', '/v1/users')
+        .as(tiers.superAdmin)
+        .withBody({
+          email: makeEmail('resolver-class'),
+          password: 'Password123!',
+          name: { first: 'Test', last: 'User' },
+          memberships: [{ entityType: 'class', entityId: baseFixture.classInSchoolA.id, role: 'student' }],
+        })
+        .toReturn(StatusCodes.CREATED);
+
+      expect(await getPartnerId(res.body.data.id)).toBe(baseFixture.district.id);
+    });
+
+    it('group-only membership → partnerId is the group ID (direct fallback, no DB lookup)', async () => {
+      const res = await expectRoute('POST', '/v1/users')
+        .as(tiers.superAdmin)
+        .withBody({
+          email: makeEmail('resolver-group'),
+          password: 'Password123!',
+          name: { first: 'Test', last: 'User' },
+          memberships: [{ entityType: 'group', entityId: baseFixture.group.id, role: 'student' }],
+        })
+        .toReturn(StatusCodes.CREATED);
+
+      expect(await getPartnerId(res.body.data.id)).toBe(baseFixture.group.id);
+    });
+
+    it('district takes priority over class and school when all three are present', async () => {
+      // validBodyForClassInSchoolInDistrict includes district + school + class memberships.
+      // The resolver should return on the district branch without touching the school
+      // or class ltree paths.
+      const res = await expectRoute('POST', '/v1/users')
+        .as(tiers.superAdmin)
+        .withBody(validBodyForClassInSchoolInDistrict('resolver-priority'))
+        .toReturn(StatusCodes.CREATED);
+
+      expect(await getPartnerId(res.body.data.id)).toBe(baseFixture.district.id);
+    });
+
+    it('class memberships spanning two districts → 422 (cross-district ambiguity)', async () => {
+      // classInSchoolA is under district; classInDistrictB is under districtB.
+      // resolveRootOrgProviderFromMemberships finds two distinct root IDs and throws
+      // UNPROCESSABLE_ENTITY. The catch block should delete the DB row and the
+      // Firebase account before re-throwing.
+      await expectRoute('POST', '/v1/users')
+        .as(tiers.superAdmin)
+        .withBody({
+          email: makeEmail('resolver-cross-district'),
+          password: 'Password123!',
+          name: { first: 'Test', last: 'User' },
+          memberships: [
+            { entityType: 'class', entityId: baseFixture.classInSchoolA.id, role: 'student' },
+            { entityType: 'class', entityId: baseFixture.classInDistrictB.id, role: 'student' },
+          ],
+        })
+        .toReturn(StatusCodes.UNPROCESSABLE_ENTITY);
     });
   });
 });

--- a/apps/backend/src/services/task/task.service.test.ts
+++ b/apps/backend/src/services/task/task.service.test.ts
@@ -22,6 +22,7 @@ import type { Condition } from '../../types/condition';
 import { Operator } from '../../types/condition';
 import type { User } from '../../db/schema';
 import { SortOrder, TaskSortField } from '@roar-dashboard/api-contract';
+import type { CoreTransaction } from '../../db/clients';
 
 describe('TaskService', () => {
   let authContext: AuthContext;
@@ -62,7 +63,7 @@ describe('TaskService', () => {
         });
         taskRepository.getById.mockResolvedValueOnce(mockTask);
         taskVariantRepository.runTransaction.mockImplementationOnce(async ({ fn }) => {
-          return await fn({});
+          return await fn({} as CoreTransaction);
         });
         taskVariantRepository.create.mockResolvedValueOnce(mockTaskVariant);
         taskVariantParameterRepository.createMany.mockResolvedValueOnce(mockTaskVariantParameterReturnValue);
@@ -104,7 +105,7 @@ describe('TaskService', () => {
 
         taskRepository.getById.mockResolvedValueOnce(mockTask);
         taskVariantRepository.runTransaction.mockImplementationOnce(async ({ fn }) => {
-          return await fn({});
+          return await fn({} as CoreTransaction);
         });
         taskVariantRepository.create.mockResolvedValueOnce(mockTaskVariant);
         taskVariantParameterRepository.createMany.mockResolvedValueOnce(mockParameterReturnValues);
@@ -145,7 +146,7 @@ describe('TaskService', () => {
 
         taskRepository.getById.mockResolvedValueOnce(mockTask);
         taskVariantRepository.runTransaction.mockImplementationOnce(async ({ fn }) => {
-          return await fn({});
+          return await fn({} as CoreTransaction);
         });
         taskVariantRepository.create.mockResolvedValueOnce(mockTaskVariant);
         taskVariantParameterRepository.createMany.mockResolvedValueOnce([{ id: 'param-1' }]);
@@ -205,7 +206,7 @@ describe('TaskService', () => {
 
         taskRepository.getById.mockResolvedValueOnce(mockTask);
         taskVariantRepository.runTransaction.mockImplementationOnce(async ({ fn }) => {
-          return await fn({});
+          return await fn({} as CoreTransaction);
         });
         taskVariantRepository.create.mockResolvedValueOnce(mockTaskVariant);
 
@@ -241,7 +242,7 @@ describe('TaskService', () => {
 
         taskRepository.getById.mockResolvedValue(mockTask);
         taskVariantRepository.runTransaction.mockImplementationOnce(async ({ fn }) => {
-          return await fn({});
+          return await fn({} as CoreTransaction);
         });
         taskVariantRepository.create.mockResolvedValueOnce(mockTaskVariant);
 
@@ -375,7 +376,7 @@ describe('TaskService', () => {
 
         taskRepository.getById.mockResolvedValue(mockTask);
         taskVariantRepository.runTransaction.mockImplementationOnce(async ({ fn }) => {
-          return await fn({});
+          return await fn({} as CoreTransaction);
         });
 
         const taskId = mockTask.id;
@@ -424,7 +425,7 @@ describe('TaskService', () => {
 
         taskRepository.getById.mockResolvedValueOnce(mockTask);
         taskVariantRepository.runTransaction.mockImplementationOnce(async ({ fn }) => {
-          return await fn({});
+          return await fn({} as CoreTransaction);
         });
         taskVariantRepository.create.mockResolvedValueOnce(mockTaskVariant);
         taskVariantParameterRepository.createMany.mockResolvedValueOnce([{ id: 'param-1' }]);
@@ -453,7 +454,7 @@ describe('TaskService', () => {
 
         taskRepository.getById.mockResolvedValueOnce(mockTask);
         taskVariantRepository.runTransaction.mockImplementationOnce(async ({ fn }) => {
-          return await fn({});
+          return await fn({} as CoreTransaction);
         });
         taskVariantRepository.create.mockResolvedValueOnce(mockTaskVariant);
         taskVariantParameterRepository.createMany.mockResolvedValueOnce([{ id: 'param-1' }]);
@@ -482,7 +483,7 @@ describe('TaskService', () => {
 
         taskRepository.getById.mockResolvedValueOnce(mockTask);
         taskVariantRepository.runTransaction.mockImplementationOnce(async ({ fn }) => {
-          return await fn({});
+          return await fn({} as CoreTransaction);
         });
         taskVariantRepository.create.mockResolvedValueOnce(mockTaskVariant);
         taskVariantParameterRepository.createMany.mockResolvedValueOnce([{ id: 'param-1' }]);
@@ -516,7 +517,7 @@ describe('TaskService', () => {
 
         taskRepository.getById.mockResolvedValueOnce(mockTask);
         taskVariantRepository.runTransaction.mockImplementationOnce(async ({ fn }) => {
-          return await fn({});
+          return await fn({} as CoreTransaction);
         });
         taskVariantRepository.create.mockResolvedValueOnce(mockTaskVariant);
         taskVariantParameterRepository.createMany.mockResolvedValueOnce([{ id: 'param-1' }]);
@@ -555,7 +556,7 @@ describe('TaskService', () => {
 
         taskVariantRepository.getTaskIdByVariantId.mockResolvedValueOnce({ taskId: mockTask.id });
         taskVariantRepository.runTransaction.mockImplementationOnce(async ({ fn }) => {
-          return await fn({});
+          return await fn({} as CoreTransaction);
         });
         taskVariantRepository.update.mockResolvedValueOnce();
 
@@ -579,7 +580,7 @@ describe('TaskService', () => {
 
         taskVariantRepository.getTaskIdByVariantId.mockResolvedValueOnce({ taskId: mockTask.id });
         taskVariantRepository.runTransaction.mockImplementationOnce(async ({ fn }) => {
-          return await fn({});
+          return await fn({} as CoreTransaction);
         });
         taskVariantRepository.update.mockResolvedValueOnce();
 
@@ -602,7 +603,7 @@ describe('TaskService', () => {
 
         taskVariantRepository.getTaskIdByVariantId.mockResolvedValueOnce({ taskId: mockTask.id });
         taskVariantRepository.runTransaction.mockImplementationOnce(async ({ fn }) => {
-          return await fn({});
+          return await fn({} as CoreTransaction);
         });
         taskVariantRepository.update.mockResolvedValueOnce();
 
@@ -625,7 +626,7 @@ describe('TaskService', () => {
 
         taskVariantRepository.getTaskIdByVariantId.mockResolvedValueOnce({ taskId: mockTask.id });
         taskVariantRepository.runTransaction.mockImplementationOnce(async ({ fn }) => {
-          return await fn({});
+          return await fn({} as CoreTransaction);
         });
         taskVariantParameterRepository.deleteByTaskVariantId.mockResolvedValueOnce();
         taskVariantParameterRepository.createMany.mockResolvedValueOnce([{ id: 'param-1' }]);
@@ -660,7 +661,7 @@ describe('TaskService', () => {
 
         taskVariantRepository.getTaskIdByVariantId.mockResolvedValueOnce({ taskId: mockTask.id });
         taskVariantRepository.runTransaction.mockImplementationOnce(async ({ fn }) => {
-          return await fn({});
+          return await fn({} as CoreTransaction);
         });
         taskVariantRepository.update.mockResolvedValueOnce();
         taskVariantParameterRepository.deleteByTaskVariantId.mockResolvedValueOnce();
@@ -696,7 +697,7 @@ describe('TaskService', () => {
 
         taskVariantRepository.getTaskIdByVariantId.mockResolvedValueOnce({ taskId: mockTask.id });
         taskVariantRepository.runTransaction.mockImplementationOnce(async ({ fn }) => {
-          return await fn({});
+          return await fn({} as CoreTransaction);
         });
         taskVariantRepository.update.mockResolvedValueOnce();
 
@@ -719,7 +720,7 @@ describe('TaskService', () => {
 
         taskVariantRepository.getTaskIdByVariantId.mockResolvedValueOnce({ taskId: mockTask.id });
         taskVariantRepository.runTransaction.mockImplementationOnce(async ({ fn }) => {
-          return await fn({});
+          return await fn({} as CoreTransaction);
         });
         taskVariantParameterRepository.deleteByTaskVariantId.mockResolvedValueOnce();
 
@@ -901,7 +902,7 @@ describe('TaskService', () => {
 
         taskVariantRepository.getTaskIdByVariantId.mockResolvedValueOnce({ taskId: mockTask.id });
         taskVariantRepository.runTransaction.mockImplementationOnce(async ({ fn }) => {
-          return await fn({});
+          return await fn({} as CoreTransaction);
         });
         taskVariantRepository.update.mockResolvedValueOnce();
 
@@ -923,7 +924,7 @@ describe('TaskService', () => {
 
         taskVariantRepository.getTaskIdByVariantId.mockResolvedValueOnce({ taskId: mockTask.id });
         taskVariantRepository.runTransaction.mockImplementationOnce(async ({ fn }) => {
-          return await fn({});
+          return await fn({} as CoreTransaction);
         });
         taskVariantParameterRepository.deleteByTaskVariantId.mockResolvedValueOnce();
         taskVariantParameterRepository.createMany.mockResolvedValueOnce([{ id: 'param-1' }]);
@@ -945,7 +946,7 @@ describe('TaskService', () => {
         for (const status of [TaskVariantStatus.DRAFT, TaskVariantStatus.PUBLISHED, TaskVariantStatus.DEPRECATED]) {
           taskVariantRepository.getTaskIdByVariantId.mockResolvedValueOnce({ taskId: mockTask.id });
           taskVariantRepository.runTransaction.mockImplementationOnce(async ({ fn }) => {
-            return await fn({});
+            return await fn({} as CoreTransaction);
           });
           taskVariantRepository.update.mockResolvedValueOnce();
 

--- a/apps/backend/src/services/user/user.service.create.test.ts
+++ b/apps/backend/src/services/user/user.service.create.test.ts
@@ -29,6 +29,7 @@ import { createMockDistrictRepository } from '../../test-support/repositories/di
 import { createMockSchoolRepository } from '../../test-support/repositories/school.repository';
 import { createMockGroupRepository } from '../../test-support/repositories/group.repository';
 import { createMockFamilyRepository } from '../../test-support/repositories/family.repository';
+import type { CoreTransaction } from '../../db/clients';
 import { createMockClassRepository } from '../../test-support/repositories/class.repository';
 import { createMockRosterProviderIdRepository } from '../../test-support/repositories/roster-provider-id.repository';
 import { OrgFactory } from '../../test-support/factories/org.factory';
@@ -141,7 +142,9 @@ describe('UserService.create', () => {
     mockFamilyRepo.getActiveById.mockResolvedValue(FamilyFactory.build());
     mockUserRepo.createWithMemberships.mockResolvedValue({ id: newUserId });
     mockUserRepo.delete.mockResolvedValue(undefined);
+    mockUserRepo.runTransaction.mockImplementation(async ({ fn }) => fn({} as CoreTransaction));
     mockRosterProviderRepo.create.mockResolvedValue({ id: newUserId });
+    mockRosterProviderRepo.deleteByEntityId.mockResolvedValue(undefined);
 
     mockAuth.getUserByEmail.mockRejectedValue(makeFirebaseError('auth/user-not-found'));
     mockAuth.createUser.mockResolvedValue({ uid: firebaseUid });
@@ -444,8 +447,10 @@ describe('UserService.create', () => {
         statusCode: StatusCodes.INTERNAL_SERVER_ERROR,
       });
 
-      // FGA compensation
+      // FGA partial-write compensation
       expect(mockAuthzService.deleteTuples).toHaveBeenCalledOnce();
+      // Roster provider row must be deleted before the user row (trigger ordering)
+      expect(mockRosterProviderRepo.deleteByEntityId).toHaveBeenCalledWith(newUserId);
       // DB compensation
       expect(mockUserRepo.delete).toHaveBeenCalledWith({ id: newUserId });
       // Firebase compensation
@@ -502,10 +507,11 @@ describe('UserService.create', () => {
 
       expect(mockUserRepo.createWithMemberships).toHaveBeenCalledWith(
         expect.objectContaining({ assessmentPid: 'custom-pid' }),
-        expect.anything(),
-        expect.anything(),
-        expect.anything(),
-        expect.anything(),
+        expect.anything(), // orgMemberships
+        expect.anything(), // classMemberships
+        expect.anything(), // groupMemberships
+        expect.anything(), // familyMemberships
+        expect.anything(), // tx
       );
     });
 

--- a/apps/backend/src/services/user/user.service.create.test.ts
+++ b/apps/backend/src/services/user/user.service.create.test.ts
@@ -434,6 +434,44 @@ describe('UserService.create', () => {
         expect.stringContaining('compensation failed'),
       );
     });
+
+    it('resolveRootOrgProviderFromMemberships throws before transaction opens → only Firebase compensated', async () => {
+      // Resolver runs before runTransaction is called. If it throws, no DB write has
+      // occurred — only the Firebase account (created in step 3) needs compensation.
+      const authContext = AuthContextFactory.build({ isSuperAdmin: true });
+      mockClassRepo.getDistinctRootOrgIds.mockResolvedValue([{ id: 'district-a' }, { id: 'district-b' }]);
+      const body = {
+        ...validBody,
+        memberships: [{ entityType: EntityType.CLASS, entityId: classId, role: UserRole.STUDENT }],
+      };
+
+      await expect(service.create(authContext, body)).rejects.toMatchObject({
+        statusCode: StatusCodes.UNPROCESSABLE_ENTITY,
+      });
+
+      // Resolver threw before the transaction opened — no DB write was attempted
+      expect(mockUserRepo.runTransaction).not.toHaveBeenCalled();
+      expect(mockUserRepo.delete).not.toHaveBeenCalled();
+      expect(mockRosterProviderRepo.create).not.toHaveBeenCalled();
+      // Firebase was created in step 3 and must be compensated
+      expect(mockAuth.deleteUser).toHaveBeenCalledWith(firebaseUid);
+    });
+
+    it('rosterProviderIdRepository.create fails inside transaction → transaction rolled back, only Firebase compensated', async () => {
+      // rosterProviderIdRepository.create runs inside runTransaction. On failure the
+      // transaction rolls back atomically — no explicit userRepository.delete is needed.
+      const authContext = AuthContextFactory.build({ isSuperAdmin: true });
+      mockRosterProviderRepo.create.mockRejectedValue(new Error('insert failed'));
+
+      await expect(service.create(authContext, validBody)).rejects.toMatchObject({
+        statusCode: StatusCodes.INTERNAL_SERVER_ERROR,
+      });
+
+      // Transaction rolled back — explicit row delete must not be attempted
+      expect(mockUserRepo.delete).not.toHaveBeenCalled();
+      // Firebase was created in step 3 and must be compensated
+      expect(mockAuth.deleteUser).toHaveBeenCalledWith(firebaseUid);
+    });
   });
 
   // ── FGA write + full compensation ─────────────────────────────────────────

--- a/apps/backend/src/services/user/user.service.create.test.ts
+++ b/apps/backend/src/services/user/user.service.create.test.ts
@@ -29,6 +29,8 @@ import { createMockDistrictRepository } from '../../test-support/repositories/di
 import { createMockSchoolRepository } from '../../test-support/repositories/school.repository';
 import { createMockGroupRepository } from '../../test-support/repositories/group.repository';
 import { createMockFamilyRepository } from '../../test-support/repositories/family.repository';
+import { createMockClassRepository } from '../../test-support/repositories/class.repository';
+import { createMockRosterProviderIdRepository } from '../../test-support/repositories/roster-provider-id.repository';
 import { OrgFactory } from '../../test-support/factories/org.factory';
 import { GroupFactory } from '../../test-support/factories/group.factory';
 import { FamilyFactory } from '../../test-support/factories/family.factory';
@@ -98,7 +100,9 @@ describe('UserService.create', () => {
   let mockDistrictRepo: ReturnType<typeof createMockDistrictRepository>;
   let mockSchoolRepo: ReturnType<typeof createMockSchoolRepository>;
   let mockGroupRepo: ReturnType<typeof createMockGroupRepository>;
+  let mockClassRepo: ReturnType<typeof createMockClassRepository>;
   let mockFamilyRepo: ReturnType<typeof createMockFamilyRepository>;
+  let mockRosterProviderRepo: ReturnType<typeof createMockRosterProviderIdRepository>;
   let mockAuthzService: ReturnType<typeof createMockAuthorizationService>;
   let service: ReturnType<typeof UserService>;
 
@@ -107,7 +111,9 @@ describe('UserService.create', () => {
     mockDistrictRepo = createMockDistrictRepository();
     mockSchoolRepo = createMockSchoolRepository();
     mockGroupRepo = createMockGroupRepository();
+    mockClassRepo = createMockClassRepository();
     mockFamilyRepo = createMockFamilyRepository();
+    mockRosterProviderRepo = createMockRosterProviderIdRepository();
     mockAuthzService = createMockAuthorizationService();
 
     service = UserService({
@@ -117,8 +123,10 @@ describe('UserService.create', () => {
       agreementRepository: createMockAgreementRepository(),
       districtRepository: mockDistrictRepo,
       schoolRepository: mockSchoolRepo,
+      classRepository: mockClassRepo,
       groupRepository: mockGroupRepo,
       familyRepository: mockFamilyRepo,
+      rosterProviderIdRepository: mockRosterProviderRepo,
       authorizationService: mockAuthzService,
     });
 
@@ -127,10 +135,13 @@ describe('UserService.create', () => {
     mockUserRepo.existsByUniqueFields.mockResolvedValue(false);
     mockDistrictRepo.getActiveById.mockResolvedValue(OrgFactory.build());
     mockSchoolRepo.getActiveById.mockResolvedValue(OrgFactory.build());
+    mockClassRepo.getDistinctRootIds.mockResolvedValue([{ id: districtId }]);
+    mockSchoolRepo.getDistinctRootIds.mockResolvedValue([{ id: districtId }]);
     mockGroupRepo.getActiveById.mockResolvedValue(GroupFactory.build());
     mockFamilyRepo.getActiveById.mockResolvedValue(FamilyFactory.build());
     mockUserRepo.createWithMemberships.mockResolvedValue({ id: newUserId });
     mockUserRepo.delete.mockResolvedValue(undefined);
+    mockRosterProviderRepo.create.mockResolvedValue({ id: newUserId });
 
     mockAuth.getUserByEmail.mockRejectedValue(makeFirebaseError('auth/user-not-found'));
     mockAuth.createUser.mockResolvedValue({ uid: firebaseUid });
@@ -380,6 +391,8 @@ describe('UserService.create', () => {
         statusCode: StatusCodes.CONFLICT,
       });
       expect(mockAuth.deleteUser).toHaveBeenCalledWith(firebaseUid);
+      // createWithMemberships threw, so newUserId was never set — DB row delete must not be attempted
+      expect(mockUserRepo.delete).not.toHaveBeenCalled();
       expect(mockAuthzService.writeTuplesOrThrow).not.toHaveBeenCalled();
     });
 
@@ -391,6 +404,7 @@ describe('UserService.create', () => {
         statusCode: StatusCodes.UNPROCESSABLE_ENTITY,
       });
       expect(mockAuth.deleteUser).toHaveBeenCalledWith(firebaseUid);
+      expect(mockUserRepo.delete).not.toHaveBeenCalled();
     });
 
     it('DB generic error → calls deleteUser compensation → 500', async () => {
@@ -401,6 +415,7 @@ describe('UserService.create', () => {
         statusCode: StatusCodes.INTERNAL_SERVER_ERROR,
       });
       expect(mockAuth.deleteUser).toHaveBeenCalledWith(firebaseUid);
+      expect(mockUserRepo.delete).not.toHaveBeenCalled();
     });
 
     it('DB failure + deleteUser compensation failure → returns 500 and logs with full context', async () => {
@@ -451,6 +466,8 @@ describe('UserService.create', () => {
       );
     });
   });
+
+  // ──  ─────────────────────────────────────────────────
 
   // ── Happy path end-to-end ─────────────────────────────────────────────────
 

--- a/apps/backend/src/services/user/user.service.create.test.ts
+++ b/apps/backend/src/services/user/user.service.create.test.ts
@@ -314,6 +314,34 @@ describe('UserService.create', () => {
       });
       expect(mockAuth.createUser).not.toHaveBeenCalled();
     });
+
+    it('non-super-admin: non-existent district entityId → 422 before Firebase call (defense-in-depth)', async () => {
+      // verifyMembershipEntityExists is called for all non-class, non-family memberships
+      // even when the FGA check would likely catch it anyway. Defense-in-depth.
+      const authContext = AuthContextFactory.build({ isSuperAdmin: false });
+      mockDistrictRepo.getActiveById.mockResolvedValue(null);
+
+      await expect(service.create(authContext, validBody)).rejects.toMatchObject({
+        statusCode: StatusCodes.UNPROCESSABLE_ENTITY,
+      });
+      expect(mockAuth.createUser).not.toHaveBeenCalled();
+    });
+
+    it('non-super-admin: non-existent family entityId → 422 before Firebase call (defense-in-depth)', async () => {
+      // Family entities have no FGA check, so verifyMembershipEntityExists is the only guard.
+      const authContext = AuthContextFactory.build({ isSuperAdmin: false });
+      const familyId = 'family-uuid-1';
+      const body = {
+        ...validBody,
+        memberships: [{ entityType: EntityType.FAMILY, entityId: familyId, role: UserFamilyRole.CHILD }],
+      };
+      mockFamilyRepo.getActiveById.mockResolvedValue(null);
+
+      await expect(service.create(authContext, body)).rejects.toMatchObject({
+        statusCode: StatusCodes.UNPROCESSABLE_ENTITY,
+      });
+      expect(mockAuth.createUser).not.toHaveBeenCalled();
+    });
   });
 
   // ── Pre-flight uniqueness ──────────────────────────────────────────────────
@@ -472,6 +500,42 @@ describe('UserService.create', () => {
       // Firebase was created in step 3 and must be compensated
       expect(mockAuth.deleteUser).toHaveBeenCalledWith(firebaseUid);
     });
+
+    it('class membership with no resolvable root district → 404 before transaction opens', async () => {
+      // getDistinctRootOrgIds returns [] when the class has no org hierarchy row above it.
+      // The resolver throws NOT_FOUND before runTransaction is called.
+      const authContext = AuthContextFactory.build({ isSuperAdmin: true });
+      mockClassRepo.getDistinctRootOrgIds.mockResolvedValue([]);
+      const body = {
+        ...validBody,
+        memberships: [{ entityType: EntityType.CLASS, entityId: classId, role: UserRole.STUDENT }],
+      };
+
+      await expect(service.create(authContext, body)).rejects.toMatchObject({
+        statusCode: StatusCodes.NOT_FOUND,
+      });
+
+      expect(mockUserRepo.runTransaction).not.toHaveBeenCalled();
+      expect(mockAuth.deleteUser).toHaveBeenCalledWith(firebaseUid);
+    });
+
+    it('school membership with no resolvable root district → 404 before transaction opens', async () => {
+      // getDistinctRootOrgIds returns [] when the school has no parent in the org hierarchy.
+      // The resolver throws NOT_FOUND before runTransaction is called.
+      const authContext = AuthContextFactory.build({ isSuperAdmin: true });
+      mockSchoolRepo.getDistinctRootOrgIds.mockResolvedValue([]);
+      const body = {
+        ...validBody,
+        memberships: [{ entityType: EntityType.SCHOOL, entityId: schoolId, role: UserRole.STUDENT }],
+      };
+
+      await expect(service.create(authContext, body)).rejects.toMatchObject({
+        statusCode: StatusCodes.NOT_FOUND,
+      });
+
+      expect(mockUserRepo.runTransaction).not.toHaveBeenCalled();
+      expect(mockAuth.deleteUser).toHaveBeenCalledWith(firebaseUid);
+    });
   });
 
   // ── FGA write + full compensation ─────────────────────────────────────────
@@ -487,10 +551,11 @@ describe('UserService.create', () => {
 
       // FGA partial-write compensation
       expect(mockAuthzService.deleteTuples).toHaveBeenCalledOnce();
-      // Roster provider row must be deleted before the user row (trigger ordering)
-      expect(mockRosterProviderRepo.deleteByEntityId).toHaveBeenCalledWith(newUserId);
+      // Roster provider row must be deleted before the user row (trigger ordering),
+      // both inside a single transaction for atomicity.
+      expect(mockRosterProviderRepo.deleteByEntityId).toHaveBeenCalledWith(newUserId, expect.anything());
       // DB compensation
-      expect(mockUserRepo.delete).toHaveBeenCalledWith({ id: newUserId });
+      expect(mockUserRepo.delete).toHaveBeenCalledWith(expect.objectContaining({ id: newUserId }));
       // Firebase compensation
       expect(mockAuth.deleteUser).toHaveBeenCalledWith(firebaseUid);
     });

--- a/apps/backend/src/services/user/user.service.create.test.ts
+++ b/apps/backend/src/services/user/user.service.create.test.ts
@@ -135,8 +135,8 @@ describe('UserService.create', () => {
     mockUserRepo.existsByUniqueFields.mockResolvedValue(false);
     mockDistrictRepo.getActiveById.mockResolvedValue(OrgFactory.build());
     mockSchoolRepo.getActiveById.mockResolvedValue(OrgFactory.build());
-    mockClassRepo.getDistinctRootIds.mockResolvedValue([{ id: districtId }]);
-    mockSchoolRepo.getDistinctRootIds.mockResolvedValue([{ id: districtId }]);
+    mockClassRepo.getDistinctRootOrgIds.mockResolvedValue([{ id: districtId }]);
+    mockSchoolRepo.getDistinctRootOrgIds.mockResolvedValue([{ id: districtId }]);
     mockGroupRepo.getActiveById.mockResolvedValue(GroupFactory.build());
     mockFamilyRepo.getActiveById.mockResolvedValue(FamilyFactory.build());
     mockUserRepo.createWithMemberships.mockResolvedValue({ id: newUserId });

--- a/apps/backend/src/services/user/user.service.create.test.ts
+++ b/apps/backend/src/services/user/user.service.create.test.ts
@@ -510,8 +510,6 @@ describe('UserService.create', () => {
     });
   });
 
-  // ──  ─────────────────────────────────────────────────
-
   // ── Happy path end-to-end ─────────────────────────────────────────────────
 
   describe('happy path', () => {
@@ -587,6 +585,45 @@ describe('UserService.create', () => {
       expect(orgMemberships).toHaveLength(2); // district + school
       expect(classMemberships).toHaveLength(0);
       expect(groupMemberships).toHaveLength(1);
+    });
+
+    it('multiple group memberships → first group ID used as partnerId (first-wins)', async () => {
+      // Groups are flat; no hierarchy to validate. First in request order wins.
+      const authContext = AuthContextFactory.build({ isSuperAdmin: true });
+      const secondGroupId = 'group-uuid-2';
+      const body = {
+        ...validBody,
+        memberships: [
+          { entityType: EntityType.GROUP, entityId: groupId, role: UserRole.STUDENT },
+          { entityType: EntityType.GROUP, entityId: secondGroupId, role: UserRole.STUDENT },
+        ],
+      };
+
+      await service.create(authContext, body);
+
+      expect(mockRosterProviderRepo.create).toHaveBeenCalledWith(
+        expect.objectContaining({ data: expect.objectContaining({ partnerId: groupId }) }),
+      );
+    });
+
+    it('multiple family memberships → first family ID used as partnerId (first-wins)', async () => {
+      // Families are flat; no hierarchy to validate. First in request order wins.
+      const authContext = AuthContextFactory.build({ isSuperAdmin: true });
+      const firstFamilyId = 'family-uuid-1';
+      const secondFamilyId = 'family-uuid-2';
+      const body = {
+        ...validBody,
+        memberships: [
+          { entityType: EntityType.FAMILY, entityId: firstFamilyId, role: UserFamilyRole.PARENT },
+          { entityType: EntityType.FAMILY, entityId: secondFamilyId, role: UserFamilyRole.PARENT },
+        ],
+      };
+
+      await service.create(authContext, body);
+
+      expect(mockRosterProviderRepo.create).toHaveBeenCalledWith(
+        expect.objectContaining({ data: expect.objectContaining({ partnerId: firstFamilyId }) }),
+      );
     });
   });
 });

--- a/apps/backend/src/services/user/user.service.create.test.ts
+++ b/apps/backend/src/services/user/user.service.create.test.ts
@@ -572,6 +572,8 @@ describe('UserService.create', () => {
         expect.objectContaining({ context: expect.objectContaining({ newUserId }) }),
         expect.stringContaining('DB delete compensation failed'),
       );
+      // Firebase compensation must fire regardless of whether DB cleanup succeeded
+      expect(mockAuth.deleteUser).toHaveBeenCalledWith(firebaseUid);
     });
   });
 

--- a/apps/backend/src/services/user/user.service.create.test.ts
+++ b/apps/backend/src/services/user/user.service.create.test.ts
@@ -79,7 +79,7 @@ const validBody = {
   email: 'student@example.com',
   password: 'password123',
   name: { first: 'Test', last: 'Student' },
-  userType: UserType.ADMIN,
+  userType: UserType.STUDENT,
   memberships: [{ entityType: EntityType.DISTRICT, entityId: districtId, role: UserRole.STUDENT }],
 };
 

--- a/apps/backend/src/services/user/user.service.ts
+++ b/apps/backend/src/services/user/user.service.ts
@@ -3,6 +3,8 @@ import type { User, NewUserAgreement, NewUserOrg, NewUserClass, NewUserGroup, Ne
 import type { Grade } from '../../enums/grade.enum';
 import type { FreeReducedLunchStatus } from '../../enums/frl-status.enum';
 import type { TupleKey, TupleKeyWithoutCondition } from '@openfga/sdk';
+import { RosteringProvider } from '../../enums/rostering-provider.enum';
+import { RosteringEntityType } from '../../enums/rostering-entity-type.enum';
 import { UserRole } from '../../enums/user-role.enum';
 import { UserFamilyRole } from '../../enums/user-family-role.enum';
 import { EntityType } from '../../types/entity-type';
@@ -19,8 +21,10 @@ import { AgreementVersionRepository } from '../../repositories/agreement-version
 import { AgreementRepository } from '../../repositories/agreement.repository';
 import { DistrictRepository } from '../../repositories/district.repository';
 import { SchoolRepository } from '../../repositories/school.repository';
+import { ClassRepository } from '../../repositories/class.repository';
 import { GroupRepository } from '../../repositories/group.repository';
 import { FamilyRepository } from '../../repositories/family.repository';
+import { RosterProviderIdRepository } from '../../repositories/roster-provider-id.repository';
 import { isMajorityAge } from '../../utils/is-majority-age.util';
 import { generateAssessmentPid } from '../../utils/assessment-pid.util';
 import { FirebaseAuthClient } from '../../clients/firebase-auth.clients';
@@ -89,6 +93,15 @@ interface CreateUserMemberships {
   role: UserRole | UserFamilyRole;
   enrollmentStart?: string | undefined;
   enrollmentEnd?: string | undefined;
+}
+
+/** Interface for creating a user's roster provider in the create user payload. */
+interface CreateUserRosterProvider {
+  providerType: RosteringProvider;
+  providerId: string;
+  partnerId: string;
+  entityType: RosteringEntityType;
+  entityId: string;
 }
 
 /**
@@ -180,8 +193,10 @@ export function UserService({
   agreementRepository = new AgreementRepository(),
   districtRepository = new DistrictRepository(),
   schoolRepository = new SchoolRepository(),
+  classRepository = new ClassRepository(),
   groupRepository = new GroupRepository(),
   familyRepository = new FamilyRepository(),
+  rosterProviderIdRepository = new RosterProviderIdRepository(),
   authorizationService = AuthorizationService(),
 }: {
   userRepository?: UserRepository;
@@ -190,8 +205,10 @@ export function UserService({
   agreementRepository?: AgreementRepository;
   districtRepository?: DistrictRepository;
   schoolRepository?: SchoolRepository;
+  classRepository?: ClassRepository;
   groupRepository?: GroupRepository;
   familyRepository?: FamilyRepository;
+  rosterProviderIdRepository?: RosterProviderIdRepository;
   authorizationService?: ReturnType<typeof AuthorizationService>;
 } = {}) {
   /** Map repository entity types to FGA object type prefixes. */
@@ -363,6 +380,7 @@ export function UserService({
    * @throws {ApiError} INTERNAL_SERVER_ERROR (500) on unexpected failures or unrecoverable compensation
    */
   async function create(authContext: AuthContext, body: CreateUserData): Promise<{ id: string }> {
+    const { demographics, dob, grade, email, identifiers, memberships, name, password, userType } = body;
     const { userId, isSuperAdmin } = authContext;
 
     // ── Step 1: Authorization + entity existence pre-flight ───────────────────
@@ -381,7 +399,7 @@ export function UserService({
 
     if (!isSuperAdmin) {
       // Guard against a current platform admin creating a new platform admin account
-      for (const m of body.memberships) {
+      for (const m of memberships) {
         if (isOrgMembership(m) && m.role === UserRole.PLATFORM_ADMIN)
           throw new ApiError('Platform admin cannot create a new platform admin account', {
             statusCode: StatusCodes.FORBIDDEN,
@@ -392,12 +410,12 @@ export function UserService({
 
       // Verify that all membership entities exist before proceeding
       await Promise.all(
-        body.memberships.map(async (membership) => {
+        memberships.map(async (membership) => {
           if (membership.entityType === EntityType.CLASS) {
             const schoolId = await userRepository.findClassParentSchool(membership.entityId);
             if (!schoolId) {
               logger.warn(
-                { userId, classId: membership.entityId, totalMemberships: body.memberships.length },
+                { userId, classId: membership.entityId, totalMemberships: memberships.length },
                 'Class not found or rostered out during user create pre-flight',
               );
               throw new ApiError(ApiErrorMessage.UNPROCESSABLE_ENTITY, {
@@ -406,6 +424,7 @@ export function UserService({
                 context: { userId, classId: membership.entityId },
               });
             }
+
             await authorizationService.requirePermission(
               userId,
               FgaRelation.CAN_CREATE_USERS,
@@ -459,7 +478,7 @@ export function UserService({
       // after a Firebase account has already been created and needs compensating deletion.
 
       await Promise.all(
-        body.memberships.map(async ({ entityType, entityId }) => {
+        memberships.map(async ({ entityType, entityId }) => {
           const exists = await verifyMembershipEntityExists(entityType, entityId);
           if (!exists) {
             logger.warn({ userId, entityType, entityId }, 'Membership entity not found during user create pre-flight');
@@ -484,16 +503,16 @@ export function UserService({
     // the true last line of defense for concurrent creates.
 
     const assessmentPid =
-      body.identifiers?.pid ??
+      identifiers?.pid ??
       generateAssessmentPid({
-        userId: body.email,
+        userId: email,
         // Prefixes could be derived from the first district/school membership abbreviation;
         // omitted for now to keep this endpoint consistent with the current cloud function
         // default (checksum-only) for new single-user creation.
       });
 
     const alreadyExists = await userRepository.existsByUniqueFields({
-      email: body.email,
+      email,
       assessmentPid,
     });
 
@@ -501,31 +520,28 @@ export function UserService({
       throw new ApiError(ApiErrorMessage.CONFLICT, {
         statusCode: StatusCodes.CONFLICT,
         code: ApiErrorCode.RESOURCE_CONFLICT,
-        context: { userId, email: body.email },
+        context: { userId, email },
       });
     }
 
     // Also check Firebase Auth — a user might exist there without a DB row
     try {
-      await FirebaseAuthClient.getUserByEmail(body.email);
+      await FirebaseAuthClient.getUserByEmail(email);
       // If getUserByEmail succeeds, the account already exists
       throw new ApiError(ApiErrorMessage.CONFLICT, {
         statusCode: StatusCodes.CONFLICT,
         code: ApiErrorCode.RESOURCE_CONFLICT,
-        context: { userId, email: body.email },
+        context: { userId, email },
       });
     } catch (error) {
       if (error instanceof ApiError) throw error;
       // `auth/user-not-found` is the expected case — swallow and continue
       if (!isFirebaseError(error) || error.code !== FIREBASE_ERROR_CODES.AUTH.USER_NOT_FOUND) {
-        logger.error(
-          { err: error, context: { userId, email: body.email } },
-          'Firebase getUserByEmail failed during pre-flight',
-        );
+        logger.error({ err: error, context: { userId, email } }, 'Firebase getUserByEmail failed during pre-flight');
         throw new ApiError('Failed to check Firebase user existence', {
           statusCode: StatusCodes.INTERNAL_SERVER_ERROR,
           code: ApiErrorCode.DATABASE_QUERY_FAILED,
-          context: { userId, email: body.email },
+          context: { userId, email },
           cause: error,
         });
       }
@@ -536,9 +552,9 @@ export function UserService({
     let firebaseUid: string;
     try {
       const authRecord = await FirebaseAuthClient.createUser({
-        email: body.email,
-        password: body.password,
-        displayName: [body.name.first, body.name.last].filter(Boolean).join(' '),
+        email,
+        password: password,
+        displayName: [name.first, name.last].filter(Boolean).join(' '),
       });
       firebaseUid = authRecord.uid;
     } catch (error) {
@@ -546,7 +562,7 @@ export function UserService({
         throw new ApiError(ApiErrorMessage.CONFLICT, {
           statusCode: StatusCodes.CONFLICT,
           code: ApiErrorCode.RESOURCE_CONFLICT,
-          context: { userId, email: body.email },
+          context: { userId, email },
         });
       }
 
@@ -554,25 +570,25 @@ export function UserService({
         throw new ApiError(ApiErrorMessage.RATE_LIMITED, {
           statusCode: StatusCodes.TOO_MANY_REQUESTS,
           code: ApiErrorCode.RATE_LIMITED,
-          context: { userId, email: body.email },
+          context: { userId, email },
           cause: error,
         });
       }
 
-      logger.error({ err: error, context: { userId, email: body.email } }, 'Firebase createUser failed');
+      logger.error({ err: error, context: { userId, email } }, 'Firebase createUser failed');
       throw new ApiError('Failed to create Firebase auth account', {
         statusCode: StatusCodes.INTERNAL_SERVER_ERROR,
         code: ApiErrorCode.DATABASE_QUERY_FAILED,
-        context: { userId, email: body.email },
+        context: { userId, email },
         cause: error,
       });
     }
 
-    // ── Step 4: DB transaction (user row + junction rows) ────────────────────
+    // ── Step 4: DB transaction (user row + junction rows + roster provider ID row) ────────────────────
     //
     // On failure: compensate by deleting the Firebase auth account.
 
-    let newUserId: string;
+    let newUserId!: string;
     try {
       const enrollmentStart = new Date();
 
@@ -619,22 +635,22 @@ export function UserService({
         {
           authId: firebaseUid,
           authProvider: [AuthProvider.PASSWORD],
-          email: body.email,
-          nameFirst: body.name.first,
-          nameMiddle: body.name.middle ?? null,
-          nameLast: body.name.last,
-          dob: body.dob ?? null,
-          grade: body.grade ?? null,
+          email: email,
+          nameFirst: name.first,
+          nameMiddle: name.middle ?? null,
+          nameLast: name.last,
+          dob: dob ?? null,
+          grade: grade ?? null,
           assessmentPid,
-          userType: body.userType,
-          statusEll: body.demographics?.statusEll ?? null,
-          statusFrl: body.demographics?.statusFrl ?? null,
-          statusIep: body.demographics?.statusIep ?? null,
-          gender: body.demographics?.gender ?? null,
-          race: body.demographics?.race ?? null,
-          hispanicEthnicity: body.demographics?.hispanicEthnicity ?? null,
-          homeLanguage: body.demographics?.homeLanguage ?? null,
-          stateId: body.identifiers?.stateId ?? null,
+          userType: userType,
+          statusEll: demographics?.statusEll ?? null,
+          statusFrl: demographics?.statusFrl ?? null,
+          statusIep: demographics?.statusIep ?? null,
+          gender: demographics?.gender ?? null,
+          race: demographics?.race ?? null,
+          hispanicEthnicity: demographics?.hispanicEthnicity ?? null,
+          homeLanguage: demographics?.homeLanguage ?? null,
+          stateId: identifiers?.stateId ?? null,
           isSuperAdmin: false,
         },
         orgMemberships,
@@ -644,39 +660,65 @@ export function UserService({
       );
 
       newUserId = result.id;
+
+      // Determine the root org provider from the memberships — throws if unresolvable
+      const resolvedPartnerId = await resolveRootOrgProviderFromMemberships(memberships);
+
+      const rosterProviderData: CreateUserRosterProvider = {
+        providerType: RosteringProvider.DASHBOARD,
+        providerId: newUserId,
+        partnerId: resolvedPartnerId,
+        entityType: RosteringEntityType.USER,
+        entityId: newUserId,
+      };
+
+      await rosterProviderIdRepository.create({ data: rosterProviderData });
     } catch (error) {
+      // ── Compensation ────────────────────────────────────────────────────────
+      // If createWithMemberships already committed a row, delete it now.
+      // This covers failures from resolveRootOrgProviderFromMemberships,
+      // the !resolvedPartnerId guard, and rosterProviderIdRepository.create().
+      if (newUserId) {
+        try {
+          await userRepository.delete({ id: newUserId });
+        } catch (dbDeleteError) {
+          logger.error(
+            { err: dbDeleteError, context: { userId, newUserId } },
+            'DB delete compensation failed during step 4 — manual cleanup required',
+          );
+        }
+      }
+
+      // Always compensate Firebase — step 3 has already run by this point.
+      await compensateDeleteFirebaseUser(firebaseUid, userId, email, 'step 4 failure');
+
       if (error instanceof ApiError) throw error;
 
       const dbError = unwrapDrizzleError(error);
 
       if (isUniqueViolation(dbError)) {
-        // Compensate: roll back the Firebase auth account
-        await compensateDeleteFirebaseUser(firebaseUid, userId, body.email, 'DB unique violation');
         throw new ApiError(ApiErrorMessage.CONFLICT, {
           statusCode: StatusCodes.CONFLICT,
           code: ApiErrorCode.RESOURCE_CONFLICT,
-          context: { userId, email: body.email },
+          context: { userId, email },
           cause: error,
         });
       }
 
       if (isForeignKeyViolation(dbError)) {
-        // A membership entityId didn't resolve — FK constraint fired
-        await compensateDeleteFirebaseUser(firebaseUid, userId, body.email, 'FK violation on membership entity');
         throw new ApiError(ApiErrorMessage.UNPROCESSABLE_ENTITY, {
           statusCode: StatusCodes.UNPROCESSABLE_ENTITY,
           code: ApiErrorCode.RESOURCE_NOT_FOUND,
-          context: { userId, email: body.email },
+          context: { userId, email },
           cause: error,
         });
       }
 
-      logger.error({ err: error, context: { userId, email: body.email } }, 'DB write failed during user create');
-      await compensateDeleteFirebaseUser(firebaseUid, userId, body.email, 'DB write failure');
+      logger.error({ err: error, context: { userId, email } }, 'DB write failed during user create');
       throw new ApiError('Failed to create user record', {
         statusCode: StatusCodes.INTERNAL_SERVER_ERROR,
         code: ApiErrorCode.DATABASE_QUERY_FAILED,
-        context: { userId, email: body.email, firebaseUid },
+        context: { userId, email, firebaseUid },
         cause: error,
       });
     }
@@ -685,13 +727,13 @@ export function UserService({
     //
     // On failure: compensate by deleting FGA tuples, then the DB row, then Firebase.
 
-    const fgaTuples = buildMembershipTuples(newUserId, body.memberships);
+    const fgaTuples = buildMembershipTuples(newUserId, memberships);
 
     try {
       await authorizationService.writeTuplesOrThrow(fgaTuples);
     } catch (error) {
       logger.error(
-        { err: error, context: { userId, newUserId, email: body.email, firebaseUid } },
+        { err: error, context: { userId, newUserId, email, firebaseUid } },
         'FGA write failed during user create — beginning compensation',
       );
 
@@ -714,17 +756,17 @@ export function UserService({
       }
 
       // Delete the Firebase auth account
-      await compensateDeleteFirebaseUser(firebaseUid, userId, body.email, 'FGA write failure');
+      await compensateDeleteFirebaseUser(firebaseUid, userId, email, 'FGA write failure');
 
       throw new ApiError(ApiErrorMessage.EXTERNAL_SERVICE_UNAVAILABLE, {
         statusCode: StatusCodes.INTERNAL_SERVER_ERROR,
         code: ApiErrorCode.DATABASE_QUERY_FAILED,
-        context: { userId, newUserId, email: body.email, firebaseUid },
+        context: { userId, newUserId, email, firebaseUid },
         cause: error,
       });
     }
 
-    logger.info({ userId, newUserId, email: body.email }, 'Created user');
+    logger.info({ userId, newUserId, email }, 'Created user');
     return { id: newUserId };
   }
 
@@ -742,6 +784,127 @@ export function UserService({
     if (entityType === EntityType.CLASS) return (await userRepository.findClassParentSchool(entityId)) !== null;
     if (entityType === EntityType.GROUP) return (await groupRepository.getActiveById({ id: entityId })) !== null;
     return (await familyRepository.getActiveById({ id: entityId })) !== null;
+  }
+
+  /**
+   * Resolve the single root org provider ID from the user's memberships.
+   *
+   * Resolution priority (first match wins):
+   * 1. Explicit district membership → district ID
+   * 2. Class memberships → district ID via ltree path (classRepository.getDistinctRootIds)
+   * 3. School memberships → district ID via ltree path (schoolRepository.getDistinctRootIds)
+   * 4. Group memberships → first group ID
+   * 5. Family memberships → first family ID
+   *
+   * @param memberships The user's membership information from the request body
+   * @returns The resolved root org provider ID
+   * @throws {ApiError} If the ID cannot be resolved or if cross-district memberships are detected
+   */
+  async function resolveRootOrgProviderFromMemberships(memberships: CreateUserMemberships[]): Promise<string> {
+    // Extract the partner IDs from the memberships
+    const partnerIds = memberships.map(({ entityId, entityType }) => ({ entityId, entityType }));
+
+    // 1) If there's an explicit district membership, return it
+    const districtIds = partnerIds
+      .filter(({ entityType }) => entityType === EntityType.DISTRICT)
+      .map(({ entityId }) => entityId);
+
+    if (districtIds.length > 1) {
+      throw new ApiError('Multiple district memberships found', {
+        statusCode: StatusCodes.UNPROCESSABLE_ENTITY,
+        code: ApiErrorCode.RESOURCE_UNPROCESSABLE,
+        context: { districtIds },
+      });
+    }
+
+    if (districtIds.length === 1) {
+      return districtIds[0]!;
+    }
+
+    // 2) If there are class memberships, resolve class -> school -> district
+    const classIds = partnerIds
+      .filter(({ entityType }) => entityType === EntityType.CLASS)
+      .map(({ entityId }) => entityId);
+
+    if (classIds.length > 0) {
+      const districtIdsFromClasses = (await classRepository.getDistinctRootIds(classIds)).map(({ id }) => id);
+
+      // Check if there are any district IDs from class memberships
+      const districtIdsFromClassesSet = new Set(districtIdsFromClasses);
+
+      // If no district IDs are found from class memberships, throw an error
+      if (districtIdsFromClassesSet.size === 0) {
+        throw new ApiError('No district found for class memberships', {
+          statusCode: StatusCodes.NOT_FOUND,
+          code: ApiErrorCode.RESOURCE_NOT_FOUND,
+          context: { classIds, districtIdsFromClasses },
+        });
+      }
+
+      // If multiple district IDs are found from class memberships, throw an error
+      if (districtIdsFromClassesSet.size > 1) {
+        throw new ApiError('Multiple districts found for class memberships', {
+          statusCode: StatusCodes.UNPROCESSABLE_ENTITY,
+          code: ApiErrorCode.RESOURCE_UNPROCESSABLE,
+          context: { classIds, districtIdsFromClasses },
+        });
+      }
+
+      // If a single district ID is found from class memberships, return it
+      return districtIdsFromClasses[0]!;
+    }
+
+    // 3) If there are school memberships, resolve school -> district
+    const schoolIds = partnerIds
+      .filter(({ entityType }) => entityType === EntityType.SCHOOL)
+      .map(({ entityId }) => entityId);
+
+    if (schoolIds.length > 0) {
+      const districtIdsFromSchools = (await schoolRepository.getDistinctRootIds(schoolIds)).map(({ id }) => id);
+
+      // Check if there are any district IDs from school memberships
+      const districtIdsFromSchoolsSet = new Set(districtIdsFromSchools);
+
+      // If no district IDs are found from school memberships, throw an error
+      if (districtIdsFromSchoolsSet.size === 0) {
+        throw new ApiError('No district found from school memberships', {
+          statusCode: StatusCodes.NOT_FOUND,
+          code: ApiErrorCode.RESOURCE_NOT_FOUND,
+          context: { schoolIds },
+        });
+      }
+
+      // If multiple district IDs are found from school memberships, throw an error
+      if (districtIdsFromSchoolsSet.size > 1) {
+        throw new ApiError('Multiple districts found from school memberships', {
+          statusCode: StatusCodes.UNPROCESSABLE_ENTITY,
+          code: ApiErrorCode.RESOURCE_UNPROCESSABLE,
+          context: { schoolIds, districtIdsFromSchools },
+        });
+      }
+
+      // If a single district ID is found from school memberships, return it
+      return districtIdsFromSchools[0]!;
+    }
+
+    // 4) Fall back to group, then family
+    const groupIds = partnerIds
+      .filter(({ entityType }) => entityType === EntityType.GROUP)
+      .map(({ entityId }) => entityId);
+
+    if (groupIds.length > 0) return groupIds[0]!;
+
+    const familyIds = partnerIds
+      .filter(({ entityType }) => entityType === EntityType.FAMILY)
+      .map(({ entityId }) => entityId);
+
+    if (familyIds.length > 0) return familyIds[0]!;
+
+    throw new ApiError('Failed to resolve root org provider from user memberships', {
+      statusCode: StatusCodes.NOT_FOUND,
+      code: ApiErrorCode.RESOURCE_NOT_FOUND,
+      context: { memberships },
+    });
   }
 
   /**

--- a/apps/backend/src/services/user/user.service.ts
+++ b/apps/backend/src/services/user/user.service.ts
@@ -780,105 +780,80 @@ export function UserService({
   /**
    * Resolve the single root org provider ID from the user's memberships.
    *
-   * Resolution priority (first match wins):
-   * 1. Explicit district membership → district ID
-   * 2. Class memberships → district ID via ltree path (classRepository.getDistinctRootOrgIds)
-   * 3. School memberships → district ID via ltree path (schoolRepository.getDistinctRootOrgIds)
-   * 4. Group memberships → first group ID
-   * 5. Family memberships → first family ID
+   * District resolution gathers evidence from all three org sources first, then
+   * validates that they agree before returning. This catches inconsistencies such
+   * as an explicit district_A combined with a class whose ltree root is district_B.
+   *
+   * Resolution order:
+   * 1. Collect district IDs from: explicit district memberships + class ltree roots
+   *    + school ltree roots (all resolved in parallel).
+   * 2. If the combined set has exactly one district → return it.
+   * 3. If the combined set has more than one distinct district → throw 422.
+   * 4. If no district evidence → fall through to group, then family.
    *
    * @param memberships The user's membership information from the request body
    * @returns The resolved root org provider ID
-   * @throws {ApiError} If the ID cannot be resolved or if cross-district memberships are detected
+   * @throws {ApiError} NOT_FOUND if a class or school membership has no resolvable root district
+   * @throws {ApiError} UNPROCESSABLE_ENTITY if memberships span more than one distinct district
+   * @throws {ApiError} NOT_FOUND if no provider can be resolved at all
    */
   async function resolveRootOrgProviderFromMemberships(memberships: CreateUserMemberships[]): Promise<string> {
-    // Extract the partner IDs from the memberships
     const partnerIds = memberships.map(({ entityId, entityType }) => ({ entityId, entityType }));
 
-    // 1) If there's an explicit district membership, return it
-    const districtIds = partnerIds
-      .filter(({ entityType }) => entityType === EntityType.DISTRICT)
-      .map(({ entityId }) => entityId);
-
-    if (districtIds.length > 1) {
-      throw new ApiError('Multiple district memberships found', {
-        statusCode: StatusCodes.UNPROCESSABLE_ENTITY,
-        code: ApiErrorCode.RESOURCE_UNPROCESSABLE,
-        context: { districtIds },
-      });
-    }
-
-    if (districtIds.length === 1) {
-      return districtIds[0]!;
-    }
-
-    // 2) If there are class memberships, resolve class -> school -> district
     const classIds = partnerIds
       .filter(({ entityType }) => entityType === EntityType.CLASS)
       .map(({ entityId }) => entityId);
 
-    if (classIds.length > 0) {
-      const districtIdsFromClasses = (await classRepository.getDistinctRootOrgIds(classIds)).map(({ id }) => id);
-
-      // Check if there are any district IDs from class memberships
-      const districtIdsFromClassesSet = new Set(districtIdsFromClasses);
-
-      // If no district IDs are found from class memberships, throw an error
-      if (districtIdsFromClassesSet.size === 0) {
-        throw new ApiError('No district found for class memberships', {
-          statusCode: StatusCodes.NOT_FOUND,
-          code: ApiErrorCode.RESOURCE_NOT_FOUND,
-          context: { classIds, districtIdsFromClasses },
-        });
-      }
-
-      // If multiple district IDs are found from class memberships, throw an error
-      if (districtIdsFromClassesSet.size > 1) {
-        throw new ApiError('Multiple districts found for class memberships', {
-          statusCode: StatusCodes.UNPROCESSABLE_ENTITY,
-          code: ApiErrorCode.RESOURCE_UNPROCESSABLE,
-          context: { classIds, districtIdsFromClasses },
-        });
-      }
-
-      // If a single district ID is found from class memberships, return it
-      return districtIdsFromClasses[0]!;
-    }
-
-    // 3) If there are school memberships, resolve school -> district
     const schoolIds = partnerIds
       .filter(({ entityType }) => entityType === EntityType.SCHOOL)
       .map(({ entityId }) => entityId);
 
-    if (schoolIds.length > 0) {
-      const districtIdsFromSchools = (await schoolRepository.getDistinctRootOrgIds(schoolIds)).map(({ id }) => id);
+    // Resolve class and school roots in parallel to keep the write window short.
+    const [classDistricts, schoolDistricts] = await Promise.all([
+      classIds.length > 0 ? classRepository.getDistinctRootOrgIds(classIds) : Promise.resolve([]),
+      schoolIds.length > 0 ? schoolRepository.getDistinctRootOrgIds(schoolIds) : Promise.resolve([]),
+    ]);
 
-      // Check if there are any district IDs from school memberships
-      const districtIdsFromSchoolsSet = new Set(districtIdsFromSchools);
-
-      // If no district IDs are found from school memberships, throw an error
-      if (districtIdsFromSchoolsSet.size === 0) {
-        throw new ApiError('No district found from school memberships', {
-          statusCode: StatusCodes.NOT_FOUND,
-          code: ApiErrorCode.RESOURCE_NOT_FOUND,
-          context: { schoolIds },
-        });
-      }
-
-      // If multiple district IDs are found from school memberships, throw an error
-      if (districtIdsFromSchoolsSet.size > 1) {
-        throw new ApiError('Multiple districts found from school memberships', {
-          statusCode: StatusCodes.UNPROCESSABLE_ENTITY,
-          code: ApiErrorCode.RESOURCE_UNPROCESSABLE,
-          context: { schoolIds, districtIdsFromSchools },
-        });
-      }
-
-      // If a single district ID is found from school memberships, return it
-      return districtIdsFromSchools[0]!;
+    if (classIds.length > 0 && classDistricts.length === 0) {
+      throw new ApiError(ApiErrorMessage.NOT_FOUND, {
+        statusCode: StatusCodes.NOT_FOUND,
+        code: ApiErrorCode.RESOURCE_NOT_FOUND,
+        context: { classIds },
+      });
     }
 
-    // 4) Fall back to group, then family
+    if (schoolIds.length > 0 && schoolDistricts.length === 0) {
+      throw new ApiError(ApiErrorMessage.NOT_FOUND, {
+        statusCode: StatusCodes.NOT_FOUND,
+        code: ApiErrorCode.RESOURCE_NOT_FOUND,
+        context: { schoolIds },
+      });
+    }
+
+    // Gather all district evidence into one set: explicit memberships + ltree roots.
+    // Using a Set naturally deduplicates — e.g., district_A explicit + school_in_district_A
+    // correctly collapses to a single entry rather than being flagged as cross-district.
+    const resolvedDistricts = new Set<string>();
+
+    for (const { entityId } of partnerIds.filter(({ entityType }) => entityType === EntityType.DISTRICT)) {
+      resolvedDistricts.add(entityId);
+    }
+    for (const { id } of classDistricts) resolvedDistricts.add(id);
+    for (const { id } of schoolDistricts) resolvedDistricts.add(id);
+
+    if (resolvedDistricts.size > 1) {
+      throw new ApiError(ApiErrorMessage.UNPROCESSABLE_ENTITY, {
+        statusCode: StatusCodes.UNPROCESSABLE_ENTITY,
+        code: ApiErrorCode.RESOURCE_UNPROCESSABLE,
+        context: { resolvedDistricts: [...resolvedDistricts] },
+      });
+    }
+
+    if (resolvedDistricts.size === 1) {
+      return [...resolvedDistricts][0]!;
+    }
+
+    // No district evidence — fall through to group, then family
     const groupIds = partnerIds
       .filter(({ entityType }) => entityType === EntityType.GROUP)
       .map(({ entityId }) => entityId);
@@ -891,7 +866,7 @@ export function UserService({
 
     if (familyIds.length > 0) return familyIds[0]!;
 
-    throw new ApiError('Failed to resolve root org provider from user memberships', {
+    throw new ApiError(ApiErrorMessage.NOT_FOUND, {
       statusCode: StatusCodes.NOT_FOUND,
       code: ApiErrorCode.RESOURCE_NOT_FOUND,
       context: { memberships },

--- a/apps/backend/src/services/user/user.service.ts
+++ b/apps/backend/src/services/user/user.service.ts
@@ -95,15 +95,6 @@ interface CreateUserMemberships {
   enrollmentEnd?: string | undefined;
 }
 
-/** Interface for creating a user's roster provider in the create user payload. */
-interface CreateUserRosterProvider {
-  providerType: RosteringProvider;
-  providerId: string;
-  partnerId: string;
-  entityType: RosteringEntityType;
-  entityId: string;
-}
-
 /**
  * Narrowed membership types used only in the create function for type-safe mapping.
  * The flat CreateUserMemberships interface is kept for controller compatibility —
@@ -586,7 +577,12 @@ export function UserService({
 
     // ── Step 4: DB transaction (user row + junction rows + roster provider ID row) ────────────────────
     //
-    // On failure: compensate by deleting the Firebase auth account.
+    // createWithMemberships and rosterProviderIdRepository.create run inside a single
+    // transaction so all DB writes succeed or roll back together.
+    // resolveRootOrgProviderFromMemberships is read-only and runs before the transaction
+    // opens to keep the write window as short as possible.
+    //
+    // On failure: the transaction rolls back atomically — only Firebase needs compensation.
 
     let newUserId!: string;
     try {
@@ -631,65 +627,58 @@ export function UserService({
           leftOn: m.enrollmentEnd ? new Date(m.enrollmentEnd) : null,
         }));
 
-      const result = await userRepository.createWithMemberships(
-        {
-          authId: firebaseUid,
-          authProvider: [AuthProvider.PASSWORD],
-          email: email,
-          nameFirst: name.first,
-          nameMiddle: name.middle ?? null,
-          nameLast: name.last,
-          dob: dob ?? null,
-          grade: grade ?? null,
-          assessmentPid,
-          userType: userType,
-          statusEll: demographics?.statusEll ?? null,
-          statusFrl: demographics?.statusFrl ?? null,
-          statusIep: demographics?.statusIep ?? null,
-          gender: demographics?.gender ?? null,
-          race: demographics?.race ?? null,
-          hispanicEthnicity: demographics?.hispanicEthnicity ?? null,
-          homeLanguage: demographics?.homeLanguage ?? null,
-          stateId: identifiers?.stateId ?? null,
-          isSuperAdmin: false,
-        },
-        orgMemberships,
-        classMemberships,
-        groupMemberships,
-        familyMemberships,
-      );
-
-      newUserId = result.id;
-
-      // Determine the root org provider from the memberships — throws if unresolvable
+      // Resolve the root org partner ID before opening the write transaction.
+      // Read-only — if it throws, no DB writes have happened yet so only Firebase needs compensation.
       const resolvedPartnerId = await resolveRootOrgProviderFromMemberships(memberships);
 
-      const rosterProviderData: CreateUserRosterProvider = {
-        providerType: RosteringProvider.DASHBOARD,
-        providerId: newUserId,
-        partnerId: resolvedPartnerId,
-        entityType: RosteringEntityType.USER,
-        entityId: newUserId,
-      };
-
-      await rosterProviderIdRepository.create({ data: rosterProviderData });
-    } catch (error) {
-      // ── Compensation ────────────────────────────────────────────────────────
-      // If createWithMemberships already committed a row, delete it now.
-      // This covers failures from resolveRootOrgProviderFromMemberships,
-      // the !resolvedPartnerId guard, and rosterProviderIdRepository.create().
-      if (newUserId) {
-        try {
-          await userRepository.delete({ id: newUserId });
-        } catch (dbDeleteError) {
-          logger.error(
-            { err: dbDeleteError, context: { userId, newUserId } },
-            'DB delete compensation failed during step 4 — manual cleanup required',
+      newUserId = await userRepository.runTransaction({
+        fn: async (tx) => {
+          const result = await userRepository.createWithMemberships(
+            {
+              authId: firebaseUid,
+              authProvider: [AuthProvider.PASSWORD],
+              email: email,
+              nameFirst: name.first,
+              nameMiddle: name.middle ?? null,
+              nameLast: name.last,
+              dob: dob ?? null,
+              grade: grade ?? null,
+              assessmentPid,
+              userType: userType,
+              statusEll: demographics?.statusEll ?? null,
+              statusFrl: demographics?.statusFrl ?? null,
+              statusIep: demographics?.statusIep ?? null,
+              gender: demographics?.gender ?? null,
+              race: demographics?.race ?? null,
+              hispanicEthnicity: demographics?.hispanicEthnicity ?? null,
+              homeLanguage: demographics?.homeLanguage ?? null,
+              stateId: identifiers?.stateId ?? null,
+              isSuperAdmin: false,
+            },
+            orgMemberships,
+            classMemberships,
+            groupMemberships,
+            familyMemberships,
+            tx,
           );
-        }
-      }
 
-      // Always compensate Firebase — step 3 has already run by this point.
+          await rosterProviderIdRepository.create({
+            data: {
+              providerType: RosteringProvider.DASHBOARD,
+              providerId: result.id,
+              partnerId: resolvedPartnerId,
+              entityType: RosteringEntityType.USER,
+              entityId: result.id,
+            },
+            transaction: tx,
+          });
+
+          return result.id;
+        },
+      });
+    } catch (error) {
+      // The transaction rolled back atomically — DB is clean.
+      // Only Firebase requires compensation since step 3 has already run.
       await compensateDeleteFirebaseUser(firebaseUid, userId, email, 'step 4 failure');
 
       if (error instanceof ApiError) throw error;
@@ -745,8 +734,10 @@ export function UserService({
       }));
       await authorizationService.deleteTuples(deleteTuples);
 
-      // Delete the DB row (cascade removes junction rows)
+      // Delete DB rows in the correct order: roster provider ID must be removed first
+      // or the `prevent_rostered_entity_delete` trigger will block the user DELETE.
       try {
+        await rosterProviderIdRepository.deleteByEntityId(newUserId);
         await userRepository.delete({ id: newUserId });
       } catch (dbDeleteError) {
         logger.error(

--- a/apps/backend/src/services/user/user.service.ts
+++ b/apps/backend/src/services/user/user.service.ts
@@ -735,11 +735,16 @@ export function UserService({
       }));
       await authorizationService.deleteTuples(deleteTuples);
 
-      // Delete DB rows in the correct order: roster provider ID must be removed first
-      // or the `prevent_rostered_entity_delete` trigger will block the user DELETE.
+      // Wrap both deletes in a single transaction: the roster provider row must be
+      // removed first (trigger ordering), and atomicity ensures we never end up with
+      // a user row that has no rostering entry if the second delete fails.
       try {
-        await rosterProviderIdRepository.deleteByEntityId(newUserId);
-        await userRepository.delete({ id: newUserId });
+        await userRepository.runTransaction({
+          fn: async (tx) => {
+            await rosterProviderIdRepository.deleteByEntityId(newUserId, tx);
+            await userRepository.delete({ id: newUserId, transaction: tx });
+          },
+        });
       } catch (dbDeleteError) {
         logger.error(
           { err: dbDeleteError, context: { userId, newUserId, firebaseUid } },

--- a/apps/backend/src/services/user/user.service.ts
+++ b/apps/backend/src/services/user/user.service.ts
@@ -791,8 +791,8 @@ export function UserService({
    *
    * Resolution priority (first match wins):
    * 1. Explicit district membership → district ID
-   * 2. Class memberships → district ID via ltree path (classRepository.getDistinctRootIds)
-   * 3. School memberships → district ID via ltree path (schoolRepository.getDistinctRootIds)
+   * 2. Class memberships → district ID via ltree path (classRepository.getDistinctRootOrgIds)
+   * 3. School memberships → district ID via ltree path (schoolRepository.getDistinctRootOrgIds)
    * 4. Group memberships → first group ID
    * 5. Family memberships → first family ID
    *
@@ -827,7 +827,7 @@ export function UserService({
       .map(({ entityId }) => entityId);
 
     if (classIds.length > 0) {
-      const districtIdsFromClasses = (await classRepository.getDistinctRootIds(classIds)).map(({ id }) => id);
+      const districtIdsFromClasses = (await classRepository.getDistinctRootOrgIds(classIds)).map(({ id }) => id);
 
       // Check if there are any district IDs from class memberships
       const districtIdsFromClassesSet = new Set(districtIdsFromClasses);
@@ -860,7 +860,7 @@ export function UserService({
       .map(({ entityId }) => entityId);
 
     if (schoolIds.length > 0) {
-      const districtIdsFromSchools = (await schoolRepository.getDistinctRootIds(schoolIds)).map(({ id }) => id);
+      const districtIdsFromSchools = (await schoolRepository.getDistinctRootOrgIds(schoolIds)).map(({ id }) => id);
 
       // Check if there are any district IDs from school memberships
       const districtIdsFromSchoolsSet = new Set(districtIdsFromSchools);

--- a/apps/backend/src/services/user/user.service.ts
+++ b/apps/backend/src/services/user/user.service.ts
@@ -677,7 +677,8 @@ export function UserService({
         },
       });
     } catch (error) {
-      // The transaction rolled back atomically — DB is clean.
+      // DB is clean: either the transaction rolled back atomically, or no transaction
+      // was opened (resolver threw before runTransaction was called).
       // Only Firebase requires compensation since step 3 has already run.
       await compensateDeleteFirebaseUser(firebaseUid, userId, email, 'step 4 failure');
 
@@ -790,6 +791,12 @@ export function UserService({
    * 2. If the combined set has exactly one district → return it.
    * 3. If the combined set has more than one distinct district → throw 422.
    * 4. If no district evidence → fall through to group, then family.
+   *
+   * Group and family fall-through use first-wins semantics: when multiple group or
+   * family memberships are present and no district evidence exists, the first ID in
+   * request order is returned. Groups and families are flat (non-hierarchical) so
+   * there is no "root" to validate uniqueness against. Callers should not rely on
+   * which entry wins when order is ambiguous.
    *
    * @param memberships The user's membership information from the request body
    * @returns The resolved root org provider ID

--- a/apps/backend/src/services/user/user.service.ts
+++ b/apps/backend/src/services/user/user.service.ts
@@ -392,6 +392,10 @@ export function UserService({
       // Guard against a current platform admin creating a new platform admin account
       for (const m of memberships) {
         if (isOrgMembership(m) && m.role === UserRole.PLATFORM_ADMIN)
+          logger.warn(
+            { userId, attemptedRole: m.role, entityType: m.entityType, entityId: m.entityId },
+            'Non-super-admin attempted to create platform_admin via user creation',
+          );
           throw new ApiError(ApiErrorMessage.FORBIDDEN, {
             statusCode: StatusCodes.FORBIDDEN,
             code: ApiErrorCode.AUTH_FORBIDDEN,

--- a/apps/backend/src/services/user/user.service.ts
+++ b/apps/backend/src/services/user/user.service.ts
@@ -392,7 +392,7 @@ export function UserService({
       // Guard against a current platform admin creating a new platform admin account
       for (const m of memberships) {
         if (isOrgMembership(m) && m.role === UserRole.PLATFORM_ADMIN)
-          throw new ApiError('Platform admin cannot create a new platform admin account', {
+          throw new ApiError('ApiErrorMessage.FORBIDDEN, {
             statusCode: StatusCodes.FORBIDDEN,
             code: ApiErrorCode.AUTH_FORBIDDEN,
             context: { userId },

--- a/apps/backend/src/services/user/user.service.ts
+++ b/apps/backend/src/services/user/user.service.ts
@@ -391,7 +391,7 @@ export function UserService({
     if (!isSuperAdmin) {
       // Guard against a current platform admin creating a new platform admin account
       for (const m of memberships) {
-        if (isOrgMembership(m) && m.role === UserRole.PLATFORM_ADMIN)
+        if (isOrgMembership(m) && m.role === UserRole.PLATFORM_ADMIN) {
           logger.warn(
             { userId, attemptedRole: m.role, entityType: m.entityType, entityId: m.entityId },
             'Non-super-admin attempted to create platform_admin via user creation',
@@ -401,6 +401,7 @@ export function UserService({
             code: ApiErrorCode.AUTH_FORBIDDEN,
             context: { userId },
           });
+        }
       }
 
       // Verify that all membership entities exist before proceeding
@@ -633,7 +634,7 @@ export function UserService({
 
       // Resolve the root org partner ID before opening the write transaction.
       // Read-only — if it throws, no DB writes have happened yet so only Firebase needs compensation.
-      const resolvedPartnerId = await resolveRootOrgProviderFromMemberships(memberships);
+      const resolvedRootOrgProvider = await resolveRootOrgProviderFromMemberships(memberships);
 
       newUserId = await userRepository.runTransaction({
         fn: async (tx) => {
@@ -670,7 +671,7 @@ export function UserService({
             data: {
               providerType: RosteringProvider.DASHBOARD,
               providerId: result.id,
-              partnerId: resolvedPartnerId,
+              partnerId: resolvedRootOrgProvider,
               entityType: RosteringEntityType.USER,
               entityId: result.id,
             },
@@ -859,35 +860,35 @@ export function UserService({
    * @throws {ApiError} UNPROCESSABLE_ENTITY if memberships span more than one distinct district
    */
   async function resolveDistrictProvider(memberships: CreateUserMemberships[]): Promise<string | undefined> {
-    const partnerIds = memberships.map(({ entityId, entityType }) => ({ entityId, entityType }));
+    const membershipRefs = memberships.map(({ entityId, entityType }) => ({ entityId, entityType }));
 
-    const classIds = partnerIds
+    const classRefs = membershipRefs
       .filter(({ entityType }) => entityType === EntityType.CLASS)
       .map(({ entityId }) => entityId);
 
-    const schoolIds = partnerIds
+    const schoolRefs = membershipRefs
       .filter(({ entityType }) => entityType === EntityType.SCHOOL)
       .map(({ entityId }) => entityId);
 
     // Resolve class and school roots in parallel to keep the write window short.
     const [classDistricts, schoolDistricts] = await Promise.all([
-      classIds.length > 0 ? classRepository.getDistinctRootOrgIds(classIds) : Promise.resolve([]),
-      schoolIds.length > 0 ? schoolRepository.getDistinctRootOrgIds(schoolIds) : Promise.resolve([]),
+      classRefs.length > 0 ? classRepository.getDistinctRootOrgIds(classRefs) : Promise.resolve([]),
+      schoolRefs.length > 0 ? schoolRepository.getDistinctRootOrgIds(schoolRefs) : Promise.resolve([]),
     ]);
 
-    if (classIds.length > 0 && classDistricts.length === 0) {
+    if (classRefs.length > 0 && classDistricts.length === 0) {
       throw new ApiError(ApiErrorMessage.NOT_FOUND, {
         statusCode: StatusCodes.NOT_FOUND,
         code: ApiErrorCode.RESOURCE_NOT_FOUND,
-        context: { classIds },
+        context: { classRefs },
       });
     }
 
-    if (schoolIds.length > 0 && schoolDistricts.length === 0) {
+    if (schoolRefs.length > 0 && schoolDistricts.length === 0) {
       throw new ApiError(ApiErrorMessage.NOT_FOUND, {
         statusCode: StatusCodes.NOT_FOUND,
         code: ApiErrorCode.RESOURCE_NOT_FOUND,
-        context: { schoolIds },
+        context: { schoolRefs },
       });
     }
 
@@ -896,7 +897,7 @@ export function UserService({
     // correctly collapses to a single entry rather than being flagged as cross-district.
     const resolvedDistricts = new Set<string>();
 
-    for (const { entityId } of partnerIds.filter(({ entityType }) => entityType === EntityType.DISTRICT)) {
+    for (const { entityId } of membershipRefs.filter(({ entityType }) => entityType === EntityType.DISTRICT)) {
       resolvedDistricts.add(entityId);
     }
     for (const { id } of classDistricts) resolvedDistricts.add(id);

--- a/apps/backend/src/services/user/user.service.ts
+++ b/apps/backend/src/services/user/user.service.ts
@@ -392,7 +392,7 @@ export function UserService({
       // Guard against a current platform admin creating a new platform admin account
       for (const m of memberships) {
         if (isOrgMembership(m) && m.role === UserRole.PLATFORM_ADMIN)
-          throw new ApiError('ApiErrorMessage.FORBIDDEN, {
+          throw new ApiError(ApiErrorMessage.FORBIDDEN, {
             statusCode: StatusCodes.FORBIDDEN,
             code: ApiErrorCode.AUTH_FORBIDDEN,
             context: { userId },
@@ -810,6 +810,51 @@ export function UserService({
    * @throws {ApiError} NOT_FOUND if no provider can be resolved at all
    */
   async function resolveRootOrgProviderFromMemberships(memberships: CreateUserMemberships[]): Promise<string> {
+    // First, try to resolve district evidence (class/school roots + explicit district memberships)
+    const resolvedDistrict = await resolveDistrictProvider(memberships);
+    if (resolvedDistrict) return resolvedDistrict;
+
+    // No district evidence — fall through to group, then family
+    const resolvedGroup = resolveGroupProvider(memberships);
+    if (resolvedGroup) return resolvedGroup;
+
+    const resolvedFamily = resolveFamilyProvider(memberships);
+    if (resolvedFamily) return resolvedFamily;
+
+    throw new ApiError(ApiErrorMessage.NOT_FOUND, {
+      statusCode: StatusCodes.NOT_FOUND,
+      code: ApiErrorCode.RESOURCE_NOT_FOUND,
+      context: { memberships },
+    });
+  }
+
+  /**
+   * Resolve a single district provider ID from the user's memberships.
+   *
+   * Gathers district evidence from all three org sources in parallel, then
+   * validates that they all agree before returning. This catches inconsistencies
+   * such as an explicit district_A combined with a class whose ltree root is
+   * district_B.
+   *
+   * Evidence sources:
+   * - Explicit `district` memberships in the request
+   * - ltree root of any `class` memberships (via `classRepository.getDistinctRootOrgIds`)
+   * - ltree root of any `school` memberships (via `schoolRepository.getDistinctRootOrgIds`)
+   *
+   * Resolution rules:
+   * 1. Resolve class and school ltree roots in parallel.
+   * 2. Deduplicate all district IDs into a single set.
+   * 3. Exactly one distinct district → return it.
+   * 4. More than one distinct district → throw 422.
+   * 5. No district evidence at all → return `undefined` (caller falls through to group/family).
+   *
+   * @param memberships The user's membership information from the request body
+   * @returns The resolved district ID, or `undefined` if no district evidence exists
+   * @throws {ApiError} NOT_FOUND if class memberships are present but have no resolvable root district
+   * @throws {ApiError} NOT_FOUND if school memberships are present but have no resolvable root district
+   * @throws {ApiError} UNPROCESSABLE_ENTITY if memberships span more than one distinct district
+   */
+  async function resolveDistrictProvider(memberships: CreateUserMemberships[]): Promise<string | undefined> {
     const partnerIds = memberships.map(({ entityId, entityType }) => ({ entityId, entityType }));
 
     const classIds = partnerIds
@@ -865,24 +910,35 @@ export function UserService({
       return [...resolvedDistricts][0]!;
     }
 
-    // No district evidence — fall through to group, then family
-    const groupIds = partnerIds
-      .filter(({ entityType }) => entityType === EntityType.GROUP)
-      .map(({ entityId }) => entityId);
+    return undefined;
+  }
 
-    if (groupIds.length > 0) return groupIds[0]!;
+  /**
+   * Resolve the root org provider from group memberships.
+   *
+   * Uses first-wins semantics: when multiple group memberships are present,
+   * the first ID in request order is returned. Groups are flat (non-hierarchical)
+   * so there is no root to validate uniqueness against.
+   *
+   * @param memberships The user's membership information from the request body
+   * @returns The first group ID found, or `undefined` if no group memberships exist
+   */
+  function resolveGroupProvider(memberships: CreateUserMemberships[]): string | undefined {
+    return memberships.find(({ entityType }) => entityType === EntityType.GROUP)?.entityId;
+  }
 
-    const familyIds = partnerIds
-      .filter(({ entityType }) => entityType === EntityType.FAMILY)
-      .map(({ entityId }) => entityId);
-
-    if (familyIds.length > 0) return familyIds[0]!;
-
-    throw new ApiError(ApiErrorMessage.NOT_FOUND, {
-      statusCode: StatusCodes.NOT_FOUND,
-      code: ApiErrorCode.RESOURCE_NOT_FOUND,
-      context: { memberships },
-    });
+  /**
+   * Resolve the root org provider from family memberships.
+   *
+   * Uses first-wins semantics: when multiple family memberships are present,
+   * the first ID in request order is returned. Families are flat (non-hierarchical)
+   * so there is no root to validate uniqueness against.
+   *
+   * @param memberships The user's membership information from the request body
+   * @returns The first family ID found, or `undefined` if no family memberships exist
+   */
+  function resolveFamilyProvider(memberships: CreateUserMemberships[]): string | undefined {
+    return memberships.find(({ entityType }) => entityType === EntityType.FAMILY)?.entityId;
   }
 
   /**

--- a/apps/backend/src/test-support/repositories/class.repository.ts
+++ b/apps/backend/src/test-support/repositories/class.repository.ts
@@ -14,6 +14,7 @@ export function createMockClassRepository(): MockedObject<ClassRepository> {
     getUsersByClassId: vi.fn(),
     listBySchoolId: vi.fn(),
     createClass: vi.fn(),
+    getDistinctRootIds: vi.fn(),
   } as unknown as MockedObject<ClassRepository>;
 }
 

--- a/apps/backend/src/test-support/repositories/class.repository.ts
+++ b/apps/backend/src/test-support/repositories/class.repository.ts
@@ -14,7 +14,6 @@ export function createMockClassRepository(): MockedObject<ClassRepository> {
     getUsersByClassId: vi.fn(),
     listBySchoolId: vi.fn(),
     createClass: vi.fn(),
-    getDistinctRootOrgIds: vi.fn(),
   } as unknown as MockedObject<ClassRepository>;
 }
 

--- a/apps/backend/src/test-support/repositories/class.repository.ts
+++ b/apps/backend/src/test-support/repositories/class.repository.ts
@@ -1,6 +1,6 @@
 import { vi } from 'vitest';
 import type { MockedObject } from 'vitest';
-import { createMockBaseRepositoryMethods } from './base.repository';
+import { createMockLtreeRepository } from './l-tree.repository';
 import type { ClassRepository } from '../../repositories/class.repository';
 
 /**
@@ -10,11 +10,11 @@ import type { ClassRepository } from '../../repositories/class.repository';
  */
 export function createMockClassRepository(): MockedObject<ClassRepository> {
   return {
-    ...createMockBaseRepositoryMethods(),
+    ...createMockLtreeRepository(),
     getUsersByClassId: vi.fn(),
     listBySchoolId: vi.fn(),
     createClass: vi.fn(),
-    getDistinctRootIds: vi.fn(),
+    getDistinctRootOrgIds: vi.fn(),
   } as unknown as MockedObject<ClassRepository>;
 }
 

--- a/apps/backend/src/test-support/repositories/district.repository.ts
+++ b/apps/backend/src/test-support/repositories/district.repository.ts
@@ -1,7 +1,7 @@
 import { vi } from 'vitest';
 import type { MockedObject } from 'vitest';
-import { createMockBaseRepositoryMethods } from './base.repository';
 import type { DistrictRepository } from '../../repositories/district.repository';
+import { createMockLtreeRepository } from './l-tree.repository';
 
 /**
  * Mock District Repository
@@ -10,7 +10,7 @@ import type { DistrictRepository } from '../../repositories/district.repository'
  */
 export function createMockDistrictRepository(): MockedObject<DistrictRepository> {
   return {
-    ...createMockBaseRepositoryMethods(),
+    ...createMockLtreeRepository(),
     listAll: vi.fn(),
     listByIds: vi.fn(),
     getUnrestrictedById: vi.fn(),

--- a/apps/backend/src/test-support/repositories/l-tree.repository.ts
+++ b/apps/backend/src/test-support/repositories/l-tree.repository.ts
@@ -1,0 +1,9 @@
+import { vi } from 'vitest';
+import { createMockBaseRepositoryMethods } from './base.repository';
+
+export function createMockLtreeRepository() {
+  return {
+    ...createMockBaseRepositoryMethods(),
+    getDistinctRootOrgIds: vi.fn(),
+  };
+}

--- a/apps/backend/src/test-support/repositories/roster-provider-id.repository.ts
+++ b/apps/backend/src/test-support/repositories/roster-provider-id.repository.ts
@@ -1,4 +1,4 @@
-import type { MockedObject } from 'vitest';
+import { vi, type MockedObject } from 'vitest';
 import { createMockBaseRepositoryMethods } from './base.repository';
 import type { RosterProviderIdRepository } from '../../repositories/roster-provider-id.repository';
 
@@ -10,7 +10,8 @@ import type { RosterProviderIdRepository } from '../../repositories/roster-provi
 export function createMockRosterProviderIdRepository(): MockedObject<RosterProviderIdRepository> {
   return {
     ...createMockBaseRepositoryMethods(),
-  } as MockedObject<RosterProviderIdRepository>;
+    deleteByEntityId: vi.fn(),
+  } as unknown as MockedObject<RosterProviderIdRepository>;
 }
 
 export type MockRosterProviderIdRepository = ReturnType<typeof createMockRosterProviderIdRepository>;

--- a/apps/backend/src/test-support/repositories/roster-provider-id.repository.ts
+++ b/apps/backend/src/test-support/repositories/roster-provider-id.repository.ts
@@ -1,0 +1,16 @@
+import type { MockedObject } from 'vitest';
+import { createMockBaseRepositoryMethods } from './base.repository';
+import type { RosterProviderIdRepository } from '../../repositories/roster-provider-id.repository';
+
+/**
+ * Mock RosterProviderIdRepository
+ * Returns a mocked version of RosterProviderIdRepository with all methods as vi.fn() mocks.
+ * This allows unit tests to acoid implementation details of the base repository (typedTable, db, etc.).
+ */
+export function createMockRosterProviderIdRepository(): MockedObject<RosterProviderIdRepository> {
+  return {
+    ...createMockBaseRepositoryMethods(),
+  } as MockedObject<RosterProviderIdRepository>;
+}
+
+export type MockRosterProviderIdRepository = ReturnType<typeof createMockRosterProviderIdRepository>;

--- a/apps/backend/src/test-support/repositories/roster-provider-id.repository.ts
+++ b/apps/backend/src/test-support/repositories/roster-provider-id.repository.ts
@@ -5,7 +5,7 @@ import type { RosterProviderIdRepository } from '../../repositories/roster-provi
 /**
  * Mock RosterProviderIdRepository
  * Returns a mocked version of RosterProviderIdRepository with all methods as vi.fn() mocks.
- * This allows unit tests to acoid implementation details of the base repository (typedTable, db, etc.).
+ * This allows unit tests to avoid implementation details of the base repository (typedTable, db, etc.).
  */
 export function createMockRosterProviderIdRepository(): MockedObject<RosterProviderIdRepository> {
   return {

--- a/apps/backend/src/test-support/repositories/school.repository.ts
+++ b/apps/backend/src/test-support/repositories/school.repository.ts
@@ -1,7 +1,7 @@
 import { vi } from 'vitest';
 import type { MockedObject } from 'vitest';
-import { createMockBaseRepositoryMethods } from './base.repository';
 import type { SchoolRepository } from '../../repositories/school.repository';
+import { createMockLtreeRepository } from './l-tree.repository';
 
 /**
  * Mock School Repository
@@ -10,7 +10,7 @@ import type { SchoolRepository } from '../../repositories/school.repository';
  */
 export function createMockSchoolRepository(): MockedObject<SchoolRepository> {
   return {
-    ...createMockBaseRepositoryMethods(),
+    ...createMockLtreeRepository(),
     listAll: vi.fn(),
     listByIds: vi.fn(),
     listAccessibleByDistrictId: vi.fn(),
@@ -18,7 +18,7 @@ export function createMockSchoolRepository(): MockedObject<SchoolRepository> {
     listAllByDistrictId: vi.fn(),
     getUsersBySchoolId: vi.fn(),
     createSchool: vi.fn(),
-    getDistinctRootIds: vi.fn(),
+    getDistinctRootOrgIds: vi.fn(),
     getActiveById: vi.fn(),
   } as unknown as MockedObject<SchoolRepository>;
 }

--- a/apps/backend/src/test-support/repositories/school.repository.ts
+++ b/apps/backend/src/test-support/repositories/school.repository.ts
@@ -18,6 +18,8 @@ export function createMockSchoolRepository(): MockedObject<SchoolRepository> {
     listAllByDistrictId: vi.fn(),
     getUsersBySchoolId: vi.fn(),
     createSchool: vi.fn(),
+    getDistinctRootIds: vi.fn(),
+    getActiveById: vi.fn(),
   } as unknown as MockedObject<SchoolRepository>;
 }
 

--- a/apps/backend/src/test-support/repositories/school.repository.ts
+++ b/apps/backend/src/test-support/repositories/school.repository.ts
@@ -18,7 +18,6 @@ export function createMockSchoolRepository(): MockedObject<SchoolRepository> {
     listAllByDistrictId: vi.fn(),
     getUsersBySchoolId: vi.fn(),
     createSchool: vi.fn(),
-    getDistinctRootOrgIds: vi.fn(),
     getActiveById: vi.fn(),
   } as unknown as MockedObject<SchoolRepository>;
 }


### PR DESCRIPTION
## Proposed changes

<!--
Describe your changes here. Why are they necessary?

If it fixes a bug or resolves a feature request, be sure to link to that issue.

If appropriate, include images of the expected behavior or user experience.
You can drag and drop images into this text box.
-->

## Summary

This pull requests implements logic which writes a `rostering_provider_id` entity whenever a user is created in the `POST /v1/users` method.

User data and membship data in the request body are used to construct the `rostering_provider_id` table data.
The `providerId` field is resolved dynamically. `districts`, `groups` and `families` resolve to their own `uuids`, while `schools` and `classes` use a new method `getDistinctRootIds` in their respective repositories. This method uses l-tree to select the distinct root orgs for the provided list of schools and classes (these entities are not guaranteed to have the same root org amongst themselves).

A new user service method `resolveRootOrgProviderFromMemberships` parses the provided memberships and guarantees that only a single root org provider is resolved: either a `district`, `group`, or `family`. Cases where multiple `districts` would resolve will throw an error. An error is thrown if no root org can be resolved.

A new repository `RosterProviderId` is created to facilitate the table insert. This repository overloads the `create` method in the `BaseRepository` to return its `entityId` field.

This PR also re-types the `Transaction` property in `BaseParams` to use actualy PG database types rather than `any` type.

## Types of changes

What types of changes does this pull request introduce?

<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactoring (non-breaking change that does not add functionality but makes code cleaner or more efficient)
- [ ] Documentation Update
- [x] Tests (new or updated tests)
- [ ] Style (changes to code styling)
- [ ] CI (continuous integration changes)
- [ ] Repository Maintenance
- [ ] Other (please describe below)

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask.  We're here
to help! This is simply a reminder of what we are going to look for before
merging your code.
-->

- [x] I have read the [guidelines for contributing](https://github.com/yeatmanlab/roar-dashboard/blob/main/.github/CONTRIBUTING.md).
- [x] The changes in this PR are as small as they can be. They represent one and only one fix or enhancement.
- [x] Linting checks pass with my changes.
- [x] Any existing unit tests pass with my changes.
- [x] Any existing end-to-end tests pass with my changes.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] If this PR fixes an existing issue, I have added a unit or end-to-end test that will detect if this issue reoccurs.
- [x] I have added JSDoc comments as appropriate.
- [ ] I have added the necessary documentation to the [roar-docs repository](https://github.com/yeatmanlab/roar-docs).
- [x] I have shared this PR on the roar-pr-reviews channel (if I have access)
- [x] I have linked relevant issues (if any)

## Justification of missing checklist items

<!--
If you feel that a checklist item above is not applicable to this PR, please
provide your justification here. Otherwise, delete this section.
-->

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
