### PR TITLE
Add LtreeRepository for ltree-based hierarchy queries

### DIFF
--- a/apps/backend/src/repositories/class.repository.ts
+++ b/apps/backend/src/repositories/class.repository.ts
@@ -5,14 +5,14 @@ import { and, asc, count, desc, eq, isNull, sql } from 'drizzle-orm';
 import type { NodePgDatabase } from 'drizzle-orm/node-postgres';
 import { CoreDbClient } from '../db/clients';
 import type { Class } from '../db/schema';
-import { classes, userClasses, users } from '../db/schema';
+import { classes, orgs, userClasses, users } from '../db/schema';
 import type * as CoreDbSchema from '../db/schema/core';
 import type { ClassType } from '../enums/class-type.enum';
 import type { Grade } from '../enums/grade.enum';
 import type { ParsedFilter } from '../types/filter';
 import type { EnrolledUserEntity, EnrolledUsersSortFieldType, ListEnrolledUsersOptions } from '../types/user';
 import type { PaginatedResult } from './base.repository';
-import { BaseRepository } from './base.repository';
+import { LtreeRepository } from './ltree.repository';
 import {
   ENROLLED_USERS_SORT_COLUMNS,
   getEnrolledUsersFilterConditions,
@@ -51,9 +51,9 @@ export interface CreateClassInput {
   location?: string | undefined;
 }
 
-export class ClassRepository extends BaseRepository<Class, typeof classes> {
+export class ClassRepository extends LtreeRepository<Class, typeof classes> {
   constructor(db: NodePgDatabase<typeof CoreDbSchema> = CoreDbClient) {
-    super(db, classes);
+    super(db, classes, classes.orgPath, orgs, orgs.path);
   }
 
   /**

--- a/apps/backend/src/repositories/district.repository.ts
+++ b/apps/backend/src/repositories/district.repository.ts
@@ -11,7 +11,7 @@ import { OrgType } from '../enums/org-type.enum';
 import type { UserRole } from '../enums/user-role.enum';
 import type { EnrolledUserEntity, EnrolledUsersSortFieldType, ListEnrolledUsersOptions } from '../types/user';
 import type { PaginatedResult } from './base.repository';
-import { BaseRepository } from './base.repository';
+import { LtreeRepository } from './ltree.repository';
 import {
   ENROLLED_USERS_SORT_COLUMNS,
   getEnrolledUsersFilterConditions,
@@ -87,9 +87,9 @@ export interface ListDistrictOptions {
  *
  * Handles data access for districts (orgs with orgType = 'district').
  */
-export class DistrictRepository extends BaseRepository<District, typeof orgs> {
+export class DistrictRepository extends LtreeRepository<District, typeof orgs> {
   constructor(db: NodePgDatabase<typeof CoreDbSchema> = CoreDbClient) {
-    super(db, orgs);
+    super(db, orgs, orgs.path);
   }
 
   /**

--- a/apps/backend/src/repositories/ltree.repository.integration.test.ts
+++ b/apps/backend/src/repositories/ltree.repository.integration.test.ts
@@ -1,0 +1,181 @@
+/**
+ * Integration tests for LtreeRepository.
+ *
+ * Exercises `getDistinctRootOrgIds()` through all three concrete subclasses
+ * (DistrictRepository, SchoolRepository, ClassRepository) against the real
+ * `app.orgs` and `app.classes` tables. The base fixture provides two
+ * district branches plus their schools and classes — enough to verify both
+ * single-input and mixed-input behavior across hierarchies.
+ *
+ * Coverage includes:
+ * - Districts (self-rooted in orgs) — input id equals output id
+ * - Schools (orgs-rooted in orgs) — returns the parent district id
+ * - Classes (classes-rooted in orgs) — returns the root district id
+ * - Mixed inputs spanning multiple branches → distinct roots, no duplicates
+ * - Duplicate inputs → returns each root once
+ * - Empty input array → short-circuits to `[]` without hitting the DB
+ * - Nonexistent ids → silently dropped, no error thrown
+ */
+import { describe, it, expect, beforeAll } from 'vitest';
+import type { NodePgDatabase } from 'drizzle-orm/node-postgres';
+import type * as CoreDbSchema from '../db/schema/core';
+import { baseFixture } from '../test-support/fixtures';
+import { OrgFactory } from '../test-support/factories/org.factory';
+import { ClassFactory } from '../test-support/factories/class.factory';
+import { OrgType } from '../enums/org-type.enum';
+import { DistrictRepository } from './district.repository';
+import { SchoolRepository } from './school.repository';
+import { ClassRepository } from './class.repository';
+
+describe('LtreeRepository', () => {
+  let districtRepository: DistrictRepository;
+  let schoolRepository: SchoolRepository;
+  let classRepository: ClassRepository;
+
+  beforeAll(() => {
+    districtRepository = new DistrictRepository();
+    schoolRepository = new SchoolRepository();
+    classRepository = new ClassRepository();
+  });
+
+  describe('getDistinctRootOrgIds (DistrictRepository — self-rooted)', () => {
+    it('returns the same id for a single district (the root is itself)', async () => {
+      const result = await districtRepository.getDistinctRootOrgIds([baseFixture.district.id]);
+
+      expect(result).toHaveLength(1);
+      expect(result[0]!.id).toBe(baseFixture.district.id);
+    });
+
+    it('returns distinct roots when multiple districts are passed', async () => {
+      const result = await districtRepository.getDistinctRootOrgIds([
+        baseFixture.district.id,
+        baseFixture.districtB.id,
+      ]);
+
+      const ids = result.map((row) => row.id).sort();
+      expect(ids).toEqual([baseFixture.district.id, baseFixture.districtB.id].sort());
+    });
+
+    it('deduplicates duplicate input ids', async () => {
+      const result = await districtRepository.getDistinctRootOrgIds([
+        baseFixture.district.id,
+        baseFixture.district.id,
+        baseFixture.district.id,
+      ]);
+
+      expect(result).toHaveLength(1);
+      expect(result[0]!.id).toBe(baseFixture.district.id);
+    });
+
+    it('returns an empty array for nonexistent ids', async () => {
+      const result = await districtRepository.getDistinctRootOrgIds(['00000000-0000-0000-0000-000000000000']);
+
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('getDistinctRootOrgIds (SchoolRepository — orgs-rooted in orgs)', () => {
+    it('returns the parent district id for a single school', async () => {
+      const result = await schoolRepository.getDistinctRootOrgIds([baseFixture.schoolA.id]);
+
+      expect(result).toHaveLength(1);
+      expect(result[0]!.id).toBe(baseFixture.district.id);
+    });
+
+    it('returns the same district once when multiple schools share it', async () => {
+      const result = await schoolRepository.getDistinctRootOrgIds([baseFixture.schoolA.id, baseFixture.schoolB.id]);
+
+      expect(result).toHaveLength(1);
+      expect(result[0]!.id).toBe(baseFixture.district.id);
+    });
+
+    it('returns multiple districts when schools span branches', async () => {
+      const result = await schoolRepository.getDistinctRootOrgIds([
+        baseFixture.schoolA.id,
+        baseFixture.schoolInDistrictB.id,
+      ]);
+
+      const ids = result.map((row) => row.id).sort();
+      expect(ids).toEqual([baseFixture.district.id, baseFixture.districtB.id].sort());
+    });
+
+    it('handles a deeper hierarchy where the root is not a direct parent', async () => {
+      // Build a department under School A so the input row is two hops below the district.
+      const department = await OrgFactory.create({
+        name: 'Test Department',
+        orgType: OrgType.DEPARTMENT,
+        parentOrgId: baseFixture.schoolA.id,
+      });
+
+      const result = await schoolRepository.getDistinctRootOrgIds([department.id]);
+
+      expect(result).toHaveLength(1);
+      expect(result[0]!.id).toBe(baseFixture.district.id);
+    });
+  });
+
+  describe('getDistinctRootOrgIds (ClassRepository — classes-rooted in orgs)', () => {
+    it('returns the root district id for a single class', async () => {
+      const result = await classRepository.getDistinctRootOrgIds([baseFixture.classInSchoolA.id]);
+
+      expect(result).toHaveLength(1);
+      expect(result[0]!.id).toBe(baseFixture.district.id);
+    });
+
+    it('deduplicates classes that share a root', async () => {
+      const result = await classRepository.getDistinctRootOrgIds([
+        baseFixture.classInSchoolA.id,
+        baseFixture.classInSchoolB.id,
+      ]);
+
+      expect(result).toHaveLength(1);
+      expect(result[0]!.id).toBe(baseFixture.district.id);
+    });
+
+    it('returns multiple roots when classes span districts', async () => {
+      const result = await classRepository.getDistinctRootOrgIds([
+        baseFixture.classInSchoolA.id,
+        baseFixture.classInDistrictB.id,
+      ]);
+
+      const ids = result.map((row) => row.id).sort();
+      expect(ids).toEqual([baseFixture.district.id, baseFixture.districtB.id].sort());
+    });
+
+    it('still resolves to the root after additional rows are added', async () => {
+      // A new class under schoolB should still resolve to the District A root.
+      const newClass = await ClassFactory.create({
+        name: 'Late-Created Class',
+        schoolId: baseFixture.schoolB.id,
+        districtId: baseFixture.district.id,
+      });
+
+      const result = await classRepository.getDistinctRootOrgIds([newClass.id]);
+
+      expect(result).toHaveLength(1);
+      expect(result[0]!.id).toBe(baseFixture.district.id);
+    });
+  });
+
+  describe('getDistinctRootOrgIds (empty-input short-circuit)', () => {
+    it('returns [] for an empty input array without hitting the database', async () => {
+      // Inject a db client that throws on every call. If the method short-circuits
+      // before invoking Drizzle, no method is called and the assertion passes.
+      // If the implementation regresses and tries to query, the throwing handler
+      // surfaces the bug clearly.
+      const throwingDb = new Proxy(
+        {},
+        {
+          get(_target, prop: string) {
+            throw new Error(`Unexpected db access during empty-input short-circuit: ${String(prop)}`);
+          },
+        },
+      ) as unknown as NodePgDatabase<typeof CoreDbSchema>;
+
+      const repo = new DistrictRepository(throwingDb);
+      const result = await repo.getDistinctRootOrgIds([]);
+
+      expect(result).toEqual([]);
+    });
+  });
+});

--- a/apps/backend/src/repositories/ltree.repository.integration.test.ts
+++ b/apps/backend/src/repositories/ltree.repository.integration.test.ts
@@ -98,16 +98,23 @@ describe('LtreeRepository', () => {
       const ids = result.map((row) => row.id).sort();
       expect(ids).toEqual([baseFixture.district.id, baseFixture.districtB.id].sort());
     });
+  });
 
-    it('handles a deeper hierarchy where the root is not a direct parent', async () => {
-      // Build a department under School A so the input row is two hops below the district.
+  describe('getDistinctRootOrgIds (orgs-rooted multi-hop)', () => {
+    // Orgs-rooted hierarchies (districts and schools both drive the orgs table)
+    // share the same ltree traversal. Validate behavior more than two labels
+    // deep — covers cases where the root isn't a direct parent.
+    it('resolves a department two hops below the district to the district root', async () => {
       const department = await OrgFactory.create({
         name: 'Test Department',
         orgType: OrgType.DEPARTMENT,
         parentOrgId: baseFixture.schoolA.id,
       });
 
-      const result = await schoolRepository.getDistinctRootOrgIds([department.id]);
+      // Either DistrictRepository or SchoolRepository works here — both drive
+      // `orgs` and use the same ltree path. Use DistrictRepository since
+      // "find the root district" is the canonical framing.
+      const result = await districtRepository.getDistinctRootOrgIds([department.id]);
 
       expect(result).toHaveLength(1);
       expect(result[0]!.id).toBe(baseFixture.district.id);

--- a/apps/backend/src/repositories/ltree.repository.ts
+++ b/apps/backend/src/repositories/ltree.repository.ts
@@ -1,0 +1,201 @@
+import type { AnyColumn } from 'drizzle-orm';
+import { eq, inArray, sql } from 'drizzle-orm';
+import type { NodePgDatabase } from 'drizzle-orm/node-postgres';
+import type { PgTable } from 'drizzle-orm/pg-core';
+import { alias } from 'drizzle-orm/pg-core';
+import { BaseRepository } from './base.repository';
+
+/**
+ * Abstract repository for tables that store hierarchical data using PostgreSQL ltree.
+ *
+ * Extends `BaseRepository` with operations that need a materialized path column
+ * (`ltree`). Repositories that do not store a path (`UserRepository`,
+ * `RunRepository`, etc.) should continue to extend `BaseRepository` directly —
+ * `LtreeRepository` is opt-in for repositories whose driving table participates
+ * in an ltree hierarchy.
+ *
+ * Subclasses configure two things via the constructor:
+ *
+ * 1. **`pathColumn`** — the ltree column on the driving table. The column name
+ *    differs across the codebase (`orgs.path`, `classes.orgPath`), so the
+ *    column reference is passed explicitly rather than inferred via a
+ *    structural type constraint.
+ * 2. **`ancestorTable`** (optional) — the table where root rows live. Defaults
+ *    to the driving table itself, which is the right choice when nodes and
+ *    their roots share a table (e.g., `orgs` rooted in `orgs`). Pass a
+ *    different table when ancestors live elsewhere — for example, classes
+ *    are rooted in `orgs`, so `ClassRepository` passes `(classes, classes.orgPath, orgs, orgs.path)`.
+ *
+ * Method naming follows the existing repository convention:
+ * `getDistinctRootOrgIds` is intentionally specific — in this codebase the top
+ * of every ltree path is an org row (district, state, national, etc.), so the
+ * return type is always `{ id: string }[]` against `app.orgs`.
+ *
+ * @typeParam TEntity - The select type of the driving entity (from `$inferSelect`).
+ * @typeParam TTable - The Drizzle PgTable reference for the driving entity.
+ *
+ * @example
+ * ```typescript
+ * // Districts and schools — driving rows live in orgs, ancestors live in orgs.
+ * export class DistrictRepository extends LtreeRepository<District, typeof orgs> {
+ *   constructor(db: NodePgDatabase<typeof CoreDbSchema> = CoreDbClient) {
+ *     super(db, orgs, orgs.path);
+ *   }
+ * }
+ *
+ * // Classes — driving rows live in classes, ancestors live in orgs.
+ * export class ClassRepository extends LtreeRepository<Class, typeof classes> {
+ *   constructor(db: NodePgDatabase<typeof CoreDbSchema> = CoreDbClient) {
+ *     super(db, classes, classes.orgPath, orgs, orgs.path);
+ *   }
+ * }
+ * ```
+ */
+export abstract class LtreeRepository<
+  TEntity extends Record<string, unknown>,
+  TTable extends PgTable,
+> extends BaseRepository<TEntity, TTable> {
+  /**
+   * The ltree column on the driving table (`this.table`).
+   */
+  protected readonly pathColumn: AnyColumn;
+
+  /**
+   * The table where root rows are resolved. Defaults to `this.table` when
+   * roots and descendants share a table (e.g., `orgs` rooted in `orgs`).
+   */
+  protected readonly ancestorTable: PgTable;
+
+  /**
+   * The id column of `ancestorTable`. Resolved from the table reference so
+   * subclasses don't need to pass it explicitly.
+   */
+  protected readonly ancestorIdColumn: AnyColumn;
+
+  /**
+   * The ltree column on `ancestorTable` used as the join target.
+   */
+  protected readonly ancestorPathColumn: AnyColumn;
+
+  /**
+   * @param db - Drizzle database client.
+   * @param table - The Drizzle table reference for this repository.
+   * @param pathColumn - The ltree column on `table`.
+   * @param ancestorTable - Optional separate table where root rows live.
+   *                       Defaults to `table` for self-rooted hierarchies.
+   * @param ancestorPathColumn - Optional ltree column on `ancestorTable`.
+   *                             Defaults to `pathColumn` when `ancestorTable`
+   *                             is the same as `table`. Required when
+   *                             `ancestorTable` differs from `table`.
+   */
+  constructor(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    db: NodePgDatabase<any>,
+    table: TTable,
+    pathColumn: AnyColumn,
+    ancestorTable?: PgTable,
+    ancestorPathColumn?: AnyColumn,
+  ) {
+    super(db, table);
+    this.pathColumn = pathColumn;
+    this.ancestorTable = ancestorTable ?? table;
+
+    // Mirror BaseRepository's runtime column-access pattern. `id` is required
+    // on every table per the codebase convention; `ancestorPathColumn` falls
+    // back to the driving path column only when the ancestor and driving
+    // tables are the same.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const ancestorTyped = this.ancestorTable as PgTable & Record<string, any>;
+    this.ancestorIdColumn = ancestorTyped['id'] as AnyColumn;
+    this.ancestorPathColumn = ancestorPathColumn ?? pathColumn;
+  }
+
+  /**
+   * Returns the distinct set of root org ids covering a list of node ids.
+   *
+   * For each input id, the node's "root" is the row in `ancestorTable` whose
+   * path is the first label of the node's path — i.e., `subpath(path, 0, 1)`
+   * extracts the top-level label, and the join resolves it back to a real
+   * row.
+   *
+   * The variation across subclasses is just two table references — the driving
+   * table (rows being looked up) and the ancestor table (where the roots
+   * live). For districts and schools, both are `orgs`. For classes, the
+   * driving table is `classes` and the ancestor table is `orgs` because a
+   * class's `org_path` is composed of org labels.
+   *
+   * Notes:
+   * - Roots are returned without the input→root mapping. If you need to know
+   *   which input maps to which root, add a non-distinct variant — this
+   *   abstraction does not provide one.
+   * - Orphan paths — root labels that have no matching row in `ancestorTable`
+   *   — are silently dropped by the inner join. This shouldn't occur in
+   *   practice (the path-computation triggers maintain referential integrity),
+   *   but if you need orphans surfaced, write a custom query that uses a
+   *   left join instead.
+   * - An empty `ids` array short-circuits to `[]` without round-tripping to
+   *   the database.
+   * - Duplicate input ids do not produce duplicate roots — `selectDistinct`
+   *   guarantees each root appears at most once.
+   * - The roots returned are always rows from `ancestorTable`. In this
+   *   codebase that is always `orgs`, so callers should treat the returned
+   *   ids as `orgs.id` values, regardless of whether the top-level org is a
+   *   district, state, national, or local.
+   *
+   * @param ids - The ids of the nodes whose roots should be resolved.
+   * @returns The distinct set of root rows, each with an `id` field.
+   */
+  async getDistinctRootOrgIds(ids: string[]): Promise<{ id: string }[]> {
+    // Short-circuit: `inArray` with an empty array generates `false` and
+    // would round-trip to the database for a guaranteed-empty result.
+    if (ids.length === 0) return [];
+
+    // Self-join alias: when `ancestorTable === this.table` (e.g., orgs joined
+    // to orgs), the root and node references would collapse to the same
+    // table identifier. The alias gives the join target a distinct name so
+    // the ON clause is unambiguous.
+    const root = alias(this.ancestorTable, 'root');
+
+    // Drizzle's strict generics can't resolve dynamically-named columns
+    // through a generic `TTable` parameter; mirror `BaseRepository`'s
+    // dynamic-access pattern by reading column references off a typed
+    // intersection view of the table. The casts are scoped to query
+    // construction and do not leak into the public surface.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const drivingTable = this.table as PgTable & Record<string, any>;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const rootTable = root as PgTable & Record<string, any>;
+    const idColumn = drivingTable['id'] as Parameters<typeof eq>[0];
+    const rootIdColumn = rootTable['id'] as AnyColumn;
+    const rootPathColumn = rootTable[this.ancestorPathColumnName()] as AnyColumn;
+
+    // `subpath(path, 0, 1)` extracts the first label of the ltree — that is,
+    // the root label of the node's tree. We then look up the ancestor row
+    // whose own path equals that single-label ltree, which is the root row.
+    const result = await this.db
+      .selectDistinct({ id: sql<string>`${rootIdColumn}` })
+      .from(drivingTable)
+      .innerJoin(rootTable, sql`${rootPathColumn} = subpath(${this.pathColumn}, 0, 1)`)
+      .where(inArray(idColumn, ids));
+
+    return result;
+  }
+
+  /**
+   * Returns the JS property name for the ancestor path column.
+   *
+   * Drizzle's `alias()` returns a proxy whose columns are accessible by the
+   * same property keys as the original table. For the ltree columns in this
+   * codebase, the underlying SQL column name and the JS property name
+   * happen to align (`orgs.path` is property `path` mapped to SQL `path`).
+   * If a future ancestor table has a column where these differ (e.g.,
+   * `classes.orgPath` is property `orgPath` mapped to SQL `org_path`),
+   * subclasses must pass the correct property name explicitly via a
+   * different mechanism rather than relying on the SQL name.
+   */
+  private ancestorPathColumnName(): string {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const column = this.ancestorPathColumn as any;
+    return column.name as string;
+  }
+}

--- a/apps/backend/src/repositories/ltree.repository.ts
+++ b/apps/backend/src/repositories/ltree.repository.ts
@@ -1,5 +1,5 @@
 import type { AnyColumn } from 'drizzle-orm';
-import { eq, inArray, sql } from 'drizzle-orm';
+import { inArray, sql } from 'drizzle-orm';
 import type { NodePgDatabase } from 'drizzle-orm/node-postgres';
 import type { PgTable } from 'drizzle-orm/pg-core';
 import { alias } from 'drizzle-orm/pg-core';
@@ -67,15 +67,18 @@ export abstract class LtreeRepository<
   protected readonly ancestorTable: PgTable;
 
   /**
-   * The id column of `ancestorTable`. Resolved from the table reference so
-   * subclasses don't need to pass it explicitly.
-   */
-  protected readonly ancestorIdColumn: AnyColumn;
-
-  /**
    * The ltree column on `ancestorTable` used as the join target.
    */
   protected readonly ancestorPathColumn: AnyColumn;
+
+  /**
+   * The JS property key on `ancestorTable` (and on its `alias()` proxy) that
+   * resolves to `ancestorPathColumn`. Pre-computed at construction time so
+   * the alias lookup at query time uses the correct key — `alias()` exposes
+   * columns by JS property name (`orgPath`), not by SQL column name
+   * (`org_path`), and conflating the two is a silent runtime bug.
+   */
+  protected readonly ancestorPathColumnKey: string;
 
   /**
    * @param db - Drizzle database client.
@@ -99,15 +102,32 @@ export abstract class LtreeRepository<
     super(db, table);
     this.pathColumn = pathColumn;
     this.ancestorTable = ancestorTable ?? table;
-
-    // Mirror BaseRepository's runtime column-access pattern. `id` is required
-    // on every table per the codebase convention; `ancestorPathColumn` falls
-    // back to the driving path column only when the ancestor and driving
-    // tables are the same.
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const ancestorTyped = this.ancestorTable as PgTable & Record<string, any>;
-    this.ancestorIdColumn = ancestorTyped['id'] as AnyColumn;
     this.ancestorPathColumn = ancestorPathColumn ?? pathColumn;
+
+    // Resolve the JS property key for the ancestor path column up front so
+    // the alias lookup at query time can't silently miss when the SQL name
+    // and JS property name differ (e.g., orgPath ↔ org_path). Throwing here
+    // surfaces a misconfigured subclass at startup rather than at first use.
+    this.ancestorPathColumnKey = LtreeRepository.findColumnKey(this.ancestorTable, this.ancestorPathColumn);
+  }
+
+  /**
+   * Find the JS property key on `table` whose value is the given `column`
+   * reference. Used to resolve the alias-side property name for columns
+   * whose SQL name differs from their JS key (e.g., `orgPath` → `org_path`).
+   *
+   * @throws If `column` is not a property of `table`.
+   */
+  private static findColumnKey(table: PgTable, column: AnyColumn): string {
+    const tableRecord = table as unknown as Record<string, unknown>;
+    const entry = Object.entries(tableRecord).find(([, value]) => value === column);
+    if (!entry) {
+      throw new Error(
+        'LtreeRepository: ancestorPathColumn is not a property of ancestorTable. ' +
+          'Pass a column reference owned by the ancestor table (e.g., `orgs.path`).',
+      );
+    }
+    return entry[0];
   }
 
   /**
@@ -165,9 +185,9 @@ export abstract class LtreeRepository<
     const drivingTable = this.table as PgTable & Record<string, any>;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const rootTable = root as PgTable & Record<string, any>;
-    const idColumn = drivingTable['id'] as Parameters<typeof eq>[0];
+    const idColumn = drivingTable['id'] as Parameters<typeof inArray>[0];
     const rootIdColumn = rootTable['id'] as AnyColumn;
-    const rootPathColumn = rootTable[this.ancestorPathColumnName()] as AnyColumn;
+    const rootPathColumn = rootTable[this.ancestorPathColumnKey] as AnyColumn;
 
     // `subpath(path, 0, 1)` extracts the first label of the ltree — that is,
     // the root label of the node's tree. We then look up the ancestor row
@@ -179,23 +199,5 @@ export abstract class LtreeRepository<
       .where(inArray(idColumn, ids));
 
     return result;
-  }
-
-  /**
-   * Returns the JS property name for the ancestor path column.
-   *
-   * Drizzle's `alias()` returns a proxy whose columns are accessible by the
-   * same property keys as the original table. For the ltree columns in this
-   * codebase, the underlying SQL column name and the JS property name
-   * happen to align (`orgs.path` is property `path` mapped to SQL `path`).
-   * If a future ancestor table has a column where these differ (e.g.,
-   * `classes.orgPath` is property `orgPath` mapped to SQL `org_path`),
-   * subclasses must pass the correct property name explicitly via a
-   * different mechanism rather than relying on the SQL name.
-   */
-  private ancestorPathColumnName(): string {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const column = this.ancestorPathColumn as any;
-    return column.name as string;
   }
 }

--- a/apps/backend/src/repositories/school.repository.ts
+++ b/apps/backend/src/repositories/school.repository.ts
@@ -2,7 +2,7 @@ import { eq, countDistinct, and, isNull, sql, inArray, asc, desc } from 'drizzle
 import type { SQL } from 'drizzle-orm';
 import type { NodePgDatabase } from 'drizzle-orm/node-postgres';
 import type { PaginatedResult } from './base.repository';
-import { BaseRepository } from './base.repository';
+import { LtreeRepository } from './ltree.repository';
 import type { Org } from '../db/schema';
 import { orgs, userOrgs, classes, userClasses, users } from '../db/schema';
 import { CoreDbClient } from '../db/clients';
@@ -88,9 +88,9 @@ export interface ListAuthorizedOptions {
  * Provides both unrestricted access (for super admins) and FGA-filtered access
  * (for regular users based on their FGA object membership).
  */
-export class SchoolRepository extends BaseRepository<School, typeof orgs> {
+export class SchoolRepository extends LtreeRepository<School, typeof orgs> {
   constructor(db: NodePgDatabase<typeof CoreDbSchema> = CoreDbClient) {
-    super(db, orgs);
+    super(db, orgs, orgs.path);
   }
 
   /**


### PR DESCRIPTION
## Summary

This PR adds an `LtreeRepository<TEntity, TTable>` abstract class that extends `BaseRepository` with operations for tables whose rows participate in a PostgreSQL `ltree` hierarchy. The first method is `getDistinctRootOrgIds(ids)` — for a list of node ids, return the unique set of root org ids covering those nodes.

`DistrictRepository`, `SchoolRepository`, and `ClassRepository` are migrated to extend `LtreeRepository` instead of `BaseRepository`. All other repositories (users, runs, agreements, tasks, etc.) continue to extend `BaseRepository` directly — the new class is opt-in for repositories whose driving table has an ltree column.

This is **scaffolding for a follow-up PR**: there is no consumer of `getDistinctRootOrgIds` in this PR. The expected first consumer is in input validation for `POST /users`, which needs to resolve a set of membership district, school, and class IDs back to their roots orgs. Landing the abstraction now keeps that follow-up PR focused on access-control logic.

## Why an opt-in subclass instead of a method on BaseRepository

`BaseRepository` is the universal base. Many repositories (`UserRepository`, `RunRepository`, `AgreementRepository`, etc.) drive tables that have no path column. Adding `getDistinctRootOrgIds` to `BaseRepository` would either force a structural constraint that those tables can't satisfy, or push column existence checks to runtime. Putting the method on a separate `LtreeRepository extends BaseRepository` keeps the universal base honest: only repositories whose driving table actually has an ltree column get the method.

## Why "RootOrgIds" not "RootIds"

In this codebase, the top of every ltree path is always a row in `app.orgs`. Districts root in orgs (themselves). Schools root in orgs (their district or higher). Classes root in orgs (the district above their school). The method name reflects that invariant. Callers get back `orgs.id` values, not generic "root row" ids that could mean anything.

This matters because the path label format encodes the org type: a national-level rostering root has a path like `national_<uuid>`, a district-level root has `district_<uuid>`. The method does not promise that the returned roots are districts. They are whichever org sits at the rostering top of each input's path. Today that's almost always a district; the schema permits other types in the future.

## How the SQL works

For each input id, the node's "root" is the row in `ancestorTable` whose path equals the first label of the node's path. PostgreSQL's `subpath(ltree, 0, 1)` extracts that first label. The query is a self-join (or a cross-table join, for classes) on path equality, with `selectDistinct` to deduplicate roots across multiple inputs.

```sql
SELECT DISTINCT root.id
FROM <table>
INNER JOIN orgs root ON root.path = subpath(<table>.<pathColumn>, 0, 1)
WHERE <table>.id = ANY($1);
```

The Drizzle implementation uses `alias()` to give the join target a distinct table identifier. Without it, a self-join on `orgs` would collapse both references to the same alias and the ON clause would be ambiguous.

GiST indexes on `orgs.path` and `classes.org_path` already exist (`orgs_path_gist_idx`, `classes_org_path_gist_idx`), so the underlying scans are well-supported.

## Edge cases

- **Empty `ids`**: short-circuits to `[]` without round-tripping. `inArray([])` would otherwise generate `false` and run a guaranteed-empty query.
- **Duplicate input ids**: `selectDistinct` returns each root once.
- **Nonexistent input ids**: silently dropped by the `inArray` filter; no error.
- **Orphan paths** (root label not present in `ancestorTable`): silently dropped by the inner join. This shouldn't occur in practice (the `trg_orgs_compute_path_insert` and `trg_classes_compute_org_path_insert` triggers maintain referential integrity), but the JSDoc documents it explicitly so a future contributor doesn't have to reverse-engineer the join semantics.

## Usage examples

### District-rooted lookup (district → itself)

```typescript
const districts = new DistrictRepository();

// A single district resolves to itself — its path is a single label.
const result = await districts.getDistinctRootOrgIds([baseFixture.district.id]);
// → [{ id: baseFixture.district.id }]
```

### School-rooted lookup (school → parent district)

```typescript
const schools = new SchoolRepository();

// Schools across a single district collapse to one root.
const result = await schools.getDistinctRootOrgIds([
  baseFixture.schoolA.id,
  baseFixture.schoolB.id,
]);
// → [{ id: baseFixture.district.id }]
```

### Class-rooted lookup (class → root district via orgs join)

```typescript
const classes = new ClassRepository();

// Classes spanning two districts return two distinct roots.
const result = await classes.getDistinctRootOrgIds([
  baseFixture.classInSchoolA.id,
  baseFixture.classInDistrictB.id,
]);
// → [{ id: baseFixture.district.id }, { id: baseFixture.districtB.id }]
```

## What this PR does NOT add

- **`getRootIdsForIds(ids)`**: the input→root mapping variant (preserves which input maps to which root, instead of returning the distinct set). YAGNI; add when there's a concrete consumer.
- **Type-filtered roots**: e.g., "give me the root, but only if it's a district." Adds a `where` predicate hook that's speculative without a use case.
- **A `getRoots()` no-input variant**: "all roots in the table" is well-served by `WHERE parent_org_id IS NULL` for orgs; not worth a generic.

## Files changed

- **New:** `apps/backend/src/repositories/ltree.repository.ts` — abstract class with `getDistinctRootOrgIds`.
- **New:** `apps/backend/src/repositories/ltree.repository.integration.test.ts` — integration tests across all three subclasses.
- **Modified:** `apps/backend/src/repositories/district.repository.ts` — extends `LtreeRepository` instead of `BaseRepository`; constructor passes `orgs.path`.
- **Modified:** `apps/backend/src/repositories/school.repository.ts` — same migration as `DistrictRepository`.
- **Modified:** `apps/backend/src/repositories/class.repository.ts` — extends `LtreeRepository`; constructor passes `classes.orgPath, orgs, orgs.path` so roots resolve in the orgs table.

No other files change. Public API of the three subclasses is unaffected — `LtreeRepository` adds a method, doesn't remove or alter anything from `BaseRepository`.

## Tests

`ltree.repository.integration.test.ts` covers, against the real database with `baseFixture`:

**District (self-rooted)**

- Single district → returns itself.
- Multiple districts spanning branches → distinct roots.
- Duplicate input ids → returns each root once.
- Nonexistent ids → empty result, no error.

**School (orgs-rooted in orgs)**

- Single school → parent district id.
- Multiple schools sharing a district → one root.
- Schools across branches (District A and District B) → two distinct roots.
- Deeper hierarchy: a department under School A → still resolves to the District A root (verifies the path is more than two labels deep).

**Class (classes-rooted in orgs)**

- Single class → root district id.
- Multiple classes sharing a root → one root.
- Classes spanning two districts → two distinct roots.
- Newly-created class under an existing school → resolves correctly (verifies the path-computation triggers play well with the join).

**Empty-input short-circuit**

- Injects a `Proxy`-based db client that throws on every property access. Calling `getDistinctRootOrgIds([])` must return `[]` without ever touching the db. Regressions that remove the short-circuit will throw a clear error instead of silently round-tripping.

No unit tests for `LtreeRepository` itself — the SQL semantics (`subpath`, `@>`, GiST behavior) need a real database to validate, and the abstract class has no logic worth mocking out from.

## Types of changes

What types of changes does this pull request introduce?

<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (non-breaking change that does not add functionality but makes code cleaner or more efficient)
- [ ] Documentation Update
- [x] Tests (new or updated tests)
- [ ] Style (changes to code styling)
- [ ] CI (continuous integration changes)
- [ ] Repository Maintenance
- [ ] Other (please describe below)

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask.  We're here
to help! This is simply a reminder of what we are going to look for before
merging your code.
-->

- [x] I have read the [guidelines for contributing](https://github.com/yeatmanlab/roar-dashboard/blob/main/.github/CONTRIBUTING.md).
- [x] The changes in this PR are as small as they can be. They represent one and only one fix or enhancement.
- [x] Linting checks pass with my changes.
- [x] Any existing unit tests pass with my changes.
- [x] Any existing end-to-end tests pass with my changes.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] If this PR fixes an existing issue, I have added a unit or end-to-end test that will detect if this issue reoccurs.
- [x] I have added JSDoc comments as appropriate.
- [ ] I have added the necessary documentation to the [roar-docs repository](https://github.com/yeatmanlab/roar-docs).
- [x] I have shared this PR on the roar-pr-reviews channel (if I have access)
- [x] I have linked relevant issues (if any)