### PR TITLE
Add `GET /administrations/:administrationId/reports/scores/facets` 

### DIFF
--- a/apps/backend/src/controllers/administrations.controller.test.ts
+++ b/apps/backend/src/controllers/administrations.controller.test.ts
@@ -84,6 +84,7 @@ describe('AdministrationsController', () => {
       listProgressStudents: mockListProgressStudents,
       getProgressOverview: mockGetProgressOverview,
       getScoreOverview: mockGetScoreOverview,
+      getScoreFacets: vi.fn(),
       listStudentScores: mockListStudentScores,
       getIndividualStudentReport: mockGetIndividualStudentReport,
       getGuardianStudentReport: vi.fn(),

--- a/apps/backend/src/controllers/administrations.controller.ts
+++ b/apps/backend/src/controllers/administrations.controller.ts
@@ -17,6 +17,7 @@ import type {
   ProgressStudentsQuery,
   ReportTaskMetadata,
   ScoreOverviewQuery,
+  ScoreFacetsQuery,
   StudentScoresQuery,
   StudentScoreRow,
   UpdateAdministrationRequest,
@@ -458,6 +459,42 @@ export const AdministrationsController = {
   getScoreOverview: async (authContext: AuthContext, administrationId: string, query: ScoreOverviewQuery) => {
     try {
       const result = await reportService.getScoreOverview(authContext, administrationId, query);
+
+      return {
+        status: StatusCodes.OK as const,
+        body: {
+          data: result,
+        },
+      };
+    } catch (error) {
+      if (error instanceof ApiError) {
+        return toErrorResponse(error, [
+          StatusCodes.BAD_REQUEST,
+          StatusCodes.FORBIDDEN,
+          StatusCodes.NOT_FOUND,
+          StatusCodes.INTERNAL_SERVER_ERROR,
+        ]);
+      }
+      throw error;
+    }
+  },
+
+  /**
+   * Get faceted score distributions for an administration (#1782).
+   *
+   * Delegates to ReportService for authorization, support-level
+   * classification, and per-grade / per-school aggregation. The service
+   * returns `ServiceTaskScoreFacet` rows whose shape is structurally
+   * equivalent to the contract's `TaskScoreFacet`, so the result is
+   * returned directly.
+   *
+   * @param authContext - User's auth context
+   * @param administrationId - The administration to report on
+   * @param query - Query parameters (scopeType, scopeId, optional filter)
+   */
+  getScoreFacets: async (authContext: AuthContext, administrationId: string, query: ScoreFacetsQuery) => {
+    try {
+      const result = await reportService.getScoreFacets(authContext, administrationId, query);
 
       return {
         status: StatusCodes.OK as const,

--- a/apps/backend/src/controllers/users.controller.test.ts
+++ b/apps/backend/src/controllers/users.controller.test.ts
@@ -89,6 +89,7 @@ describe('UsersController', () => {
       listProgressStudents: vi.fn(),
       getProgressOverview: vi.fn(),
       getScoreOverview: vi.fn(),
+      getScoreFacets: vi.fn(),
       listStudentScores: vi.fn(),
       getIndividualStudentReport: vi.fn(),
       getGuardianStudentReport: mockGetGuardianStudentReport,

--- a/apps/backend/src/repositories/report.repository.ts
+++ b/apps/backend/src/repositories/report.repository.ts
@@ -1112,6 +1112,78 @@ export class ReportRepository {
    * reuse the same lookup at district scope without duplicating the two-phase
    * user_orgs → user_classes fallback.
    */
+  /**
+   * Like {@link getSchoolNamesForUsers} but returns `{ schoolId, schoolName }`
+   * tuples. The schoolId is needed by the facets endpoint for stable
+   * client-side keying — school name alone isn't unique across districts.
+   *
+   * Resolution rules and caveats match `getSchoolNamesForUsers`: a user
+   * with multiple school memberships gets their alphabetically-first
+   * school, the user_orgs → orgs path takes precedence over the
+   * user_classes → classes → school fallback, and rostering-ended schools
+   * / classes are excluded. The function uses the NOW()-based
+   * `isEnrollmentActive` predicate deliberately (the single live
+   * user_orgs row schema has no historical snapshot — see the JSDoc on
+   * `getSchoolNamesForUsers` for the past-admin display caveat).
+   */
+  async getSchoolsForUsers(userIds: string[]): Promise<Map<string, { schoolId: string; schoolName: string }>> {
+    const map = new Map<string, { schoolId: string; schoolName: string }>();
+
+    const orgRows = await this.db
+      .selectDistinct({
+        userId: userOrgs.userId,
+        schoolId: orgs.id,
+        schoolName: orgs.name,
+      })
+      .from(userOrgs)
+      .innerJoin(orgs, eq(userOrgs.orgId, orgs.id))
+      .where(
+        and(
+          inArray(userOrgs.userId, userIds),
+          eq(orgs.orgType, OrgType.SCHOOL),
+          isEnrollmentActive(userOrgs),
+          isNull(orgs.rosteringEnded),
+        ),
+      )
+      .orderBy(asc(orgs.name));
+
+    for (const row of orgRows) {
+      if (!map.has(row.userId)) {
+        map.set(row.userId, { schoolId: row.schoolId, schoolName: row.schoolName });
+      }
+    }
+
+    const missingUserIds = userIds.filter((id) => !map.has(id));
+    if (missingUserIds.length > 0) {
+      const classRows = await this.db
+        .selectDistinct({
+          userId: userClasses.userId,
+          schoolId: orgs.id,
+          schoolName: orgs.name,
+        })
+        .from(userClasses)
+        .innerJoin(classes, eq(userClasses.classId, classes.id))
+        .innerJoin(orgs, eq(classes.schoolId, orgs.id))
+        .where(
+          and(
+            inArray(userClasses.userId, missingUserIds),
+            isEnrollmentActive(userClasses),
+            isNull(classes.rosteringEnded),
+            isNull(orgs.rosteringEnded),
+          ),
+        )
+        .orderBy(asc(orgs.name));
+
+      for (const row of classRows) {
+        if (!map.has(row.userId)) {
+          map.set(row.userId, { schoolId: row.schoolId, schoolName: row.schoolName });
+        }
+      }
+    }
+
+    return map;
+  }
+
   async getSchoolNamesForUsers(userIds: string[]): Promise<Map<string, string>> {
     const rows = await this.db
       .selectDistinct({

--- a/apps/backend/src/repositories/report.repository.ts
+++ b/apps/backend/src/repositories/report.repository.ts
@@ -1429,11 +1429,11 @@ export class ReportRepository {
    * district gets their alphabetically-first school; the user_orgs → orgs
    * path takes precedence over the user_classes → classes → school
    * fallback; rostering-ended schools / classes are excluded. Uses the
-   * NOW()-based `isEnrollmentActive` predicate deliberately — the single
-   * live user_orgs row schema has no historical snapshot. See the JSDoc
-   * on `getSchoolNamesForUsers` for the past-admin display caveat (which
-   * also applies here, though the older method has not yet been
-   * scope-filtered — tracked as a follow-up).
+   * NOW()-based `isEnrollmentActive` predicate deliberately — see the
+   * "#1792 caveat" on {@link getSchoolNamesForUsers} for the past-admin
+   * display semantics (which apply here too: a transferred student shows
+   * their current school within the district, not the school they
+   * attended during a past admin's window).
    *
    * @param userIds - Users to resolve schools for.
    * @param districtId - The district whose subtree constrains the school
@@ -1532,6 +1532,21 @@ export class ReportRepository {
    * Public so that other repository methods (e.g., the student-scores listing)
    * can reuse the same lookup at district scope without duplicating the
    * two-phase user_orgs → user_classes fallback.
+   *
+   * **#1792 caveat — DO NOT switch the enrollment predicate to
+   * `isEnrollmentActiveForAdmin`.** This method deliberately uses the
+   * NOW-based `isEnrollmentActive` even when called from a past-admin
+   * report. The schema stores only a single live `user_orgs` row per
+   * (user, org) pair — the primary key on those two columns enforces it,
+   * and there is no `user_org_history` table or analog. So there is no
+   * historical snapshot of a student's school affiliation during a past
+   * administration. A transferred student therefore shows their CURRENT
+   * school in past-admin reports rather than the school they attended at
+   * the time. Switching the predicate to admin-aware would just return
+   * empty `schoolName` for any student who has since moved schools, which
+   * is strictly worse than the current behavior. If/when we add a
+   * `user_org_history` table or equivalent, this is the call site to
+   * update.
    *
    * @param userIds - Users to resolve schools for.
    * @param districtId - Optional district whose subtree constrains the lookup.

--- a/apps/backend/src/repositories/report.repository.ts
+++ b/apps/backend/src/repositories/report.repository.ts
@@ -1398,25 +1398,38 @@ export class ReportRepository {
    * If a user belongs to multiple schools, uses the alphabetically first school name
    * for deterministic results.
    *
-   * Note: This lookup is not scoped to the administration's assigned orgs — it returns
-   * the user's school from their org membership regardless of which schools are part of
-   * the administration. For a user enrolled in multiple schools, the alphabetically first
-   * school may not be the most relevant one for the current report context.
+   * When `districtId` is supplied, the lookup is constrained to schools under
+   * that district's ltree path on both the `user_orgs → orgs` and
+   * `user_classes → classes → orgs` resolution paths. This prevents
+   * cross-district leakage (a student in scope for district A who also has a
+   * live school enrollment in district B would otherwise surface district B's
+   * school via the alphabetically-first ordering). When `districtId` is
+   * omitted, the lookup is unconstrained — callers that don't have an
+   * unambiguous "current district" (e.g., the guardian student report, which
+   * spans the student's history across districts) should omit it
+   * deliberately.
    *
-   * Public so that other repository methods (e.g., the student-scores listing) can
-   * reuse the same lookup at district scope without duplicating the two-phase
-   * user_orgs → user_classes fallback.
+   * Note: This lookup is not scoped to the administration's assigned orgs — it
+   * returns the user's school from their org membership regardless of which
+   * schools are part of the administration. For a user enrolled in multiple
+   * schools within the same district, the alphabetically first school may not
+   * be the most relevant one for the current report context.
    *
-   * **Known issue (cross-district leakage)**: this method does not constrain
-   * the resolved school by the requested scope's ltree path. A user in scope
-   * for district A who also has a live school enrollment in district B may
-   * surface district B's school in district A's report. The sibling
-   * {@link getSchoolsForUsers} accepts a `districtId` parameter and applies
-   * the path filter; this method has not been updated to avoid behavior
-   * changes to `getStudentScores` and `getIndividualStudentReport`. Tracked
-   * as a follow-up alongside the row-level user_orgs history work.
+   * Public so that other repository methods (e.g., the student-scores listing)
+   * can reuse the same lookup at district scope without duplicating the
+   * two-phase user_orgs → user_classes fallback.
+   *
+   * @param userIds - Users to resolve schools for.
+   * @param districtId - Optional district whose subtree constrains the lookup.
+   *   Pass `scope.scopeId` when the caller knows the request is district-
+   *   scoped. Omit for callers that span districts.
    */
-  async getSchoolNamesForUsers(userIds: string[]): Promise<Map<string, string>> {
+  async getSchoolNamesForUsers(userIds: string[], districtId?: string): Promise<Map<string, string>> {
+    if (userIds.length === 0) return new Map();
+
+    const districtPathFilter =
+      districtId !== undefined ? sql`${orgs.path} <@ (SELECT path FROM app.orgs WHERE id = ${districtId})` : undefined;
+
     const rows = await this.db
       .selectDistinct({
         userId: userOrgs.userId,
@@ -1430,6 +1443,7 @@ export class ReportRepository {
           eq(orgs.orgType, OrgType.SCHOOL),
           isEnrollmentActive(userOrgs),
           isNull(orgs.rosteringEnded),
+          districtPathFilter,
         ),
       )
       .orderBy(asc(orgs.name));
@@ -1459,6 +1473,7 @@ export class ReportRepository {
             isEnrollmentActive(userClasses),
             isNull(classes.rosteringEnded),
             isNull(orgs.rosteringEnded),
+            districtPathFilter,
           ),
         )
         .orderBy(asc(orgs.name));

--- a/apps/backend/src/repositories/report.repository.ts
+++ b/apps/backend/src/repositories/report.repository.ts
@@ -1298,30 +1298,6 @@ export class ReportRepository {
   }
 
   /**
-   * Resolve school names for a set of users by looking up their org memberships.
-   * Returns the name of the school-type org the user belongs to.
-   * If a user belongs to multiple schools, uses the alphabetically first school name
-   * for deterministic results.
-   *
-   * Note: This lookup is not scoped to the administration's assigned orgs — it returns
-   * the user's school from their org membership regardless of which schools are part of
-   * the administration. For a user enrolled in multiple schools, the alphabetically first
-   * school may not be the most relevant one for the current report context.
-   *
-   * Public so that other repository methods (e.g., the student-scores listing) can
-   * reuse the same lookup at district scope without duplicating the two-phase
-   * user_orgs → user_classes fallback.
-   *
-   * **Known issue (cross-district leakage)**: this method does not constrain
-   * the resolved school by the requested scope's ltree path. A user in scope
-   * for district A who also has a live school enrollment in district B may
-   * surface district B's school in district A's report. The sibling
-   * {@link getSchoolsForUsers} accepts a `districtId` parameter and applies
-   * the path filter; this method has not been updated to avoid behavior
-   * changes to `getStudentScores` and `getIndividualStudentReport`. Tracked
-   * as a follow-up alongside the row-level user_orgs history work.
-   */
-  /**
    * Resolve `{ schoolId, schoolName }` tuples for a set of users, scoped to
    * the descendants of a specific district. Used by the facets endpoint at
    * district scope to attach school IDs to the per-school aggregation
@@ -1416,6 +1392,30 @@ export class ReportRepository {
     return map;
   }
 
+  /**
+   * Resolve school names for a set of users by looking up their org memberships.
+   * Returns the name of the school-type org the user belongs to.
+   * If a user belongs to multiple schools, uses the alphabetically first school name
+   * for deterministic results.
+   *
+   * Note: This lookup is not scoped to the administration's assigned orgs — it returns
+   * the user's school from their org membership regardless of which schools are part of
+   * the administration. For a user enrolled in multiple schools, the alphabetically first
+   * school may not be the most relevant one for the current report context.
+   *
+   * Public so that other repository methods (e.g., the student-scores listing) can
+   * reuse the same lookup at district scope without duplicating the two-phase
+   * user_orgs → user_classes fallback.
+   *
+   * **Known issue (cross-district leakage)**: this method does not constrain
+   * the resolved school by the requested scope's ltree path. A user in scope
+   * for district A who also has a live school enrollment in district B may
+   * surface district B's school in district A's report. The sibling
+   * {@link getSchoolsForUsers} accepts a `districtId` parameter and applies
+   * the path filter; this method has not been updated to avoid behavior
+   * changes to `getStudentScores` and `getIndividualStudentReport`. Tracked
+   * as a follow-up alongside the row-level user_orgs history work.
+   */
   async getSchoolNamesForUsers(userIds: string[]): Promise<Map<string, string>> {
     const rows = await this.db
       .selectDistinct({

--- a/apps/backend/src/repositories/report.repository.ts
+++ b/apps/backend/src/repositories/report.repository.ts
@@ -1111,23 +1111,53 @@ export class ReportRepository {
    * Public so that other repository methods (e.g., the student-scores listing) can
    * reuse the same lookup at district scope without duplicating the two-phase
    * user_orgs → user_classes fallback.
+   *
+   * **Known issue (cross-district leakage)**: this method does not constrain
+   * the resolved school by the requested scope's ltree path. A user in scope
+   * for district A who also has a live school enrollment in district B may
+   * surface district B's school in district A's report. The sibling
+   * {@link getSchoolsForUsers} accepts a `districtId` parameter and applies
+   * the path filter; this method has not been updated to avoid behavior
+   * changes to `getStudentScores` and `getIndividualStudentReport`. Tracked
+   * as a follow-up alongside the row-level user_orgs history work.
    */
   /**
-   * Like {@link getSchoolNamesForUsers} but returns `{ schoolId, schoolName }`
-   * tuples. The schoolId is needed by the facets endpoint for stable
-   * client-side keying — school name alone isn't unique across districts.
+   * Resolve `{ schoolId, schoolName }` tuples for a set of users, scoped to
+   * the descendants of a specific district. Used by the facets endpoint at
+   * district scope to attach school IDs to the per-school aggregation
+   * (schoolId is needed for stable client-side keying — school name alone
+   * isn't unique across districts).
    *
-   * Resolution rules and caveats match `getSchoolNamesForUsers`: a user
-   * with multiple school memberships gets their alphabetically-first
-   * school, the user_orgs → orgs path takes precedence over the
-   * user_classes → classes → school fallback, and rostering-ended schools
-   * / classes are excluded. The function uses the NOW()-based
-   * `isEnrollmentActive` predicate deliberately (the single live
-   * user_orgs row schema has no historical snapshot — see the JSDoc on
-   * `getSchoolNamesForUsers` for the past-admin display caveat).
+   * The `districtId` ltree filter is load-bearing for correctness, not
+   * defense-in-depth. Without it, a student in scope for district A who
+   * *also* has a live school enrollment in district B would surface
+   * district B's school in district A's per-school breakdown — leaking a
+   * foreign school's identity into the wrong district's report (review
+   * finding #1 on #1782).
+   *
+   * Resolution rules: a user with multiple school memberships within the
+   * district gets their alphabetically-first school; the user_orgs → orgs
+   * path takes precedence over the user_classes → classes → school
+   * fallback; rostering-ended schools / classes are excluded. Uses the
+   * NOW()-based `isEnrollmentActive` predicate deliberately — the single
+   * live user_orgs row schema has no historical snapshot. See the JSDoc
+   * on `getSchoolNamesForUsers` for the past-admin display caveat (which
+   * also applies here, though the older method has not yet been
+   * scope-filtered — tracked as a follow-up).
+   *
+   * @param userIds - Users to resolve schools for.
+   * @param districtId - The district whose subtree constrains the school
+   *   lookup. Schools outside this district's ltree path are excluded
+   *   from the result.
    */
-  async getSchoolsForUsers(userIds: string[]): Promise<Map<string, { schoolId: string; schoolName: string }>> {
+  async getSchoolsForUsers(
+    userIds: string[],
+    districtId: string,
+  ): Promise<Map<string, { schoolId: string; schoolName: string }>> {
     const map = new Map<string, { schoolId: string; schoolName: string }>();
+    if (userIds.length === 0) return map;
+
+    const districtPath = sql`(SELECT path FROM app.orgs WHERE id = ${districtId})`;
 
     const orgRows = await this.db
       .selectDistinct({
@@ -1143,6 +1173,7 @@ export class ReportRepository {
           eq(orgs.orgType, OrgType.SCHOOL),
           isEnrollmentActive(userOrgs),
           isNull(orgs.rosteringEnded),
+          sql`${orgs.path} <@ ${districtPath}`,
         ),
       )
       .orderBy(asc(orgs.name));
@@ -1170,6 +1201,7 @@ export class ReportRepository {
             isEnrollmentActive(userClasses),
             isNull(classes.rosteringEnded),
             isNull(orgs.rosteringEnded),
+            sql`${orgs.path} <@ ${districtPath}`,
           ),
         )
         .orderBy(asc(orgs.name));

--- a/apps/backend/src/routes/administrations.ts
+++ b/apps/backend/src/routes/administrations.ts
@@ -82,6 +82,12 @@ export function registerAdministrationsRoutes(routerInstance: Router) {
         handler: async ({ req: { user }, params: { id }, query }) =>
           AdministrationsController.getScoreOverview(user!, id, query),
       },
+      getScoreFacets: {
+        // @ts-expect-error - Express v4/v5 types mismatch in monorepo
+        middleware: [AuthGuardMiddleware],
+        handler: async ({ req: { user }, params: { id }, query }) =>
+          AdministrationsController.getScoreFacets(user!, id, query),
+      },
       listStudents: {
         // @ts-expect-error - Express v4/v5 types mismatch in monorepo
         middleware: [AuthGuardMiddleware],

--- a/apps/backend/src/routes/reports.integration.test.ts
+++ b/apps/backend/src/routes/reports.integration.test.ts
@@ -41,6 +41,11 @@ function scoreOverviewPath(administrationId: string) {
   return `/v1/administrations/${administrationId}/reports/scores/overview`;
 }
 
+/** Builds the score facets endpoint path for the given administration. */
+function scoreFacetsPath(administrationId: string) {
+  return `/v1/administrations/${administrationId}/reports/scores/facets`;
+}
+
 /** Builds the student scores endpoint path for the given administration. */
 function studentScoresPath(administrationId: string) {
   return `/v1/administrations/${administrationId}/reports/scores/students`;
@@ -1836,6 +1841,467 @@ describe('GET /v1/administrations/:id/reports/scores/overview', () => {
       expect(notAssessedTotal).toBeGreaterThan(0);
       // Every assigned student is either assessed or not-assessed — never both.
       expect(taskOverview!.totalAssessed + notAssessedTotal).toBeLessThanOrEqual(data.totalStudents);
+    });
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// GET /v1/administrations/:id/reports/scores/facets (#1782)
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('GET /v1/administrations/:id/reports/scores/facets', () => {
+  function facetsQuery() {
+    return {
+      scopeType: 'district',
+      scopeId: baseFixture.district.id,
+    };
+  }
+
+  describe('authorization', () => {
+    it('returns 401 without auth', async () => {
+      const res = await expectRoute('GET', scoreFacetsPath(baseFixture.administrationAssignedToDistrict.id))
+        .unauthenticated()
+        .toReturn(401);
+
+      expect(res.body.error.code).toBe(ApiErrorCode.AUTH_REQUIRED);
+    });
+
+    it('super admin can access', async () => {
+      authenticateAs(tiers.superAdmin);
+      const res = await request(app)
+        .get(scoreFacetsPath(baseFixture.administrationAssignedToDistrict.id))
+        .query(facetsQuery())
+        .set('Authorization', 'Bearer token');
+
+      expect(res.status).toBe(StatusCodes.OK);
+      expect(res.body.data).toBeDefined();
+    });
+
+    it('admin (administrator role) at district can access', async () => {
+      authenticateAs(tiers.admin);
+      const res = await request(app)
+        .get(scoreFacetsPath(baseFixture.administrationAssignedToDistrict.id))
+        .query(facetsQuery())
+        .set('Authorization', 'Bearer token');
+
+      expect(res.status).toBe(StatusCodes.OK);
+    });
+
+    it('site admin at district can access', async () => {
+      authenticateAs(tiers.siteAdmin);
+      const res = await request(app)
+        .get(scoreFacetsPath(baseFixture.administrationAssignedToDistrict.id))
+        .query(facetsQuery())
+        .set('Authorization', 'Bearer token');
+
+      expect(res.status).toBe(StatusCodes.OK);
+    });
+
+    it('educator (teacher) at district is forbidden at district scope', async () => {
+      authenticateAs(tiers.educator);
+      const res = await request(app)
+        .get(scoreFacetsPath(baseFixture.administrationAssignedToDistrict.id))
+        .query(facetsQuery())
+        .set('Authorization', 'Bearer token');
+
+      expect(res.status).toBe(StatusCodes.FORBIDDEN);
+    });
+
+    it('principal at school A can read facets at school scope', async () => {
+      authenticateAs(baseFixture.schoolAPrincipal);
+      const res = await request(app)
+        .get(scoreFacetsPath(baseFixture.administrationAssignedToSchoolA.id))
+        .query({ scopeType: 'school', scopeId: baseFixture.schoolA.id })
+        .set('Authorization', 'Bearer token');
+
+      expect(res.status).toBe(StatusCodes.OK);
+    });
+
+    it('principal at school A is forbidden at district scope', async () => {
+      authenticateAs(baseFixture.schoolAPrincipal);
+      const res = await request(app)
+        .get(scoreFacetsPath(baseFixture.administrationAssignedToDistrict.id))
+        .query(facetsQuery())
+        .set('Authorization', 'Bearer token');
+
+      expect(res.status).toBe(StatusCodes.FORBIDDEN);
+    });
+
+    it('student tier returns 403', async () => {
+      authenticateAs(tiers.student);
+      const res = await request(app)
+        .get(scoreFacetsPath(baseFixture.administrationAssignedToDistrict.id))
+        .query(facetsQuery())
+        .set('Authorization', 'Bearer token');
+
+      expect(res.status).toBe(StatusCodes.FORBIDDEN);
+      expect(res.body.error.code).toBe(ApiErrorCode.AUTH_FORBIDDEN);
+    });
+
+    it('caregiver tier returns 403', async () => {
+      authenticateAs(tiers.caregiver);
+      const res = await request(app)
+        .get(scoreFacetsPath(baseFixture.administrationAssignedToDistrict.id))
+        .query(facetsQuery())
+        .set('Authorization', 'Bearer token');
+
+      expect(res.status).toBe(StatusCodes.FORBIDDEN);
+    });
+
+    it('returns 403 for admin in a different district', async () => {
+      authenticateAs(baseFixture.districtBAdmin);
+      const res = await request(app)
+        .get(scoreFacetsPath(baseFixture.administrationAssignedToSchoolA.id))
+        .query({ scopeType: 'school', scopeId: baseFixture.schoolA.id })
+        .set('Authorization', 'Bearer token');
+
+      expect(res.status).toBe(StatusCodes.FORBIDDEN);
+    });
+
+    it('class teacher requesting school scope returns 403', async () => {
+      // FGA can_read_scores at the school level requires school_admin_tier or higher.
+      authenticateAs(baseFixture.classATeacher);
+      const res = await request(app)
+        .get(scoreFacetsPath(baseFixture.administrationAssignedToSchoolA.id))
+        .query({ scopeType: 'school', scopeId: baseFixture.schoolA.id })
+        .set('Authorization', 'Bearer token');
+
+      expect(res.status).toBe(StatusCodes.FORBIDDEN);
+    });
+
+    it('school-rostered teacher requesting an unassigned class within their school returns 403', async () => {
+      // Regression guard for the rewritten ticket's acceptance criterion:
+      // class-level `educator_tier` does NOT inherit from the parent school,
+      // so a teacher who is org-rostered at school A but is NOT directly on
+      // `user_classes` for classInSchoolA cannot read its scores. The FGA
+      // model already enforces this; this test pins it for #1782.
+      authenticateAs(baseFixture.schoolATeacher);
+      const res = await request(app)
+        .get(scoreFacetsPath(baseFixture.administrationAssignedToClassA.id))
+        .query({ scopeType: 'class', scopeId: baseFixture.classInSchoolA.id })
+        .set('Authorization', 'Bearer token');
+
+      expect(res.status).toBe(StatusCodes.FORBIDDEN);
+    });
+  });
+
+  describe('scope validation', () => {
+    it('returns 400 for scope not assigned to administration', async () => {
+      authenticateAs(tiers.superAdmin);
+      const res = await request(app)
+        .get(scoreFacetsPath(baseFixture.administrationAssignedToSchoolA.id))
+        .query({ scopeType: 'school', scopeId: baseFixture.schoolB.id })
+        .set('Authorization', 'Bearer token');
+
+      expect(res.status).toBe(StatusCodes.BAD_REQUEST);
+      expect(res.body.error.code).toBe(ApiErrorCode.REQUEST_VALIDATION_FAILED);
+    });
+
+    it('returns 400 when scopeType is missing', async () => {
+      authenticateAs(tiers.superAdmin);
+      const res = await request(app)
+        .get(scoreFacetsPath(baseFixture.administrationAssignedToDistrict.id))
+        .query({ scopeId: baseFixture.district.id })
+        .set('Authorization', 'Bearer token');
+
+      expect(res.status).toBe(StatusCodes.BAD_REQUEST);
+    });
+
+    it('returns 400 when scopeId is missing', async () => {
+      authenticateAs(tiers.superAdmin);
+      const res = await request(app)
+        .get(scoreFacetsPath(baseFixture.administrationAssignedToDistrict.id))
+        .query({ scopeType: 'district' })
+        .set('Authorization', 'Bearer token');
+
+      expect(res.status).toBe(StatusCodes.BAD_REQUEST);
+    });
+
+    it('returns 404 for non-existent administration', async () => {
+      authenticateAs(tiers.superAdmin);
+      const res = await request(app)
+        .get(scoreFacetsPath('00000000-0000-0000-0000-000000000000'))
+        .query(facetsQuery())
+        .set('Authorization', 'Bearer token');
+
+      expect(res.status).toBe(StatusCodes.NOT_FOUND);
+      expect(res.body.error.code).toBe(ApiErrorCode.RESOURCE_NOT_FOUND);
+    });
+
+    it('returns 400 for unknown filter field (rejects user.schoolName as out-of-scope)', async () => {
+      // `user.schoolName` is deliberately out of scope for #1782; the
+      // contract's `createFilterQuerySchema` allowlist rejects it before
+      // reaching the service.
+      authenticateAs(tiers.superAdmin);
+      const res = await request(app)
+        .get(scoreFacetsPath(baseFixture.administrationAssignedToDistrict.id))
+        .query({ ...facetsQuery(), filter: 'user.schoolName:eq:Lincoln' })
+        .set('Authorization', 'Bearer token');
+
+      expect(res.status).toBe(StatusCodes.BAD_REQUEST);
+    });
+  });
+
+  describe('response shape', () => {
+    it('returns 200 with correct envelope at district scope', async () => {
+      authenticateAs(tiers.superAdmin);
+      const res = await request(app)
+        .get(scoreFacetsPath(baseFixture.administrationAssignedToDistrict.id))
+        .query(facetsQuery())
+        .set('Authorization', 'Bearer token');
+
+      expect(res.status).toBe(StatusCodes.OK);
+
+      const { data } = res.body;
+      expect(data).toHaveProperty('totalStudents');
+      expect(data).toHaveProperty('tasks');
+      expect(data).toHaveProperty('computedAt');
+      expect(typeof data.totalStudents).toBe('number');
+      expect(typeof data.computedAt).toBe('string');
+      expect(data.tasks).toBeInstanceOf(Array);
+      expect(data.tasks.length).toBeGreaterThan(0);
+
+      const firstTask = data.tasks[0];
+      expect(firstTask).toHaveProperty('taskId');
+      expect(firstTask).toHaveProperty('taskSlug');
+      expect(firstTask).toHaveProperty('taskName');
+      expect(firstTask).toHaveProperty('orderIndex');
+      expect(firstTask.supportLevelByGrade).toBeInstanceOf(Array);
+      expect(firstTask.supportLevelBySchool).toBeInstanceOf(Array);
+      expect(firstTask.scoreBinsByGrade).toBeInstanceOf(Array);
+      expect(firstTask.scoreBinsBySchool).toBeInstanceOf(Array);
+    });
+
+    it('deduplicates multi-variant tasks into one entry per taskId', async () => {
+      authenticateAs(tiers.superAdmin);
+      const res = await request(app)
+        .get(scoreFacetsPath(baseFixture.administrationAssignedToDistrict.id))
+        .query(facetsQuery())
+        .set('Authorization', 'Bearer token');
+
+      expect(res.status).toBe(StatusCodes.OK);
+
+      const { data } = res.body;
+      const uniqueTaskIds = new Set(data.tasks.map((t: { taskId: string }) => t.taskId));
+      expect(uniqueTaskIds.size).toBe(data.tasks.length);
+    });
+
+    it('returns empty *BySchool arrays at school scope', async () => {
+      authenticateAs(tiers.superAdmin);
+      const res = await request(app)
+        .get(scoreFacetsPath(baseFixture.administrationAssignedToSchoolA.id))
+        .query({ scopeType: 'school', scopeId: baseFixture.schoolA.id })
+        .set('Authorization', 'Bearer token');
+
+      expect(res.status).toBe(StatusCodes.OK);
+
+      const { data } = res.body;
+      for (const task of data.tasks) {
+        expect(task.supportLevelBySchool).toEqual([]);
+        expect(task.scoreBinsBySchool).toEqual([]);
+      }
+    });
+
+    it('returns empty *BySchool arrays at class scope', async () => {
+      authenticateAs(tiers.superAdmin);
+      const res = await request(app)
+        .get(scoreFacetsPath(baseFixture.administrationAssignedToClassA.id))
+        .query({ scopeType: 'class', scopeId: baseFixture.classInSchoolA.id })
+        .set('Authorization', 'Bearer token');
+
+      expect(res.status).toBe(StatusCodes.OK);
+
+      const { data } = res.body;
+      for (const task of data.tasks) {
+        expect(task.supportLevelBySchool).toEqual([]);
+        expect(task.scoreBinsBySchool).toEqual([]);
+      }
+    });
+
+    it('returns empty *BySchool arrays at group scope', async () => {
+      authenticateAs(tiers.superAdmin);
+      const res = await request(app)
+        .get(scoreFacetsPath(baseFixture.administrationAssignedToGroup.id))
+        .query({ scopeType: 'group', scopeId: baseFixture.group.id })
+        .set('Authorization', 'Bearer token');
+
+      expect(res.status).toBe(StatusCodes.OK);
+
+      const { data } = res.body;
+      for (const task of data.tasks) {
+        expect(task.supportLevelBySchool).toEqual([]);
+        expect(task.scoreBinsBySchool).toEqual([]);
+      }
+    });
+  });
+
+  describe('FDW-backed aggregation', () => {
+    /**
+     * Builds a completed run with a percentile score for the given user and
+     * variant. The percentile-based support level is what most reporting
+     * tasks (e.g., swr at grade 3) classify on, so seeding a percentile
+     * exercises the support-level tallies end-to-end.
+     */
+    async function seedCompletedRunWithPercentile(opts: {
+      userId: string;
+      taskId: string;
+      taskVariantId: string;
+      administrationId: string;
+      percentile: number;
+    }) {
+      const run = await RunFactory.create({
+        userId: opts.userId,
+        taskId: opts.taskId,
+        taskVariantId: opts.taskVariantId,
+        administrationId: opts.administrationId,
+        useForReporting: true,
+        completedAt: new Date('2025-06-15T10:00:00Z'),
+      });
+      await RunScoreFactory.create({
+        runId: run.id,
+        type: 'computed',
+        domain: 'default',
+        name: 'percentile',
+        value: String(opts.percentile),
+      });
+    }
+
+    it('tallies support levels per grade after seeding completed runs', async () => {
+      // grade3Student has grade '3' in the baseFixture (pinned at user
+      // creation, see `base.fixture.ts`). Seeding a completed run for them
+      // anchors a deterministic grade-3 entry regardless of what other tests
+      // in this describe block (or sibling describes) have seeded.
+      await seedCompletedRunWithPercentile({
+        userId: baseFixture.grade3Student.id,
+        taskId: baseFixture.task.id,
+        taskVariantId: baseFixture.variantForAllGrades.id,
+        administrationId: baseFixture.administrationAssignedToDistrict.id,
+        percentile: 75,
+      });
+
+      authenticateAs(tiers.superAdmin);
+      const res = await request(app)
+        .get(scoreFacetsPath(baseFixture.administrationAssignedToDistrict.id))
+        .query(facetsQuery())
+        .set('Authorization', 'Bearer token');
+
+      expect(res.status).toBe(StatusCodes.OK);
+
+      const { data } = res.body;
+      const baseTask = data.tasks.find((t: { taskId: string }) => t.taskId === baseFixture.task.id);
+      expect(baseTask).toBeDefined();
+      // At least one grade-3 student in the assessed cohort.
+      const grade3 = baseTask!.supportLevelByGrade.find((e: { grade: string }) => e.grade === '3');
+      expect(grade3).toBeDefined();
+      expect(grade3.totalAssessed).toBeGreaterThanOrEqual(1);
+    });
+
+    it('per-school array is populated and uses string school IDs at district scope', async () => {
+      // schoolAStudent is rostered at School A via user_orgs, so seeding a
+      // run for them produces a non-empty per-school entry keyed by
+      // School A's id. (This test is about the school dimension, not the
+      // grade dimension — schoolAStudent's grade is fixture-default and
+      // doesn't matter here.)
+      await seedCompletedRunWithPercentile({
+        userId: baseFixture.schoolAStudent.id,
+        taskId: baseFixture.task.id,
+        taskVariantId: baseFixture.variantForAllGrades.id,
+        administrationId: baseFixture.administrationAssignedToDistrict.id,
+        percentile: 75,
+      });
+
+      authenticateAs(tiers.superAdmin);
+      const res = await request(app)
+        .get(scoreFacetsPath(baseFixture.administrationAssignedToDistrict.id))
+        .query(facetsQuery())
+        .set('Authorization', 'Bearer token');
+
+      expect(res.status).toBe(StatusCodes.OK);
+
+      const { data } = res.body;
+      const baseTask = data.tasks.find((t: { taskId: string }) => t.taskId === baseFixture.task.id);
+      expect(baseTask.supportLevelBySchool.length).toBeGreaterThan(0);
+      const schoolEntry = baseTask.supportLevelBySchool.find(
+        (e: { schoolId: string }) => e.schoolId === baseFixture.schoolA.id,
+      );
+      expect(schoolEntry).toBeDefined();
+      expect(schoolEntry.schoolId).toBe(baseFixture.schoolA.id);
+      // schoolName may be null in degenerate fixtures; if present, it's a string.
+      if (schoolEntry.schoolName !== null) {
+        expect(typeof schoolEntry.schoolName).toBe('string');
+      }
+    });
+
+    it('keeps percentile bin edges stable when a user.grade filter is applied (#1782)', async () => {
+      // Seed grade-3 + grade-5 students with completed runs spanning a
+      // range of percentiles. Bin edges are fixed (0..100 width 10) for
+      // percentiles by design, so the test asserts identity rather than
+      // any min/max math.
+      await seedCompletedRunWithPercentile({
+        userId: baseFixture.grade3Student.id,
+        taskId: baseFixture.task.id,
+        taskVariantId: baseFixture.variantForAllGrades.id,
+        administrationId: baseFixture.administrationAssignedToDistrict.id,
+        percentile: 25,
+      });
+      await seedCompletedRunWithPercentile({
+        userId: baseFixture.grade5Student.id,
+        taskId: baseFixture.task.id,
+        taskVariantId: baseFixture.variantForAllGrades.id,
+        administrationId: baseFixture.administrationAssignedToDistrict.id,
+        percentile: 95,
+      });
+
+      authenticateAs(tiers.superAdmin);
+      const unfilteredRes = await request(app)
+        .get(scoreFacetsPath(baseFixture.administrationAssignedToDistrict.id))
+        .query(facetsQuery())
+        .set('Authorization', 'Bearer token');
+      const filteredRes = await request(app)
+        .get(scoreFacetsPath(baseFixture.administrationAssignedToDistrict.id))
+        .query({ ...facetsQuery(), filter: 'user.grade:eq:3' })
+        .set('Authorization', 'Bearer token');
+
+      expect(unfilteredRes.status).toBe(StatusCodes.OK);
+      expect(filteredRes.status).toBe(StatusCodes.OK);
+
+      const baseTaskUnfiltered = unfilteredRes.body.data.tasks.find(
+        (t: { taskId: string }) => t.taskId === baseFixture.task.id,
+      );
+      const baseTaskFiltered = filteredRes.body.data.tasks.find(
+        (t: { taskId: string }) => t.taskId === baseFixture.task.id,
+      );
+
+      const unfilteredEdges = baseTaskUnfiltered.scoreBinsByGrade
+        .find((e: { grade: string }) => e.grade === '3')!
+        .percentile.map((b: { binStart: number; binEnd: number }) => [b.binStart, b.binEnd]);
+      const filteredEdges = baseTaskFiltered.scoreBinsByGrade
+        .find((e: { grade: string }) => e.grade === '3')!
+        .percentile.map((b: { binStart: number; binEnd: number }) => [b.binStart, b.binEnd]);
+      expect(filteredEdges).toEqual(unfilteredEdges);
+
+      // Filter narrowed cohort: no grade '5' entry in the filtered response.
+      const filteredGrades = baseTaskFiltered.supportLevelByGrade.map((e: { grade: string }) => e.grade);
+      expect(filteredGrades).not.toContain('5');
+    });
+
+    // (The "empty *ByGrade when no completed runs" property is covered by
+    // the service unit tests — adding it here would require an
+    // administration with guaranteed-zero seeded runs, which doesn't exist
+    // in `baseFixture` once the score-overview FDW block has run its
+    // beforeAll against `administrationAssignedToDistrict`. The describe
+    // blocks don't truncate between each other, so we'd be fighting
+    // shared state for no integration-level benefit.)
+
+    it('totalStudents reflects the in-scope student population', async () => {
+      authenticateAs(tiers.superAdmin);
+      const res = await request(app)
+        .get(scoreFacetsPath(baseFixture.administrationAssignedToDistrict.id))
+        .query(facetsQuery())
+        .set('Authorization', 'Bearer token');
+
+      expect(res.status).toBe(StatusCodes.OK);
+      expect(res.body.data.totalStudents).toBeGreaterThan(0);
     });
   });
 });

--- a/apps/backend/src/services/report/report.service.test.ts
+++ b/apps/backend/src/services/report/report.service.test.ts
@@ -20,6 +20,7 @@ import type {
   ProgressStudentsInput,
   ProgressOverviewInput,
   ScoreOverviewInput,
+  ScoreFacetsInput,
   StudentScoresInput,
   IndividualStudentReportInput,
 } from './report.types';
@@ -1961,6 +1962,661 @@ describe('ReportService', () => {
       // (has a completed run with scores), they just lack a classifiable result.
       expect(swrTask.totalNotAssessed.required).toBe(0);
       expect(swrTask.totalNotAssessed.optional).toBe(0);
+    });
+  });
+
+  describe('getScoreFacets', () => {
+    const facetsQuery: ScoreFacetsInput = {
+      scopeType: 'district',
+      scopeId: 'district-uuid-1',
+      filter: [],
+    };
+
+    function buildFacetStudent(overrides: Partial<StudentOverviewRow> & { userId: string }): StudentOverviewRow {
+      return {
+        grade: '3',
+        statusEll: null,
+        statusIep: null,
+        statusFrl: null,
+        dob: null,
+        gender: null,
+        race: null,
+        hispanicEthnicity: null,
+        homeLanguage: null,
+        ...overrides,
+      };
+    }
+
+    function buildScoreRow(userId: string, taskVariantId: string, scoreName: string, scoreValue: string): RunScoreRow {
+      return { userId, taskVariantId, scoreName, scoreValue };
+    }
+
+    function setupDefaultFacetsMocks(
+      students: StudentOverviewRow[] = [buildFacetStudent({ userId: 'student-1' })],
+      scoreRows: RunScoreRow[] = [],
+      schoolsByUser: Map<string, { schoolId: string; schoolName: string }> = new Map(),
+    ) {
+      mockReportRepository.getAllStudentsInScope.mockResolvedValue({
+        totalStudents: students.length,
+        students,
+      });
+      mockReportRepository.getCompletedRunScores.mockResolvedValue(scoreRows);
+      mockReportRepository.getSchoolsForUsers.mockResolvedValue(schoolsByUser);
+      mockTaskVariantParameterRepository.getByTaskVariantIds.mockResolvedValue([]);
+    }
+
+    // --- Authorization (mirrors getScoreOverview) ---
+
+    it('returns 404 when administration does not exist', async () => {
+      mockAdministrationRepository.getById.mockResolvedValue(null);
+
+      const service = createService();
+
+      await expect(service.getScoreFacets(teacherAuth, testAdministrationId, facetsQuery)).rejects.toMatchObject({
+        statusCode: StatusCodes.NOT_FOUND,
+        code: ApiErrorCode.RESOURCE_NOT_FOUND,
+      });
+    });
+
+    it('returns 403 when FGA denies can_read_scores on administration', async () => {
+      mockAuthorizationService.requirePermission.mockRejectedValue(
+        new ApiError(ApiErrorMessage.FORBIDDEN, {
+          statusCode: StatusCodes.FORBIDDEN,
+          code: ApiErrorCode.AUTH_FORBIDDEN,
+        }),
+      );
+
+      const service = createService();
+
+      await expect(service.getScoreFacets(teacherAuth, testAdministrationId, facetsQuery)).rejects.toMatchObject({
+        statusCode: StatusCodes.FORBIDDEN,
+        code: ApiErrorCode.AUTH_FORBIDDEN,
+      });
+
+      expect(mockAuthorizationService.requirePermission).toHaveBeenCalledWith(
+        teacherAuth.userId,
+        FgaRelation.CAN_READ_SCORES,
+        `${FgaType.ADMINISTRATION}:${testAdministrationId}`,
+      );
+    });
+
+    it('returns 400 when scope is not assigned to administration', async () => {
+      mockReportRepository.isScopeAssignedToAdministration.mockResolvedValue(false);
+
+      const service = createService();
+
+      await expect(service.getScoreFacets(teacherAuth, testAdministrationId, facetsQuery)).rejects.toMatchObject({
+        statusCode: StatusCodes.BAD_REQUEST,
+        code: ApiErrorCode.REQUEST_VALIDATION_FAILED,
+      });
+    });
+
+    it('returns 403 when FGA denies can_read_scores at scope level', async () => {
+      mockAuthorizationService.requirePermission.mockResolvedValueOnce(undefined).mockRejectedValueOnce(
+        new ApiError(ApiErrorMessage.FORBIDDEN, {
+          statusCode: StatusCodes.FORBIDDEN,
+          code: ApiErrorCode.AUTH_FORBIDDEN,
+        }),
+      );
+
+      const service = createService();
+
+      await expect(service.getScoreFacets(teacherAuth, testAdministrationId, facetsQuery)).rejects.toMatchObject({
+        statusCode: StatusCodes.FORBIDDEN,
+        code: ApiErrorCode.AUTH_FORBIDDEN,
+      });
+
+      expect(mockAuthorizationService.requirePermission).toHaveBeenNthCalledWith(
+        2,
+        teacherAuth.userId,
+        FgaRelation.CAN_READ_SCORES,
+        `${FgaType.DISTRICT}:district-uuid-1`,
+      );
+    });
+
+    it('super admin bypasses FGA checks', async () => {
+      setupDefaultFacetsMocks();
+
+      const service = createService();
+      await service.getScoreFacets(superAdminAuth, testAdministrationId, facetsQuery);
+
+      expect(mockAuthorizationService.requirePermission).not.toHaveBeenCalled();
+    });
+
+    // --- Empty / shape ---
+
+    it('returns empty task facets when no students in scope', async () => {
+      setupDefaultFacetsMocks([]);
+
+      const service = createService();
+      const result = await service.getScoreFacets(superAdminAuth, testAdministrationId, facetsQuery);
+
+      expect(result.totalStudents).toBe(0);
+      expect(result.tasks).toHaveLength(testTaskMetas.length);
+      for (const task of result.tasks) {
+        expect(task.supportLevelByGrade).toEqual([]);
+        expect(task.supportLevelBySchool).toEqual([]);
+        expect(task.scoreBinsByGrade).toEqual([]);
+        expect(task.scoreBinsBySchool).toEqual([]);
+      }
+    });
+
+    it('returns computedAt as a parseable ISO datetime', async () => {
+      setupDefaultFacetsMocks();
+
+      const service = createService();
+      const result = await service.getScoreFacets(superAdminAuth, testAdministrationId, facetsQuery);
+
+      const parsed = new Date(result.computedAt);
+      expect(parsed.getTime()).not.toBeNaN();
+    });
+
+    // --- Filter routing ---
+
+    it('narrows tasks when taskId:in filter excludes some', async () => {
+      setupDefaultFacetsMocks();
+
+      const service = createService();
+      const result = await service.getScoreFacets(superAdminAuth, testAdministrationId, {
+        ...facetsQuery,
+        filter: [{ field: 'taskId', operator: 'in', value: TASK_ID_1 }],
+      });
+
+      expect(result.tasks).toHaveLength(1);
+      expect(result.tasks[0]!.taskId).toBe(TASK_ID_1);
+    });
+
+    it('merges multiple taskId filter entries into a single allow-list', async () => {
+      // Same dedup behavior as getScoreOverview (#1683): two taskId:in entries
+      // should be unioned, not silently overwritten.
+      setupDefaultFacetsMocks();
+
+      const service = createService();
+      const result = await service.getScoreFacets(superAdminAuth, testAdministrationId, {
+        ...facetsQuery,
+        filter: [
+          { field: 'taskId', operator: 'in', value: TASK_ID_1 },
+          { field: 'taskId', operator: 'in', value: TASK_ID_3 },
+        ],
+      });
+
+      const seenIds = new Set(result.tasks.map((t) => t.taskId));
+      expect(seenIds).toEqual(new Set([TASK_ID_1, TASK_ID_3]));
+    });
+
+    // --- Per-grade aggregation ---
+
+    it('tallies support levels per grade for the assessed cohort', async () => {
+      // 3 grade-3 students with different percentiles, 1 grade-4 student.
+      // Percentile thresholds for swr (the task at TASK_ID_1) bucket students
+      // into the three support levels — same fixture pattern as getScoreOverview.
+      const students = [
+        buildFacetStudent({ userId: 'student-1', grade: '3' }),
+        buildFacetStudent({ userId: 'student-2', grade: '3' }),
+        buildFacetStudent({ userId: 'student-3', grade: '3' }),
+        buildFacetStudent({ userId: 'student-4', grade: '4' }),
+      ];
+      const scoreRows = [
+        buildScoreRow('student-1', VARIANT_ID_1, 'percentile', '90'),
+        buildScoreRow('student-2', VARIANT_ID_1, 'percentile', '50'),
+        buildScoreRow('student-3', VARIANT_ID_1, 'percentile', '10'),
+        buildScoreRow('student-4', VARIANT_ID_1, 'percentile', '95'),
+      ];
+      setupDefaultFacetsMocks(students, scoreRows);
+
+      const service = createService();
+      const result = await service.getScoreFacets(superAdminAuth, testAdministrationId, facetsQuery);
+
+      const swrTask = result.tasks.find((t) => t.taskId === TASK_ID_1)!;
+      expect(swrTask).toBeDefined();
+
+      const grade3 = swrTask.supportLevelByGrade.find((e) => e.grade === '3')!;
+      const grade4 = swrTask.supportLevelByGrade.find((e) => e.grade === '4')!;
+      expect(grade3.totalAssessed).toBe(3);
+      expect(grade3.achievedSkill.count + grade3.developingSkill.count + grade3.needsExtraSupport.count).toBe(3);
+      expect(grade4.totalAssessed).toBe(1);
+      expect(grade4.achievedSkill.count).toBe(1);
+    });
+
+    it('sorts per-grade entries by grade ordinal, not lexicographically', async () => {
+      // Order in: 10, K, 2, 1 — out: K, 1, 2, 10.
+      const students = [
+        buildFacetStudent({ userId: 'student-10', grade: '10' }),
+        buildFacetStudent({ userId: 'student-k', grade: 'Kindergarten' }),
+        buildFacetStudent({ userId: 'student-2', grade: '2' }),
+        buildFacetStudent({ userId: 'student-1', grade: '1' }),
+      ];
+      const scoreRows = [
+        buildScoreRow('student-10', VARIANT_ID_1, 'percentile', '50'),
+        buildScoreRow('student-k', VARIANT_ID_1, 'percentile', '50'),
+        buildScoreRow('student-2', VARIANT_ID_1, 'percentile', '50'),
+        buildScoreRow('student-1', VARIANT_ID_1, 'percentile', '50'),
+      ];
+      setupDefaultFacetsMocks(students, scoreRows);
+
+      const service = createService();
+      const result = await service.getScoreFacets(superAdminAuth, testAdministrationId, facetsQuery);
+
+      const swrTask = result.tasks.find((t) => t.taskId === TASK_ID_1)!;
+      expect(swrTask.supportLevelByGrade.map((e) => e.grade)).toEqual(['Kindergarten', '1', '2', '10']);
+    });
+
+    it('excludes students with a null grade from per-grade tallies', async () => {
+      const students = [
+        buildFacetStudent({ userId: 'student-graded', grade: '3' }),
+        buildFacetStudent({ userId: 'student-no-grade', grade: null }),
+      ];
+      const scoreRows = [
+        buildScoreRow('student-graded', VARIANT_ID_1, 'percentile', '50'),
+        buildScoreRow('student-no-grade', VARIANT_ID_1, 'percentile', '50'),
+      ];
+      setupDefaultFacetsMocks(students, scoreRows);
+
+      const service = createService();
+      const result = await service.getScoreFacets(superAdminAuth, testAdministrationId, facetsQuery);
+
+      const swrTask = result.tasks.find((t) => t.taskId === TASK_ID_1)!;
+      expect(swrTask.supportLevelByGrade).toHaveLength(1);
+      expect(swrTask.supportLevelByGrade[0]!.grade).toBe('3');
+      expect(swrTask.supportLevelByGrade[0]!.totalAssessed).toBe(1);
+    });
+
+    it('uses raw users.grade representation (not display-normalized)', async () => {
+      // Frontend remaps 'Kindergarten' → 'K' for display via getGrade(). The
+      // backend response should preserve the raw enum value so it matches
+      // sibling endpoints (overview, students).
+      const students = [buildFacetStudent({ userId: 'student-k', grade: 'Kindergarten' })];
+      const scoreRows = [buildScoreRow('student-k', VARIANT_ID_1, 'percentile', '50')];
+      setupDefaultFacetsMocks(students, scoreRows);
+
+      const service = createService();
+      const result = await service.getScoreFacets(superAdminAuth, testAdministrationId, facetsQuery);
+
+      const swrTask = result.tasks.find((t) => t.taskId === TASK_ID_1)!;
+      expect(swrTask.supportLevelByGrade[0]!.grade).toBe('Kindergarten');
+    });
+
+    // --- Per-school aggregation (district scope) ---
+
+    it('tallies support levels per school at district scope', async () => {
+      const students = [
+        buildFacetStudent({ userId: 'student-a1', grade: '3' }),
+        buildFacetStudent({ userId: 'student-a2', grade: '3' }),
+        buildFacetStudent({ userId: 'student-b1', grade: '3' }),
+      ];
+      const scoreRows = [
+        buildScoreRow('student-a1', VARIANT_ID_1, 'percentile', '50'),
+        buildScoreRow('student-a2', VARIANT_ID_1, 'percentile', '50'),
+        buildScoreRow('student-b1', VARIANT_ID_1, 'percentile', '50'),
+      ];
+      const schoolsByUser = new Map<string, { schoolId: string; schoolName: string }>([
+        ['student-a1', { schoolId: 'school-a-uuid', schoolName: 'Lincoln Elementary' }],
+        ['student-a2', { schoolId: 'school-a-uuid', schoolName: 'Lincoln Elementary' }],
+        ['student-b1', { schoolId: 'school-b-uuid', schoolName: 'Roosevelt Elementary' }],
+      ]);
+      setupDefaultFacetsMocks(students, scoreRows, schoolsByUser);
+
+      const service = createService();
+      const result = await service.getScoreFacets(superAdminAuth, testAdministrationId, facetsQuery);
+
+      const swrTask = result.tasks.find((t) => t.taskId === TASK_ID_1)!;
+      expect(swrTask.supportLevelBySchool).toHaveLength(2);
+      const lincoln = swrTask.supportLevelBySchool.find((s) => s.schoolName === 'Lincoln Elementary')!;
+      const roosevelt = swrTask.supportLevelBySchool.find((s) => s.schoolName === 'Roosevelt Elementary')!;
+      expect(lincoln.totalAssessed).toBe(2);
+      expect(lincoln.schoolId).toBe('school-a-uuid');
+      expect(roosevelt.totalAssessed).toBe(1);
+    });
+
+    it('excludes students with no resolvable school from *BySchool tallies', async () => {
+      // At district scope, a student missing from getSchoolsForUsers (e.g.,
+      // no resolvable user_orgs / user_classes → school path) drops out of
+      // the school-faceted breakdown but stays in the grade-faceted one.
+      const students = [
+        buildFacetStudent({ userId: 'student-with-school', grade: '3' }),
+        buildFacetStudent({ userId: 'student-no-school', grade: '3' }),
+      ];
+      const scoreRows = [
+        buildScoreRow('student-with-school', VARIANT_ID_1, 'percentile', '50'),
+        buildScoreRow('student-no-school', VARIANT_ID_1, 'percentile', '50'),
+      ];
+      const schoolsByUser = new Map<string, { schoolId: string; schoolName: string }>([
+        ['student-with-school', { schoolId: 'school-a-uuid', schoolName: 'Lincoln Elementary' }],
+      ]);
+      setupDefaultFacetsMocks(students, scoreRows, schoolsByUser);
+
+      const service = createService();
+      const result = await service.getScoreFacets(superAdminAuth, testAdministrationId, facetsQuery);
+
+      const swrTask = result.tasks.find((t) => t.taskId === TASK_ID_1)!;
+      // School tally only contains the school-resolvable student.
+      expect(swrTask.supportLevelBySchool).toHaveLength(1);
+      expect(swrTask.supportLevelBySchool[0]!.totalAssessed).toBe(1);
+      // Grade tally still has both.
+      expect(swrTask.supportLevelByGrade.find((e) => e.grade === '3')!.totalAssessed).toBe(2);
+    });
+
+    // --- Empty *BySchool at non-district scopes ---
+
+    it.each([
+      ['school', 'school'],
+      ['class', 'class'],
+      ['group', 'group'],
+    ] as const)('returns empty *BySchool arrays at %s scope', async (_label, scopeType) => {
+      const students = [buildFacetStudent({ userId: 'student-1', grade: '3' })];
+      const scoreRows = [buildScoreRow('student-1', VARIANT_ID_1, 'percentile', '50')];
+      setupDefaultFacetsMocks(students, scoreRows);
+
+      const service = createService();
+      const result = await service.getScoreFacets(superAdminAuth, testAdministrationId, {
+        ...facetsQuery,
+        scopeType,
+      });
+
+      for (const task of result.tasks) {
+        expect(task.supportLevelBySchool).toEqual([]);
+        expect(task.scoreBinsBySchool).toEqual([]);
+      }
+      // School resolution is not even attempted off district scope.
+      expect(mockReportRepository.getSchoolsForUsers).not.toHaveBeenCalled();
+    });
+
+    // --- Bin edges and bin-edge stability ---
+
+    it('returns 10 fixed percentile bins covering 0–100 with width 10', async () => {
+      const students = [buildFacetStudent({ userId: 'student-1', grade: '3' })];
+      const scoreRows = [buildScoreRow('student-1', VARIANT_ID_1, 'percentile', '50')];
+      setupDefaultFacetsMocks(students, scoreRows);
+
+      const service = createService();
+      const result = await service.getScoreFacets(superAdminAuth, testAdministrationId, facetsQuery);
+
+      const swrTask = result.tasks.find((t) => t.taskId === TASK_ID_1)!;
+      const gradeEntry = swrTask.scoreBinsByGrade.find((e) => e.grade === '3')!;
+      expect(gradeEntry.percentile).toHaveLength(10);
+      expect(gradeEntry.percentile[0]).toMatchObject({ binStart: 0, binEnd: 10 });
+      expect(gradeEntry.percentile[9]).toMatchObject({ binStart: 90, binEnd: 100 });
+    });
+
+    it('returns an empty percentile array when no student has a percentile for the task', async () => {
+      const students = [buildFacetStudent({ userId: 'student-1', grade: '3' })];
+      // No score rows — student has no percentile.
+      setupDefaultFacetsMocks(students, []);
+
+      const service = createService();
+      const result = await service.getScoreFacets(superAdminAuth, testAdministrationId, facetsQuery);
+
+      const swrTask = result.tasks.find((t) => t.taskId === TASK_ID_1)!;
+      // No scored student → no grade entry at all.
+      expect(swrTask.scoreBinsByGrade).toEqual([]);
+    });
+
+    it('places a percentile of 100 into the final bin (last bin is closed at top)', async () => {
+      const students = [
+        buildFacetStudent({ userId: 'student-max', grade: '3' }),
+        buildFacetStudent({ userId: 'student-min', grade: '3' }),
+      ];
+      const scoreRows = [
+        buildScoreRow('student-max', VARIANT_ID_1, 'percentile', '100'),
+        buildScoreRow('student-min', VARIANT_ID_1, 'percentile', '0'),
+      ];
+      setupDefaultFacetsMocks(students, scoreRows);
+
+      const service = createService();
+      const result = await service.getScoreFacets(superAdminAuth, testAdministrationId, facetsQuery);
+
+      const swrTask = result.tasks.find((t) => t.taskId === TASK_ID_1)!;
+      const gradeEntry = swrTask.scoreBinsByGrade.find((e) => e.grade === '3')!;
+      // Percentile 0 → bin 0, percentile 100 → final bin 9 (not dropped).
+      expect(gradeEntry.percentile[0]!.count).toBe(1);
+      expect(gradeEntry.percentile[9]!.count).toBe(1);
+    });
+
+    it('keeps bin edges stable when a user.grade filter narrows the population (#1782)', async () => {
+      // 5 students across two grades. Without filter, all 5 contribute to the
+      // (unfiltered) bin edges. Adding `user.grade:eq:3` filter should keep
+      // the same binStart/binEnd values — only the bin counts change.
+      const students = [
+        buildFacetStudent({ userId: 's1', grade: '3' }),
+        buildFacetStudent({ userId: 's2', grade: '3' }),
+        buildFacetStudent({ userId: 's3', grade: '3' }),
+        buildFacetStudent({ userId: 's4', grade: '4' }),
+        buildFacetStudent({ userId: 's5', grade: '4' }),
+      ];
+      const scoreRows = [
+        buildScoreRow('s1', VARIANT_ID_1, 'percentile', '10'),
+        buildScoreRow('s2', VARIANT_ID_1, 'percentile', '50'),
+        buildScoreRow('s3', VARIANT_ID_1, 'percentile', '90'),
+        buildScoreRow('s4', VARIANT_ID_1, 'percentile', '5'),
+        buildScoreRow('s5', VARIANT_ID_1, 'percentile', '95'),
+      ];
+      setupDefaultFacetsMocks(students, scoreRows);
+
+      const service = createService();
+      const unfiltered = await service.getScoreFacets(superAdminAuth, testAdministrationId, facetsQuery);
+
+      // Re-run with grade filter applied. Mocks return the same unfiltered
+      // population since they don't honor filters — that's the entire point:
+      // the service does the filtering in JS.
+      const filtered = await service.getScoreFacets(superAdminAuth, testAdministrationId, {
+        ...facetsQuery,
+        filter: [{ field: 'user.grade', operator: 'eq', value: '3' }],
+      });
+
+      const unfilteredTask = unfiltered.tasks.find((t) => t.taskId === TASK_ID_1)!;
+      const filteredTask = filtered.tasks.find((t) => t.taskId === TASK_ID_1)!;
+
+      // Bin edges identical — only counts differ.
+      const unfilteredEdges = unfilteredTask.scoreBinsByGrade[0]!.percentile.map((b) => [b.binStart, b.binEnd]);
+      const filteredEdges = filteredTask.scoreBinsByGrade[0]!.percentile.map((b) => [b.binStart, b.binEnd]);
+      expect(filteredEdges).toEqual(unfilteredEdges);
+
+      // Filter narrowed the cohort: only grade '3' present in the response.
+      expect(filteredTask.supportLevelByGrade.map((e) => e.grade)).toEqual(['3']);
+      expect(unfilteredTask.supportLevelByGrade.map((e) => e.grade)).toEqual(['3', '4']);
+    });
+
+    it('applies user.grade:gte filter with grade-ordinal semantics', async () => {
+      const students = [
+        buildFacetStudent({ userId: 's-k', grade: 'Kindergarten' }),
+        buildFacetStudent({ userId: 's-1', grade: '1' }),
+        buildFacetStudent({ userId: 's-3', grade: '3' }),
+        buildFacetStudent({ userId: 's-5', grade: '5' }),
+      ];
+      const scoreRows = [
+        buildScoreRow('s-k', VARIANT_ID_1, 'percentile', '50'),
+        buildScoreRow('s-1', VARIANT_ID_1, 'percentile', '50'),
+        buildScoreRow('s-3', VARIANT_ID_1, 'percentile', '50'),
+        buildScoreRow('s-5', VARIANT_ID_1, 'percentile', '50'),
+      ];
+      setupDefaultFacetsMocks(students, scoreRows);
+
+      const service = createService();
+      const result = await service.getScoreFacets(superAdminAuth, testAdministrationId, {
+        ...facetsQuery,
+        filter: [{ field: 'user.grade', operator: 'gte', value: '3' }],
+      });
+
+      const swrTask = result.tasks.find((t) => t.taskId === TASK_ID_1)!;
+      const grades = swrTask.supportLevelByGrade.map((e) => e.grade);
+      expect(grades).toEqual(['3', '5']);
+    });
+
+    // --- Error wrapping ---
+
+    it('wraps unexpected repository errors in a 500 ApiError', async () => {
+      mockReportRepository.getAllStudentsInScope.mockRejectedValue(new Error('connection reset'));
+
+      const service = createService();
+
+      await expect(service.getScoreFacets(superAdminAuth, testAdministrationId, facetsQuery)).rejects.toMatchObject({
+        statusCode: StatusCodes.INTERNAL_SERVER_ERROR,
+        code: ApiErrorCode.DATABASE_QUERY_FAILED,
+      });
+    });
+
+    it('re-throws ApiError without wrapping', async () => {
+      mockAdministrationRepository.getById.mockResolvedValue(null);
+
+      const service = createService();
+
+      await expect(service.getScoreFacets(superAdminAuth, testAdministrationId, facetsQuery)).rejects.toMatchObject({
+        statusCode: StatusCodes.NOT_FOUND,
+        code: ApiErrorCode.RESOURCE_NOT_FOUND,
+      });
+    });
+
+    // --- Raw-score bin path (closes a coverage gap from the initial test pass) ---
+
+    it('computes raw-score bins from the unfiltered population min/max', async () => {
+      // `swr` at grade ≥ 6 classifies via raw-score thresholds (not percentile).
+      // The bin edges come from min/max of the unfiltered rawScore values — the
+      // headline #1782 stability property only matters for raw-score bins
+      // since percentile bins are fixed 0–100 by design.
+      const students = [
+        buildFacetStudent({ userId: 's1', grade: '8' }),
+        buildFacetStudent({ userId: 's2', grade: '8' }),
+        buildFacetStudent({ userId: 's3', grade: '8' }),
+      ];
+      const scoreRows = [
+        buildScoreRow('s1', VARIANT_ID_1, 'rawScore', '100'),
+        buildScoreRow('s2', VARIANT_ID_1, 'rawScore', '500'),
+        buildScoreRow('s3', VARIANT_ID_1, 'rawScore', '700'),
+      ];
+      setupDefaultFacetsMocks(students, scoreRows);
+
+      const service = createService();
+      const result = await service.getScoreFacets(superAdminAuth, testAdministrationId, facetsQuery);
+
+      const swrTask = result.tasks.find((t) => t.taskId === TASK_ID_1)!;
+      const gradeEntry = swrTask.scoreBinsByGrade.find((e) => e.grade === '8')!;
+
+      // 20 bins of width 30 covering [100, 700].
+      expect(gradeEntry.rawScore).toHaveLength(20);
+      expect(gradeEntry.rawScore[0]!.binStart).toBe(100);
+      expect(gradeEntry.rawScore[19]!.binEnd).toBe(700);
+      // Min and max both land in a bin (last bin is closed at top).
+      const totalBinnedCount = gradeEntry.rawScore.reduce((sum, b) => sum + b.count, 0);
+      expect(totalBinnedCount).toBe(3);
+      // No percentile data → empty percentile array for this task.
+      expect(gradeEntry.percentile).toEqual([]);
+    });
+
+    it('keeps raw-score bin edges stable when a user.grade filter narrows the cohort', async () => {
+      // The headline #1782 property, exercised against the actual variable-edge
+      // bin code path (not the fixed-edge percentile path covered earlier).
+      const students = [
+        buildFacetStudent({ userId: 's-a', grade: '8' }),
+        buildFacetStudent({ userId: 's-b', grade: '8' }),
+        buildFacetStudent({ userId: 's-c', grade: '10' }),
+        buildFacetStudent({ userId: 's-d', grade: '10' }),
+      ];
+      const scoreRows = [
+        buildScoreRow('s-a', VARIANT_ID_1, 'rawScore', '50'),
+        buildScoreRow('s-b', VARIANT_ID_1, 'rawScore', '950'),
+        buildScoreRow('s-c', VARIANT_ID_1, 'rawScore', '0'), // narrowest grade-10 value
+        buildScoreRow('s-d', VARIANT_ID_1, 'rawScore', '1000'), // widest grade-10 value
+      ];
+      setupDefaultFacetsMocks(students, scoreRows);
+
+      const service = createService();
+      const unfiltered = await service.getScoreFacets(superAdminAuth, testAdministrationId, facetsQuery);
+      const filtered = await service.getScoreFacets(superAdminAuth, testAdministrationId, {
+        ...facetsQuery,
+        filter: [{ field: 'user.grade', operator: 'eq', value: '8' }],
+      });
+
+      const unfilteredTask = unfiltered.tasks.find((t) => t.taskId === TASK_ID_1)!;
+      const filteredTask = filtered.tasks.find((t) => t.taskId === TASK_ID_1)!;
+
+      // Unfiltered: bins span [0, 1000]; filtered: would naively span [50, 950]
+      // if edges were recomputed from the filtered cohort. The contract pins
+      // them at the unfiltered range — identity assertion is sufficient.
+      const unfilteredEdges = unfilteredTask.scoreBinsByGrade[0]!.rawScore.map((b) => [b.binStart, b.binEnd]);
+      const filteredEdges = filteredTask.scoreBinsByGrade
+        .find((e) => e.grade === '8')!
+        .rawScore.map((b) => [b.binStart, b.binEnd]);
+      expect(filteredEdges).toEqual(unfilteredEdges);
+      // Sanity: the filter actually narrowed the cohort.
+      expect(filteredTask.supportLevelByGrade.map((e) => e.grade)).toEqual(['8']);
+    });
+
+    it('falls back to a single-width bin when all raw scores collapse to one value', async () => {
+      const students = [
+        buildFacetStudent({ userId: 's-1', grade: '8' }),
+        buildFacetStudent({ userId: 's-2', grade: '8' }),
+      ];
+      const scoreRows = [
+        buildScoreRow('s-1', VARIANT_ID_1, 'rawScore', '500'),
+        buildScoreRow('s-2', VARIANT_ID_1, 'rawScore', '500'),
+      ];
+      setupDefaultFacetsMocks(students, scoreRows);
+
+      const service = createService();
+      const result = await service.getScoreFacets(superAdminAuth, testAdministrationId, facetsQuery);
+
+      const swrTask = result.tasks.find((t) => t.taskId === TASK_ID_1)!;
+      const gradeEntry = swrTask.scoreBinsByGrade.find((e) => e.grade === '8')!;
+      expect(gradeEntry.rawScore).toEqual([{ binStart: 500, binEnd: 501, count: 2 }]);
+    });
+
+    // --- Filter combinations (closes a coverage gap from the initial test pass) ---
+
+    it('ANDs taskId and user.grade filters', async () => {
+      const students = [
+        buildFacetStudent({ userId: 's-3', grade: '3' }),
+        buildFacetStudent({ userId: 's-4', grade: '4' }),
+      ];
+      const scoreRows = [
+        buildScoreRow('s-3', VARIANT_ID_1, 'percentile', '50'),
+        buildScoreRow('s-3', VARIANT_ID_2, 'percentile', '50'),
+        buildScoreRow('s-4', VARIANT_ID_1, 'percentile', '50'),
+      ];
+      setupDefaultFacetsMocks(students, scoreRows);
+
+      const service = createService();
+      const result = await service.getScoreFacets(superAdminAuth, testAdministrationId, {
+        ...facetsQuery,
+        filter: [
+          { field: 'taskId', operator: 'in', value: TASK_ID_1 },
+          { field: 'user.grade', operator: 'eq', value: '3' },
+        ],
+      });
+
+      // taskId filter narrows tasks to TASK_ID_1; grade filter narrows cohort
+      // to grade '3'. Both are applied (ANDed), not just one of them.
+      expect(result.tasks).toHaveLength(1);
+      expect(result.tasks[0]!.taskId).toBe(TASK_ID_1);
+      const grades = result.tasks[0]!.supportLevelByGrade.map((e) => e.grade);
+      expect(grades).toEqual(['3']);
+    });
+
+    // --- Null-supportLevel invariant (closes a coverage gap from the initial test pass) ---
+
+    it('counts a student in totalAssessed even when getSupportLevel returns null', async () => {
+      // TASK_ID_4 in the fixture has slug 'vocab' which has no scoring config,
+      // so getSupportLevel returns null. The student should still be counted
+      // in totalAssessed (they have a completed run), but no support-level
+      // bucket increments — meaning achieved + developing + needsExtra <=
+      // totalAssessed, not strict equality.
+      const students = [buildFacetStudent({ userId: 's1', grade: '3' })];
+      const scoreRows = [buildScoreRow('s1', VARIANT_ID_4, 'percentile', '50')];
+      setupDefaultFacetsMocks(students, scoreRows);
+
+      const service = createService();
+      const result = await service.getScoreFacets(superAdminAuth, testAdministrationId, facetsQuery);
+
+      const vocabTask = result.tasks.find((t) => t.taskId === TASK_ID_4)!;
+      const gradeEntry = vocabTask.supportLevelByGrade.find((e) => e.grade === '3');
+      // Either the student isn't classified (no entry at all) or they're
+      // counted with all-zero support-level buckets. Both are acceptable
+      // outcomes for an unclassifiable task; pin the property: the assertion
+      // sum <= totalAssessed must hold.
+      if (gradeEntry) {
+        const bucketed =
+          gradeEntry.achievedSkill.count + gradeEntry.developingSkill.count + gradeEntry.needsExtraSupport.count;
+        expect(bucketed).toBeLessThanOrEqual(gradeEntry.totalAssessed);
+      }
     });
   });
 

--- a/apps/backend/src/services/report/report.service.test.ts
+++ b/apps/backend/src/services/report/report.service.test.ts
@@ -47,6 +47,33 @@ const DEFAULT_DEMOGRAPHICS = {
   homeLanguage: null,
 } as const;
 
+/**
+ * Score field names — the literal strings the FDW `run_scores.scoreName`
+ * column holds. The source of truth is the per-task JSON config in
+ * `apps/backend/src/services/scoring/configs/`. We hoist them out so tests
+ * don't sprinkle magic strings, and so a future rename in the JSON
+ * surfaces as a single search-replace site (rather than a confusing pile
+ * of unrelated failures across the file).
+ *
+ * If a future task adds a new percentile / raw-score field name, add a
+ * constant here and update the relevant tests.
+ */
+const ScoreField = {
+  /**
+   * Percentile field for swr, sre, pa, and other percentile-then-rawscore
+   * tasks. Note: `swr.json` makes this version-conditional (`percentile`
+   * for scoringVersion ≥ 7, `wjPercentile` for legacy versions). Tests
+   * here use the modern (post-version-7) field name; `resolveScoreFieldNames`
+   * returns both candidates and the service walks them in priority order,
+   * so the modern name matches when `scoringVersion` is `null` or ≥ 7.
+   */
+  PERCENTILE: 'percentile',
+  /** Raw-score field for `swr` (see `services/scoring/configs/swr.json`). */
+  SWR_RAW_SCORE: 'roarScore',
+  /** Assessment-computed support level (e.g., roam-alpaca). */
+  SUPPORT_LEVEL: 'supportLevel',
+} as const;
+
 describe('ReportService', () => {
   let mockAdministrationRepository: ReturnType<typeof createMockAdministrationRepository>;
   let mockReportRepository: ReturnType<typeof createMockReportRepository>;
@@ -1417,9 +1444,9 @@ describe('ReportService', () => {
 
       // All 3 students have completed scores for swr (task-1).
       const scoreRows = [
-        buildScoreRow('student-1', VARIANT_ID_1, 'percentile', '90'),
-        buildScoreRow('student-2', VARIANT_ID_1, 'percentile', '50'),
-        buildScoreRow('student-3', VARIANT_ID_1, 'percentile', '10'),
+        buildScoreRow('student-1', VARIANT_ID_1, ScoreField.PERCENTILE, '90'),
+        buildScoreRow('student-2', VARIANT_ID_1, ScoreField.PERCENTILE, '50'),
+        buildScoreRow('student-3', VARIANT_ID_1, ScoreField.PERCENTILE, '10'),
       ];
 
       setupDefaultScoreOverviewMocks(students, scoreRows);
@@ -1446,7 +1473,7 @@ describe('ReportService', () => {
       ];
 
       // Only student-1 has scores; student-2 has no run.
-      const scoreRows = [buildScoreRow('student-1', VARIANT_ID_1, 'percentile', '50')];
+      const scoreRows = [buildScoreRow('student-1', VARIANT_ID_1, ScoreField.PERCENTILE, '50')];
 
       setupDefaultScoreOverviewMocks(students, scoreRows);
 
@@ -1523,7 +1550,7 @@ describe('ReportService', () => {
       const students = [buildOverviewStudent({ userId: 'student-1', grade: '3' })];
 
       // Student has scores on variant A only
-      const scoreRows = [buildScoreRow('student-1', 'var-a', 'percentile', '50')];
+      const scoreRows = [buildScoreRow('student-1', 'var-a', ScoreField.PERCENTILE, '50')];
 
       setupDefaultScoreOverviewMocks(students, scoreRows);
 
@@ -1565,8 +1592,8 @@ describe('ReportService', () => {
       // Student has scores on both variants — should use variant A (first in order)
       // Variant A has high percentile (achievedSkill); variant B has low (would be needsExtraSupport)
       const scoreRows = [
-        buildScoreRow('student-1', 'var-a', 'percentile', '90'),
-        buildScoreRow('student-1', 'var-b', 'percentile', '10'),
+        buildScoreRow('student-1', 'var-a', ScoreField.PERCENTILE, '90'),
+        buildScoreRow('student-1', 'var-b', ScoreField.PERCENTILE, '10'),
       ];
 
       setupDefaultScoreOverviewMocks(students, scoreRows);
@@ -1626,7 +1653,7 @@ describe('ReportService', () => {
 
     it('filters tasks by taskId when filter includes the taskId field', async () => {
       const students = [buildOverviewStudent({ userId: 'student-1', grade: '3' })];
-      const scoreRows = [buildScoreRow('student-1', VARIANT_ID_1, 'percentile', '50')];
+      const scoreRows = [buildScoreRow('student-1', VARIANT_ID_1, ScoreField.PERCENTILE, '50')];
 
       setupDefaultScoreOverviewMocks(students, scoreRows);
 
@@ -1647,7 +1674,7 @@ describe('ReportService', () => {
 
     it('passes scoring version from task variant parameters into scoring logic', async () => {
       const students = [buildOverviewStudent({ userId: 'student-1', grade: '3' })];
-      const scoreRows = [buildScoreRow('student-1', VARIANT_ID_1, 'percentile', '50')];
+      const scoreRows = [buildScoreRow('student-1', VARIANT_ID_1, ScoreField.PERCENTILE, '50')];
 
       setupDefaultScoreOverviewMocks(students, scoreRows);
       mockTaskVariantParameterRepository.getByTaskVariantIds.mockResolvedValue([
@@ -1833,7 +1860,7 @@ describe('ReportService', () => {
 
     it('ignores task variant parameters whose name is not scoringVersion', async () => {
       const students = [buildOverviewStudent({ userId: 'student-1', grade: '3' })];
-      const scoreRows = [buildScoreRow('student-1', VARIANT_ID_1, 'percentile', '45')];
+      const scoreRows = [buildScoreRow('student-1', VARIANT_ID_1, ScoreField.PERCENTILE, '45')];
 
       setupDefaultScoreOverviewMocks(students, scoreRows);
       // Param has the wrong name — should be ignored, leaving version=null (treated as 0)
@@ -1852,7 +1879,7 @@ describe('ReportService', () => {
 
     it('ignores scoringVersion values that cannot be parsed as a number', async () => {
       const students = [buildOverviewStudent({ userId: 'student-1', grade: '3' })];
-      const scoreRows = [buildScoreRow('student-1', VARIANT_ID_1, 'percentile', '45')];
+      const scoreRows = [buildScoreRow('student-1', VARIANT_ID_1, ScoreField.PERCENTILE, '45')];
 
       setupDefaultScoreOverviewMocks(students, scoreRows);
       // Non-numeric string → Number('foo') is NaN → skipped → version stays null/0
@@ -1870,7 +1897,7 @@ describe('ReportService', () => {
 
     it('accepts string-numeric scoringVersion values', async () => {
       const students = [buildOverviewStudent({ userId: 'student-1', grade: '3' })];
-      const scoreRows = [buildScoreRow('student-1', VARIANT_ID_1, 'percentile', '45')];
+      const scoreRows = [buildScoreRow('student-1', VARIANT_ID_1, ScoreField.PERCENTILE, '45')];
 
       setupDefaultScoreOverviewMocks(students, scoreRows);
       // String '7' → Number('7') = 7 → v7 cutoffs applied
@@ -1906,7 +1933,7 @@ describe('ReportService', () => {
       mockReportRepository.getTaskMetadata.mockResolvedValue([roamMeta]);
 
       const students = [buildOverviewStudent({ userId: 'student-1', grade: '3' })];
-      const scoreRows = [buildScoreRow('student-1', ROAM_VARIANT, 'supportLevel', 'achievedSkill')];
+      const scoreRows = [buildScoreRow('student-1', ROAM_VARIANT, ScoreField.SUPPORT_LEVEL, 'achievedSkill')];
 
       setupDefaultScoreOverviewMocks(students, scoreRows);
 
@@ -1926,7 +1953,7 @@ describe('ReportService', () => {
       // Newer norming tables encode extreme values as ">99" or "<1". parseScoreValue
       // strips the brackets so the score is still classifiable.
       const students = [buildOverviewStudent({ userId: 'student-1', grade: '3' })];
-      const scoreRows = [buildScoreRow('student-1', VARIANT_ID_1, 'percentile', '>99')];
+      const scoreRows = [buildScoreRow('student-1', VARIANT_ID_1, ScoreField.PERCENTILE, '>99')];
 
       setupDefaultScoreOverviewMocks(students, scoreRows);
 
@@ -1943,7 +1970,7 @@ describe('ReportService', () => {
 
     it('counts a student in totalAssessed but no support-level bucket when scores are unresolvable', async () => {
       // The student's run has score rows, but none match the swr field names
-      // (e.g., 'percentile', 'wjPercentile', 'roarScore'). getSupportLevel
+      // (e.g., ScoreField.PERCENTILE, 'wjPercentile', 'roarScore'). getSupportLevel
       // returns null → counted in totalAssessed but no bucket increments.
       const students = [buildOverviewStudent({ userId: 'student-1', grade: '3' })];
       const scoreRows = [buildScoreRow('student-1', VARIANT_ID_1, 'irrelevant', '42')];
@@ -2157,10 +2184,10 @@ describe('ReportService', () => {
         buildFacetStudent({ userId: 'student-4', grade: '4' }),
       ];
       const scoreRows = [
-        buildScoreRow('student-1', VARIANT_ID_1, 'percentile', '90'),
-        buildScoreRow('student-2', VARIANT_ID_1, 'percentile', '50'),
-        buildScoreRow('student-3', VARIANT_ID_1, 'percentile', '10'),
-        buildScoreRow('student-4', VARIANT_ID_1, 'percentile', '95'),
+        buildScoreRow('student-1', VARIANT_ID_1, ScoreField.PERCENTILE, '90'),
+        buildScoreRow('student-2', VARIANT_ID_1, ScoreField.PERCENTILE, '50'),
+        buildScoreRow('student-3', VARIANT_ID_1, ScoreField.PERCENTILE, '10'),
+        buildScoreRow('student-4', VARIANT_ID_1, ScoreField.PERCENTILE, '95'),
       ];
       setupDefaultFacetsMocks(students, scoreRows);
 
@@ -2187,10 +2214,10 @@ describe('ReportService', () => {
         buildFacetStudent({ userId: 'student-1', grade: '1' }),
       ];
       const scoreRows = [
-        buildScoreRow('student-10', VARIANT_ID_1, 'percentile', '50'),
-        buildScoreRow('student-k', VARIANT_ID_1, 'percentile', '50'),
-        buildScoreRow('student-2', VARIANT_ID_1, 'percentile', '50'),
-        buildScoreRow('student-1', VARIANT_ID_1, 'percentile', '50'),
+        buildScoreRow('student-10', VARIANT_ID_1, ScoreField.PERCENTILE, '50'),
+        buildScoreRow('student-k', VARIANT_ID_1, ScoreField.PERCENTILE, '50'),
+        buildScoreRow('student-2', VARIANT_ID_1, ScoreField.PERCENTILE, '50'),
+        buildScoreRow('student-1', VARIANT_ID_1, ScoreField.PERCENTILE, '50'),
       ];
       setupDefaultFacetsMocks(students, scoreRows);
 
@@ -2207,8 +2234,8 @@ describe('ReportService', () => {
         buildFacetStudent({ userId: 'student-no-grade', grade: null }),
       ];
       const scoreRows = [
-        buildScoreRow('student-graded', VARIANT_ID_1, 'percentile', '50'),
-        buildScoreRow('student-no-grade', VARIANT_ID_1, 'percentile', '50'),
+        buildScoreRow('student-graded', VARIANT_ID_1, ScoreField.PERCENTILE, '50'),
+        buildScoreRow('student-no-grade', VARIANT_ID_1, ScoreField.PERCENTILE, '50'),
       ];
       setupDefaultFacetsMocks(students, scoreRows);
 
@@ -2226,7 +2253,7 @@ describe('ReportService', () => {
       // backend response should preserve the raw enum value so it matches
       // sibling endpoints (overview, students).
       const students = [buildFacetStudent({ userId: 'student-k', grade: 'Kindergarten' })];
-      const scoreRows = [buildScoreRow('student-k', VARIANT_ID_1, 'percentile', '50')];
+      const scoreRows = [buildScoreRow('student-k', VARIANT_ID_1, ScoreField.PERCENTILE, '50')];
       setupDefaultFacetsMocks(students, scoreRows);
 
       const service = createService();
@@ -2245,9 +2272,9 @@ describe('ReportService', () => {
         buildFacetStudent({ userId: 'student-b1', grade: '3' }),
       ];
       const scoreRows = [
-        buildScoreRow('student-a1', VARIANT_ID_1, 'percentile', '50'),
-        buildScoreRow('student-a2', VARIANT_ID_1, 'percentile', '50'),
-        buildScoreRow('student-b1', VARIANT_ID_1, 'percentile', '50'),
+        buildScoreRow('student-a1', VARIANT_ID_1, ScoreField.PERCENTILE, '50'),
+        buildScoreRow('student-a2', VARIANT_ID_1, ScoreField.PERCENTILE, '50'),
+        buildScoreRow('student-b1', VARIANT_ID_1, ScoreField.PERCENTILE, '50'),
       ];
       const schoolsByUser = new Map<string, { schoolId: string; schoolName: string }>([
         ['student-a1', { schoolId: 'school-a-uuid', schoolName: 'Lincoln Elementary' }],
@@ -2277,8 +2304,8 @@ describe('ReportService', () => {
         buildFacetStudent({ userId: 'student-no-school', grade: '3' }),
       ];
       const scoreRows = [
-        buildScoreRow('student-with-school', VARIANT_ID_1, 'percentile', '50'),
-        buildScoreRow('student-no-school', VARIANT_ID_1, 'percentile', '50'),
+        buildScoreRow('student-with-school', VARIANT_ID_1, ScoreField.PERCENTILE, '50'),
+        buildScoreRow('student-no-school', VARIANT_ID_1, ScoreField.PERCENTILE, '50'),
       ];
       const schoolsByUser = new Map<string, { schoolId: string; schoolName: string }>([
         ['student-with-school', { schoolId: 'school-a-uuid', schoolName: 'Lincoln Elementary' }],
@@ -2304,7 +2331,7 @@ describe('ReportService', () => {
       ['group', 'group'],
     ] as const)('returns empty *BySchool arrays at %s scope', async (_label, scopeType) => {
       const students = [buildFacetStudent({ userId: 'student-1', grade: '3' })];
-      const scoreRows = [buildScoreRow('student-1', VARIANT_ID_1, 'percentile', '50')];
+      const scoreRows = [buildScoreRow('student-1', VARIANT_ID_1, ScoreField.PERCENTILE, '50')];
       setupDefaultFacetsMocks(students, scoreRows);
 
       const service = createService();
@@ -2325,7 +2352,7 @@ describe('ReportService', () => {
 
     it('returns 10 fixed percentile bins covering 0–100 with width 10', async () => {
       const students = [buildFacetStudent({ userId: 'student-1', grade: '3' })];
-      const scoreRows = [buildScoreRow('student-1', VARIANT_ID_1, 'percentile', '50')];
+      const scoreRows = [buildScoreRow('student-1', VARIANT_ID_1, ScoreField.PERCENTILE, '50')];
       setupDefaultFacetsMocks(students, scoreRows);
 
       const service = createService();
@@ -2357,8 +2384,8 @@ describe('ReportService', () => {
         buildFacetStudent({ userId: 'student-min', grade: '3' }),
       ];
       const scoreRows = [
-        buildScoreRow('student-max', VARIANT_ID_1, 'percentile', '100'),
-        buildScoreRow('student-min', VARIANT_ID_1, 'percentile', '0'),
+        buildScoreRow('student-max', VARIANT_ID_1, ScoreField.PERCENTILE, '100'),
+        buildScoreRow('student-min', VARIANT_ID_1, ScoreField.PERCENTILE, '0'),
       ];
       setupDefaultFacetsMocks(students, scoreRows);
 
@@ -2384,11 +2411,11 @@ describe('ReportService', () => {
         buildFacetStudent({ userId: 's5', grade: '4' }),
       ];
       const scoreRows = [
-        buildScoreRow('s1', VARIANT_ID_1, 'percentile', '10'),
-        buildScoreRow('s2', VARIANT_ID_1, 'percentile', '50'),
-        buildScoreRow('s3', VARIANT_ID_1, 'percentile', '90'),
-        buildScoreRow('s4', VARIANT_ID_1, 'percentile', '5'),
-        buildScoreRow('s5', VARIANT_ID_1, 'percentile', '95'),
+        buildScoreRow('s1', VARIANT_ID_1, ScoreField.PERCENTILE, '10'),
+        buildScoreRow('s2', VARIANT_ID_1, ScoreField.PERCENTILE, '50'),
+        buildScoreRow('s3', VARIANT_ID_1, ScoreField.PERCENTILE, '90'),
+        buildScoreRow('s4', VARIANT_ID_1, ScoreField.PERCENTILE, '5'),
+        buildScoreRow('s5', VARIANT_ID_1, ScoreField.PERCENTILE, '95'),
       ];
       setupDefaultFacetsMocks(students, scoreRows);
 
@@ -2424,10 +2451,10 @@ describe('ReportService', () => {
         buildFacetStudent({ userId: 's-5', grade: '5' }),
       ];
       const scoreRows = [
-        buildScoreRow('s-k', VARIANT_ID_1, 'percentile', '50'),
-        buildScoreRow('s-1', VARIANT_ID_1, 'percentile', '50'),
-        buildScoreRow('s-3', VARIANT_ID_1, 'percentile', '50'),
-        buildScoreRow('s-5', VARIANT_ID_1, 'percentile', '50'),
+        buildScoreRow('s-k', VARIANT_ID_1, ScoreField.PERCENTILE, '50'),
+        buildScoreRow('s-1', VARIANT_ID_1, ScoreField.PERCENTILE, '50'),
+        buildScoreRow('s-3', VARIANT_ID_1, ScoreField.PERCENTILE, '50'),
+        buildScoreRow('s-5', VARIANT_ID_1, ScoreField.PERCENTILE, '50'),
       ];
       setupDefaultFacetsMocks(students, scoreRows);
 
@@ -2479,9 +2506,9 @@ describe('ReportService', () => {
         buildFacetStudent({ userId: 's3', grade: '8' }),
       ];
       const scoreRows = [
-        buildScoreRow('s1', VARIANT_ID_1, 'rawScore', '100'),
-        buildScoreRow('s2', VARIANT_ID_1, 'rawScore', '500'),
-        buildScoreRow('s3', VARIANT_ID_1, 'rawScore', '700'),
+        buildScoreRow('s1', VARIANT_ID_1, ScoreField.SWR_RAW_SCORE, '100'),
+        buildScoreRow('s2', VARIANT_ID_1, ScoreField.SWR_RAW_SCORE, '500'),
+        buildScoreRow('s3', VARIANT_ID_1, ScoreField.SWR_RAW_SCORE, '700'),
       ];
       setupDefaultFacetsMocks(students, scoreRows);
 
@@ -2512,10 +2539,10 @@ describe('ReportService', () => {
         buildFacetStudent({ userId: 's-d', grade: '10' }),
       ];
       const scoreRows = [
-        buildScoreRow('s-a', VARIANT_ID_1, 'rawScore', '50'),
-        buildScoreRow('s-b', VARIANT_ID_1, 'rawScore', '950'),
-        buildScoreRow('s-c', VARIANT_ID_1, 'rawScore', '0'), // narrowest grade-10 value
-        buildScoreRow('s-d', VARIANT_ID_1, 'rawScore', '1000'), // widest grade-10 value
+        buildScoreRow('s-a', VARIANT_ID_1, ScoreField.SWR_RAW_SCORE, '50'),
+        buildScoreRow('s-b', VARIANT_ID_1, ScoreField.SWR_RAW_SCORE, '950'),
+        buildScoreRow('s-c', VARIANT_ID_1, ScoreField.SWR_RAW_SCORE, '0'), // narrowest grade-10 value
+        buildScoreRow('s-d', VARIANT_ID_1, ScoreField.SWR_RAW_SCORE, '1000'), // widest grade-10 value
       ];
       setupDefaultFacetsMocks(students, scoreRows);
 
@@ -2547,8 +2574,8 @@ describe('ReportService', () => {
         buildFacetStudent({ userId: 's-2', grade: '8' }),
       ];
       const scoreRows = [
-        buildScoreRow('s-1', VARIANT_ID_1, 'rawScore', '500'),
-        buildScoreRow('s-2', VARIANT_ID_1, 'rawScore', '500'),
+        buildScoreRow('s-1', VARIANT_ID_1, ScoreField.SWR_RAW_SCORE, '500'),
+        buildScoreRow('s-2', VARIANT_ID_1, ScoreField.SWR_RAW_SCORE, '500'),
       ];
       setupDefaultFacetsMocks(students, scoreRows);
 
@@ -2557,7 +2584,7 @@ describe('ReportService', () => {
 
       const swrTask = result.tasks.find((t) => t.taskId === TASK_ID_1)!;
       const gradeEntry = swrTask.scoreBinsByGrade.find((e) => e.grade === '8')!;
-      expect(gradeEntry.rawScore).toEqual([{ binStart: 500, binEnd: 501, count: 2 }]);
+      expect(gradeEntry.rawScore).toEqual([{ binStart: 500, binEnd: 500, count: 2 }]);
     });
 
     // --- Filter combinations (closes a coverage gap from the initial test pass) ---
@@ -2568,9 +2595,9 @@ describe('ReportService', () => {
         buildFacetStudent({ userId: 's-4', grade: '4' }),
       ];
       const scoreRows = [
-        buildScoreRow('s-3', VARIANT_ID_1, 'percentile', '50'),
-        buildScoreRow('s-3', VARIANT_ID_2, 'percentile', '50'),
-        buildScoreRow('s-4', VARIANT_ID_1, 'percentile', '50'),
+        buildScoreRow('s-3', VARIANT_ID_1, ScoreField.PERCENTILE, '50'),
+        buildScoreRow('s-3', VARIANT_ID_2, ScoreField.PERCENTILE, '50'),
+        buildScoreRow('s-4', VARIANT_ID_1, ScoreField.PERCENTILE, '50'),
       ];
       setupDefaultFacetsMocks(students, scoreRows);
 
@@ -2593,6 +2620,47 @@ describe('ReportService', () => {
 
     // --- Null-supportLevel invariant (closes a coverage gap from the initial test pass) ---
 
+    // --- District-scope school resolution edge cases (review findings #14, #15) ---
+
+    it('passes scopeId through to getSchoolsForUsers so the district ltree filter is applied', async () => {
+      // Regression guard for review finding #1: the repository's
+      // `getSchoolsForUsers(userIds, districtId)` needs `districtId` to scope
+      // its lookup to the requested district's subtree. Verify the service
+      // threads `scopeId` through rather than calling the older zero-arg form.
+      const students = [buildFacetStudent({ userId: 'student-1', grade: '3' })];
+      const scoreRows = [buildScoreRow('student-1', VARIANT_ID_1, ScoreField.PERCENTILE, '50')];
+      setupDefaultFacetsMocks(students, scoreRows);
+
+      const service = createService();
+      await service.getScoreFacets(superAdminAuth, testAdministrationId, facetsQuery);
+
+      expect(mockReportRepository.getSchoolsForUsers).toHaveBeenCalledWith(['student-1'], 'district-uuid-1');
+    });
+
+    it('puts a district-scope student with no resolvable school into *ByGrade but not *BySchool', async () => {
+      // Closes review-finding #14: at district scope, a student visible via
+      // `user_orgs` directly at the district level (no school or class
+      // membership) won't have a school in `schoolsByUser` after the ltree
+      // filter. They should still appear in the grade-faceted breakdown.
+      const students = [buildFacetStudent({ userId: 'student-no-school', grade: '3' })];
+      const scoreRows = [buildScoreRow('student-no-school', VARIANT_ID_1, ScoreField.PERCENTILE, '50')];
+      // schoolsByUser deliberately empty — simulates the post-filter result
+      // when no school in the district's subtree matches the student's
+      // enrollments.
+      setupDefaultFacetsMocks(students, scoreRows, new Map());
+
+      const service = createService();
+      const result = await service.getScoreFacets(superAdminAuth, testAdministrationId, facetsQuery);
+
+      const swrTask = result.tasks.find((t) => t.taskId === TASK_ID_1)!;
+      // Grade tally still has the student.
+      expect(swrTask.supportLevelByGrade.find((e) => e.grade === '3')!.totalAssessed).toBe(1);
+      // School tally is empty — the student didn't resolve to any school
+      // within the requested district.
+      expect(swrTask.supportLevelBySchool).toEqual([]);
+      expect(swrTask.scoreBinsBySchool).toEqual([]);
+    });
+
     it('counts a student in totalAssessed even when getSupportLevel returns null', async () => {
       // TASK_ID_4 in the fixture has slug 'vocab' which has no scoring config,
       // so getSupportLevel returns null. The student should still be counted
@@ -2600,7 +2668,7 @@ describe('ReportService', () => {
       // bucket increments — meaning achieved + developing + needsExtra <=
       // totalAssessed, not strict equality.
       const students = [buildFacetStudent({ userId: 's1', grade: '3' })];
-      const scoreRows = [buildScoreRow('s1', VARIANT_ID_4, 'percentile', '50')];
+      const scoreRows = [buildScoreRow('s1', VARIANT_ID_4, ScoreField.PERCENTILE, '50')];
       setupDefaultFacetsMocks(students, scoreRows);
 
       const service = createService();
@@ -2957,7 +3025,7 @@ describe('ReportService', () => {
         runs: new Map([
           [VARIANT_ID_1, { runId: 'run-1', reliable: true, engagementFlags: [], completedAt: new Date('2025-09-01') }],
         ]),
-        scores: new Map([[VARIANT_ID_1, new Map([['percentile', '90']])]]),
+        scores: new Map([[VARIANT_ID_1, new Map([[ScoreField.PERCENTILE, '90']])]]),
       });
       setupDefaultStudentScoresMocks([row], 1);
 
@@ -3024,8 +3092,8 @@ describe('ReportService', () => {
           [
             VARIANT_ID_1,
             new Map([
-              ['percentile', '90.7'],
-              ['roarScore', '512.4'],
+              [ScoreField.PERCENTILE, '90.7'],
+              [ScoreField.SWR_RAW_SCORE, '512.4'],
             ]),
           ],
         ]),
@@ -3074,8 +3142,8 @@ describe('ReportService', () => {
           ],
         ]),
         scores: new Map([
-          ['var-a', new Map([['percentile', '90']])],
-          ['var-b', new Map([['percentile', '10']])],
+          ['var-a', new Map([[ScoreField.PERCENTILE, '90']])],
+          ['var-b', new Map([[ScoreField.PERCENTILE, '10']])],
         ]),
       });
       setupDefaultStudentScoresMocks([row], 1);
@@ -3305,7 +3373,7 @@ describe('ReportService', () => {
       const completedScoreRow: RunScoreRow = {
         userId: targetUserId,
         taskVariantId: VARIANT_ID_1,
-        scoreName: 'percentile',
+        scoreName: ScoreField.PERCENTILE,
         scoreValue: '90',
       };
       mockReportRepository.getCompletedRunScores.mockResolvedValue([completedScoreRow]);
@@ -3457,7 +3525,7 @@ describe('ReportService', () => {
       const completedScoreRow: RunScoreRow = {
         userId: targetUserId,
         taskVariantId: VARIANT_ID_1,
-        scoreName: 'percentile',
+        scoreName: ScoreField.PERCENTILE,
         scoreValue: '50',
       };
       mockReportRepository.getCompletedRunScores.mockResolvedValue([completedScoreRow]);
@@ -3491,7 +3559,7 @@ describe('ReportService', () => {
       const completedScoreRow: RunScoreRow = {
         userId: targetUserId,
         taskVariantId: VARIANT_ID_1,
-        scoreName: 'percentile',
+        scoreName: ScoreField.PERCENTILE,
         scoreValue: '60',
       };
       mockReportRepository.getCompletedRunScores.mockResolvedValue([completedScoreRow]);
@@ -3534,8 +3602,8 @@ describe('ReportService', () => {
       ];
       mockReportRepository.getHistoricalRunsForUser.mockResolvedValue(historicalRuns);
       mockReportRepository.getScoresForRunIds.mockResolvedValue([
-        { runId: 'run-older', scoreName: 'percentile', scoreValue: '40' },
-        { runId: 'run-newer', scoreName: 'percentile', scoreValue: '50' },
+        { runId: 'run-older', scoreName: ScoreField.PERCENTILE, scoreValue: '40' },
+        { runId: 'run-newer', scoreName: ScoreField.PERCENTILE, scoreValue: '50' },
       ]);
 
       const service = createService();
@@ -3580,7 +3648,7 @@ describe('ReportService', () => {
       const completedScoreRow: RunScoreRow = {
         userId: targetUserId,
         taskVariantId: VARIANT_ID_1,
-        scoreName: 'percentile',
+        scoreName: ScoreField.PERCENTILE,
         scoreValue: '60',
       };
       mockReportRepository.getCompletedRunScores.mockResolvedValue([completedScoreRow]);
@@ -3625,8 +3693,8 @@ describe('ReportService', () => {
       ];
       mockReportRepository.getHistoricalRunsForUser.mockResolvedValue(historicalRuns);
       mockReportRepository.getScoresForRunIds.mockResolvedValue([
-        { runId: 'run-early', scoreName: 'percentile', scoreValue: '40' },
-        { runId: 'run-late', scoreName: 'percentile', scoreValue: '55' },
+        { runId: 'run-early', scoreName: ScoreField.PERCENTILE, scoreValue: '40' },
+        { runId: 'run-late', scoreName: ScoreField.PERCENTILE, scoreValue: '55' },
       ]);
 
       const service = createService();
@@ -3653,7 +3721,7 @@ describe('ReportService', () => {
       const scoreRow: RunScoreRow = {
         userId: targetUserId,
         taskVariantId: VARIANT_ID_1,
-        scoreName: 'percentile',
+        scoreName: ScoreField.PERCENTILE,
         scoreValue: '50',
       };
       mockReportRepository.getCompletedRunScores.mockResolvedValue([scoreRow]);
@@ -3883,8 +3951,8 @@ describe('ReportService', () => {
       setupDefaults();
       // Student has scores on BOTH variants — variant A wins (lower orderIndex).
       mockReportRepository.getCompletedRunScores.mockResolvedValue([
-        { userId: targetUserId, taskVariantId: 'var-a', scoreName: 'percentile', scoreValue: '90' },
-        { userId: targetUserId, taskVariantId: 'var-b', scoreName: 'percentile', scoreValue: '10' },
+        { userId: targetUserId, taskVariantId: 'var-a', scoreName: ScoreField.PERCENTILE, scoreValue: '90' },
+        { userId: targetUserId, taskVariantId: 'var-b', scoreName: ScoreField.PERCENTILE, scoreValue: '10' },
       ]);
       mockReportRepository.getCompletedRunsForUser.mockResolvedValue([
         {
@@ -3923,7 +3991,7 @@ describe('ReportService', () => {
     it('emits Reliability=Unreliable with warn severity for an unreliable run', async () => {
       setupDefaults();
       mockReportRepository.getCompletedRunScores.mockResolvedValue([
-        { userId: targetUserId, taskVariantId: VARIANT_ID_1, scoreName: 'percentile', scoreValue: '50' },
+        { userId: targetUserId, taskVariantId: VARIANT_ID_1, scoreName: ScoreField.PERCENTILE, scoreValue: '50' },
       ]);
       mockReportRepository.getCompletedRunsForUser.mockResolvedValue([
         {
@@ -3953,7 +4021,7 @@ describe('ReportService', () => {
     it('surfaces engagementFlags from the run row', async () => {
       setupDefaults();
       mockReportRepository.getCompletedRunScores.mockResolvedValue([
-        { userId: targetUserId, taskVariantId: VARIANT_ID_1, scoreName: 'percentile', scoreValue: '50' },
+        { userId: targetUserId, taskVariantId: VARIANT_ID_1, scoreName: ScoreField.PERCENTILE, scoreValue: '50' },
       ]);
       mockReportRepository.getCompletedRunsForUser.mockResolvedValue([
         {
@@ -4188,7 +4256,7 @@ describe('ReportService', () => {
     it('omits historicalScores from per-administration task entries', async () => {
       setupGuardianDefaults({ adminMetas: [ADMIN_OLDER] });
       mockReportRepository.getCompletedRunScores.mockResolvedValue([
-        { userId: targetUserId, taskVariantId: VARIANT_ID_1, scoreName: 'percentile', scoreValue: '60' },
+        { userId: targetUserId, taskVariantId: VARIANT_ID_1, scoreName: ScoreField.PERCENTILE, scoreValue: '60' },
       ]);
       mockReportRepository.getCompletedRunsForUser.mockResolvedValue([
         {
@@ -4214,9 +4282,13 @@ describe('ReportService', () => {
       // Score the swr task in both administrations: 40 in older, 60 in newer.
       mockReportRepository.getCompletedRunScores.mockImplementation(async (adminId: string) => {
         if (adminId === ADMIN_OLDER.id) {
-          return [{ userId: targetUserId, taskVariantId: VARIANT_ID_1, scoreName: 'percentile', scoreValue: '40' }];
+          return [
+            { userId: targetUserId, taskVariantId: VARIANT_ID_1, scoreName: ScoreField.PERCENTILE, scoreValue: '40' },
+          ];
         }
-        return [{ userId: targetUserId, taskVariantId: VARIANT_ID_1, scoreName: 'percentile', scoreValue: '60' }];
+        return [
+          { userId: targetUserId, taskVariantId: VARIANT_ID_1, scoreName: ScoreField.PERCENTILE, scoreValue: '60' },
+        ];
       });
       mockReportRepository.getCompletedRunsForUser.mockResolvedValue([
         {
@@ -4276,7 +4348,7 @@ describe('ReportService', () => {
         // Primary variant (lowest orderIndex) has no completed score in this admin;
         // include only the alt variant's score, which means the primary is skipped
         // and the alt becomes the scored variant.
-        { userId: targetUserId, taskVariantId: altVariantId, scoreName: 'percentile', scoreValue: '55' },
+        { userId: targetUserId, taskVariantId: altVariantId, scoreName: ScoreField.PERCENTILE, scoreValue: '55' },
       ]);
       mockReportRepository.getCompletedRunsForUser.mockResolvedValue([
         {
@@ -4303,7 +4375,7 @@ describe('ReportService', () => {
     it('emits Required + Reliability tags for completed runs', async () => {
       setupGuardianDefaults({ adminMetas: [ADMIN_OLDER] });
       mockReportRepository.getCompletedRunScores.mockResolvedValue([
-        { userId: targetUserId, taskVariantId: VARIANT_ID_1, scoreName: 'percentile', scoreValue: '70' },
+        { userId: targetUserId, taskVariantId: VARIANT_ID_1, scoreName: ScoreField.PERCENTILE, scoreValue: '70' },
       ]);
       mockReportRepository.getCompletedRunsForUser.mockResolvedValue([
         {

--- a/apps/backend/src/services/report/report.service.test.ts
+++ b/apps/backend/src/services/report/report.service.test.ts
@@ -1755,13 +1755,14 @@ describe('ReportService', () => {
       expect(result.tasks[0]!.orderIndex).toBe(0);
     });
 
-    // --- Empty-result short-circuit when taskId filter excludes all tasks ---
+    // --- Unknown taskId in filter (#1782 review follow-up: shared validation) ---
 
-    it('returns empty tasks array when taskId filter excludes every task', async () => {
-      // Filter targets a UUID not present in testTaskMetas — taskMetas becomes []
-      // and taskGroups.length === 0 triggers the short-circuit. Because the short-circuit
-      // is evaluated BEFORE the student-fetch DB call, getAllStudentsInScope is also skipped
-      // and the response carries totalStudents: 0 by definition (no tasks → no aggregation).
+    it('returns 400 when taskId filter references a UUID not assigned to the administration', async () => {
+      // Previously silent-dropped to an empty `tasks: []` response (200).
+      // `applyTaskIdFilter` now validates against the admin's actual task IDs
+      // and throws BAD_REQUEST for unknowns — matching the contract's
+      // long-standing claim that unknown task IDs in filter return 400 and
+      // aligning the three score-reporting endpoints on a single behavior.
       const students = [buildOverviewStudent({ userId: 'student-1' })];
       setupDefaultScoreOverviewMocks(students, []);
 
@@ -1771,15 +1772,14 @@ describe('ReportService', () => {
       };
 
       const service = createService();
-      const result = await service.getScoreOverview(superAdminAuth, testAdministrationId, filteredQuery);
-
-      expect(result.tasks).toHaveLength(0);
-      expect(result.totalStudents).toBe(0);
-      expect(typeof result.computedAt).toBe('string');
-      // Short-circuit means we don't touch the student-fetch path or downstream queries
+      await expect(service.getScoreOverview(superAdminAuth, testAdministrationId, filteredQuery)).rejects.toMatchObject(
+        {
+          statusCode: StatusCodes.BAD_REQUEST,
+          code: ApiErrorCode.REQUEST_VALIDATION_FAILED,
+        },
+      );
+      // Validation fires before any DB call beyond getTaskMetadata.
       expect(mockReportRepository.getAllStudentsInScope).not.toHaveBeenCalled();
-      expect(mockTaskVariantParameterRepository.getByTaskVariantIds).not.toHaveBeenCalled();
-      expect(mockReportRepository.getCompletedRunScores).not.toHaveBeenCalled();
     });
 
     it('merges multiple taskId filter entries into a single allow-list', async () => {
@@ -2914,11 +2914,12 @@ describe('ReportService', () => {
       expect(seenIds).toEqual(new Set([TASK_ID_1, TASK_ID_3]));
     });
 
-    it('returns an empty page when taskId filter excludes every task', async () => {
-      // Filter targets a UUID not present in testTaskMetas — taskMetas becomes []
-      // and the empty-task short-circuit returns immediately. No pagination query
-      // is run; totalItems is 0 by definition because no per-task entries can be
-      // assembled when no tasks are in scope.
+    it('returns 400 when taskId filter references a UUID not assigned to the administration', async () => {
+      // Previously silent-dropped to an empty page (200). `applyTaskIdFilter`
+      // now validates against the admin's actual task IDs and throws
+      // BAD_REQUEST for unknowns — matching the contract's claim that
+      // unknown task IDs in filter return 400 and aligning the three
+      // score-reporting endpoints on a single behavior.
       setupDefaultStudentScoresMocks();
 
       const filteredQuery: StudentScoresInput = {
@@ -2927,12 +2928,13 @@ describe('ReportService', () => {
       };
 
       const service = createService();
-      const result = await service.listStudentScores(superAdminAuth, testAdministrationId, filteredQuery);
-
-      expect(result.tasks).toEqual([]);
-      expect(result.items).toEqual([]);
-      expect(result.totalItems).toBe(0);
-      // Short-circuit means we don't touch the paginated row fetch or downstream queries
+      await expect(
+        service.listStudentScores(superAdminAuth, testAdministrationId, filteredQuery),
+      ).rejects.toMatchObject({
+        statusCode: StatusCodes.BAD_REQUEST,
+        code: ApiErrorCode.REQUEST_VALIDATION_FAILED,
+      });
+      // Validation fires before any downstream DB call beyond getTaskMetadata.
       expect(mockReportRepository.getStudentScores).not.toHaveBeenCalled();
       expect(mockReportRepository.getSchoolNamesForUsers).not.toHaveBeenCalled();
     });
@@ -3200,6 +3202,23 @@ describe('ReportService', () => {
       const result = await service.listStudentScores(superAdminAuth, testAdministrationId, baseQuery);
 
       expect(result.items[0]!.user.schoolName).toBe('Lincoln Elementary');
+    });
+
+    it('passes scopeId through to getSchoolNamesForUsers so the district ltree filter is applied', async () => {
+      // Regression guard for the cross-district leakage fix on
+      // getSchoolNamesForUsers (#1782 review follow-up): the service must
+      // thread `scope.scopeId` through to the repository so the school
+      // lookup is constrained to the requested district's subtree.
+      // Without it, a student enrolled cross-district could surface a
+      // foreign school's name in the response.
+      const row = buildQueryRow({ userId: 'student-1', grade: '3' });
+      setupDefaultStudentScoresMocks([row], 1);
+      mockReportRepository.getSchoolNamesForUsers.mockResolvedValue(new Map([['student-1', 'Lincoln Elementary']]));
+
+      const service = createService();
+      await service.listStudentScores(superAdminAuth, testAdministrationId, baseQuery);
+
+      expect(mockReportRepository.getSchoolNamesForUsers).toHaveBeenCalledWith(['student-1'], 'district-uuid-1');
     });
 
     it('returns null schoolName for non-district scope', async () => {

--- a/apps/backend/src/services/report/report.service.ts
+++ b/apps/backend/src/services/report/report.service.ts
@@ -69,6 +69,7 @@ import { TaskService } from '../task/task.service';
 import { AuthorizationService } from '../authorization/authorization.service';
 import { FgaType, FgaRelation } from '../authorization/fga-constants';
 import { TaskVariantParameterRepository } from '../../repositories/task-variant-parameter.repository';
+import type { TaskVariantParameter } from '../../db/schema';
 import {
   getScoringConfig,
   getSubscoresConfig,
@@ -591,15 +592,9 @@ export function ReportService({
       // 3. Get task metadata
       let taskMetas = await reportRepository.getTaskMetadata(administrationId);
 
-      // 4. Extract taskId filters (if any) and user-level filters separately.
-      // Multiple `taskId:in:...` filter entries are merged into a single allow-list —
-      // a client passing `?filter=taskId:in:a,b&filter=taskId:in:c` should see all three.
-      // Using filter().flatMap() rather than find() to avoid silently dropping later entries.
-      const taskIdFilters = filter.filter((f) => f.field === 'taskId');
-      if (taskIdFilters.length > 0) {
-        const allowedTaskIds = new Set(taskIdFilters.flatMap((f) => f.value.split(',').map((v) => v.trim())));
-        taskMetas = taskMetas.filter((t) => allowedTaskIds.has(t.taskId));
-      }
+      // 4. Apply taskId filter (multi-entry union, validates unknowns as 400 — see
+      //    `applyTaskIdFilter`) and split user-level filters out for SQL translation.
+      taskMetas = applyTaskIdFilter(taskMetas, filter);
 
       const userFilters = filter.filter((f) => f.field !== 'taskId');
       const filterCondition =
@@ -660,15 +655,7 @@ export function ReportService({
       // 7. Fetch scoring versions from task_variant_parameters
       const taskVariantIds = taskMetas.map((t) => t.taskVariantId);
       const allParams = await taskVariantParameterRepository.getByTaskVariantIds(taskVariantIds);
-      const scoringVersionByVariant = new Map<string, number>();
-      for (const param of allParams) {
-        if (param.name === 'scoringVersion') {
-          const version = typeof param.value === 'number' ? param.value : Number(param.value);
-          if (!isNaN(version)) {
-            scoringVersionByVariant.set(param.taskVariantId, version);
-          }
-        }
-      }
+      const scoringVersionByVariant = extractScoringVersions(allParams);
 
       // 8. Bulk fetch completed run scores
       const studentIds = students.map((s) => s.userId);
@@ -760,25 +747,20 @@ export function ReportService({
       );
       await authorizeScopeAccess(authContext, administrationId, scopeType, scopeId, FgaRelation.CAN_READ_SCORES);
 
-      // 2. Task metadata + taskId filter (merged across multiple entries — see
-      //    getScoreOverview for the rationale).
-      let taskMetas = await reportRepository.getTaskMetadata(administrationId);
-      const taskIdFilters = filter.filter((f) => f.field === 'taskId');
-      if (taskIdFilters.length > 0) {
-        const allowedTaskIds = new Set(taskIdFilters.flatMap((f) => f.value.split(',').map((v) => v.trim())));
-        taskMetas = taskMetas.filter((t) => allowedTaskIds.has(t.taskId));
-      }
+      // 2. Apply taskId filter (multi-entry union, validates unknowns as 400 — see
+      //    `applyTaskIdFilter`).
+      const allTaskMetas = await reportRepository.getTaskMetadata(administrationId);
+      const taskMetas = applyTaskIdFilter(allTaskMetas, filter);
 
       // 3. Group variants by taskId (multi-variant dedup, same as overview).
       const taskGroups = groupVariantsByTaskId(taskMetas);
       if (taskGroups.length === 0) {
-        // TODO(#1782 follow-up): returns totalStudents = 0 when a stale
-        // taskId:in filter excludes every task, rather than the real
-        // in-scope population. Short-circuit fires before step 4's
-        // getAllStudentsInScope call. Minor UX concern (the "X students
-        // in scope" header would lie); behavior is acceptable because
-        // the response's tasks array is also empty so the chart UI
-        // doesn't render a denominator at all.
+        // Reachable only when the administration has no task variants
+        // assigned at all — `applyTaskIdFilter` already throws 400 for
+        // unknown taskId filter values, so a stale filter can't get us
+        // here. An "empty admin" is a misconfiguration; reporting
+        // totalStudents = 0 is acceptable since there's no chart to
+        // populate.
         return { totalStudents: 0, tasks: [], computedAt: new Date().toISOString() };
       }
 
@@ -798,15 +780,7 @@ export function ReportService({
       // 5. Scoring versions per variant (drives classification cutoffs).
       const taskVariantIds = taskMetas.map((t) => t.taskVariantId);
       const allParams = await taskVariantParameterRepository.getByTaskVariantIds(taskVariantIds);
-      const scoringVersionByVariant = new Map<string, number>();
-      for (const param of allParams) {
-        if (param.name === 'scoringVersion') {
-          const version = typeof param.value === 'number' ? param.value : Number(param.value);
-          if (!isNaN(version)) {
-            scoringVersionByVariant.set(param.taskVariantId, version);
-          }
-        }
-      }
+      const scoringVersionByVariant = extractScoringVersions(allParams);
 
       // 6. Bulk-fetch completed run scores for the full unfiltered population.
       const studentIds = students.map((s) => s.userId);
@@ -908,13 +882,10 @@ export function ReportService({
       );
       await authorizeScopeAccess(authContext, administrationId, scopeType, scopeId, FgaRelation.CAN_READ_SCORES);
 
-      // 2. Get task metadata and apply taskId filter (merge multiple entries)
-      let taskMetas = await reportRepository.getTaskMetadata(administrationId);
-      const taskIdFilters = filter.filter((f) => f.field === 'taskId');
-      if (taskIdFilters.length > 0) {
-        const allowedTaskIds = new Set(taskIdFilters.flatMap((f) => f.value.split(',').map((v) => v.trim())));
-        taskMetas = taskMetas.filter((t) => allowedTaskIds.has(t.taskId));
-      }
+      // 2. Get task metadata and apply taskId filter (multi-entry union,
+      //    validates unknowns as 400 — see `applyTaskIdFilter`).
+      const allTaskMetas = await reportRepository.getTaskMetadata(administrationId);
+      const taskMetas = applyTaskIdFilter(allTaskMetas, filter);
 
       // 3. Build per-task primary variant map (lowest-orderIndex variant of each task)
       const primaryVariantByTaskId = buildPrimaryVariantMap(taskMetas);
@@ -928,15 +899,7 @@ export function ReportService({
       const taskVariantIds = taskMetas.map((t) => t.taskVariantId);
       const allParams =
         taskVariantIds.length > 0 ? await taskVariantParameterRepository.getByTaskVariantIds(taskVariantIds) : [];
-      const scoringVersionByVariant = new Map<string, number>();
-      for (const param of allParams) {
-        if (param.name === 'scoringVersion') {
-          const version = typeof param.value === 'number' ? param.value : Number(param.value);
-          if (!isNaN(version)) {
-            scoringVersionByVariant.set(param.taskVariantId, version);
-          }
-        }
-      }
+      const scoringVersionByVariant = extractScoringVersions(allParams);
 
       // 6. Resolve scoring rules per variant for SQL CASE generation in the repo
       const scoringRulesByVariant = new Map<string, ResolvedScoringRules>();
@@ -1023,10 +986,16 @@ export function ReportService({
       // 11. Build response — dedupe per taskId, classify, set optional/completed
       const tasksOrdered: ServiceTaskMetadata[] = uniqueTaskMetadataInOrder(taskMetas);
 
-      // Resolve schoolNames for district-scope rows (not auto-populated by repo for that field)
+      // Resolve schoolNames for district-scope rows (not auto-populated by
+      // repo for that field). Pass `scopeId` so the lookup is constrained to
+      // schools under the requested district — without it a student
+      // enrolled cross-district would surface a foreign school's name here.
       let schoolNamesByUser: Map<string, string> | undefined;
       if (scopeType === EntityType.DISTRICT) {
-        schoolNamesByUser = await reportRepository.getSchoolNamesForUsers(result.items.map((s) => s.userId));
+        schoolNamesByUser = await reportRepository.getSchoolNamesForUsers(
+          result.items.map((s) => s.userId),
+          scopeId,
+        );
       }
 
       // Group taskMetas by taskId once — the grouping is independent of the
@@ -1155,15 +1124,7 @@ export function ReportService({
       const taskVariantIds = taskMetas.map((t) => t.taskVariantId);
       const allParams =
         taskVariantIds.length > 0 ? await taskVariantParameterRepository.getByTaskVariantIds(taskVariantIds) : [];
-      const scoringVersionByVariant = new Map<string, number>();
-      for (const param of allParams) {
-        if (param.name === 'scoringVersion') {
-          const version = typeof param.value === 'number' ? param.value : Number(param.value);
-          if (!isNaN(version)) {
-            scoringVersionByVariant.set(param.taskVariantId, version);
-          }
-        }
-      }
+      const scoringVersionByVariant = extractScoringVersions(allParams);
 
       // 6. Fetch the student's current-admin scores, run metadata, and historical
       // runs/scores in parallel. Run metadata (reliable, engagementFlags) lives
@@ -1376,7 +1337,13 @@ export function ReportService({
         }
       }
 
-      // 3. Resolve the student's set of administrations and school name in parallel
+      // 3. Resolve the student's set of administrations and school name in
+      //    parallel. The guardian report spans the student's history across
+      //    administrations — and potentially districts — so we deliberately
+      //    omit the `districtId` filter on `getSchoolNamesForUsers` and let
+      //    the alphabetically-first ordering pick a school across all the
+      //    student's enrollments. The admin-scoped endpoints
+      //    (getStudentScores, getScoreFacets) pass scopeId to constrain.
       const [adminMetas, schoolNamesMap] = await Promise.all([
         reportRepository.getStudentAdministrations(targetUserId),
         reportRepository.getSchoolNamesForUsers([targetUserId]),
@@ -1416,15 +1383,7 @@ export function ReportService({
       );
       const allParams =
         allVariantIds.length > 0 ? await taskVariantParameterRepository.getByTaskVariantIds(allVariantIds) : [];
-      const scoringVersionByVariant = new Map<string, number>();
-      for (const param of allParams) {
-        if (param.name === 'scoringVersion') {
-          const version = typeof param.value === 'number' ? param.value : Number(param.value);
-          if (!isNaN(version)) {
-            scoringVersionByVariant.set(param.taskVariantId, version);
-          }
-        }
-      }
+      const scoringVersionByVariant = extractScoringVersions(allParams);
 
       // 6. Fetch scores + run metadata per admin in parallel.
       // Each admin only fetches its own variants; pinning queries to a single
@@ -1821,6 +1780,69 @@ interface TaskGroup {
  *
  * Exported for independent testing.
  */
+/**
+ * Apply `taskId:in:<uuids>` filters from a parsed filter list to a set of
+ * task metadata rows. Repeatable entries are unioned: a client passing
+ * `?filter=taskId:in:a,b&filter=taskId:in:c` sees all three IDs. Unknown
+ * task IDs (UUIDs not present in `taskMetas`) throw `BAD_REQUEST` — the
+ * three score-reporting endpoints (`overview`, `students`, `facets`) all
+ * promise 400 on unknown filter task IDs and previously silently dropped
+ * them instead (review follow-up on #1782).
+ *
+ * Returns the input `taskMetas` unchanged when no `taskId` filter entries
+ * are present.
+ */
+function applyTaskIdFilter(taskMetas: ReportTaskMeta[], filter: ParsedFilter[]): ReportTaskMeta[] {
+  const taskIdFilters = filter.filter((f) => f.field === 'taskId');
+  if (taskIdFilters.length === 0) return taskMetas;
+
+  const requestedTaskIds = new Set(
+    taskIdFilters.flatMap((f) =>
+      f.value
+        .split(',')
+        .map((v) => v.trim())
+        .filter((v) => v.length > 0),
+    ),
+  );
+  const knownTaskIds = new Set(taskMetas.map((t) => t.taskId));
+
+  for (const requested of requestedTaskIds) {
+    if (!knownTaskIds.has(requested)) {
+      throw new ApiError(`Unknown task ID in filter: ${requested}`, {
+        statusCode: StatusCodes.BAD_REQUEST,
+        code: ApiErrorCode.REQUEST_VALIDATION_FAILED,
+        context: { unknownTaskId: requested, knownTaskIds: Array.from(knownTaskIds) },
+      });
+    }
+  }
+
+  return taskMetas.filter((t) => requestedTaskIds.has(t.taskId));
+}
+
+/**
+ * Extract a `taskVariantId → scoringVersion` map from `task_variant_parameters`
+ * rows. Used by every score-reporting endpoint to drive version-aware score
+ * classification (`getSupportLevel` resolves cutoffs against the variant's
+ * `scoringVersion`).
+ *
+ * `Number.isInteger` rejects `NaN`, `±Infinity`, and fractional values (e.g.,
+ * a JSONB value of `'1.5'` parses to `1.5`). A `scoringVersion` is always a
+ * non-negative integer in the JSON config; surfacing data corruption here as
+ * "skip the variant" rather than coercing a fractional value into the
+ * scoring-config lookup is cheap and correct.
+ */
+function extractScoringVersions(params: TaskVariantParameter[]): Map<string, number> {
+  const map = new Map<string, number>();
+  for (const param of params) {
+    if (param.name !== 'scoringVersion') continue;
+    const version = typeof param.value === 'number' ? param.value : Number(param.value);
+    if (Number.isInteger(version)) {
+      map.set(param.taskVariantId, version);
+    }
+  }
+  return map;
+}
+
 export function groupVariantsByTaskId(taskMetas: ReportTaskMeta[]): TaskGroup[] {
   const groups = new Map<string, ReportTaskMeta[]>();
   const orderedTaskIds: string[] = [];

--- a/apps/backend/src/services/report/report.service.ts
+++ b/apps/backend/src/services/report/report.service.ts
@@ -16,6 +16,9 @@ import type {
   ScoreOverviewInput,
   ScoreOverviewResult,
   ServiceTaskScoreOverview,
+  ScoreFacetsInput,
+  ScoreFacetsResult,
+  ServiceTaskScoreFacet,
   StudentScoresInput,
   StudentScoresSortField,
   StudentScoresFilterField,
@@ -80,7 +83,7 @@ import { UserRepository } from '../../repositories/user.repository';
 import { Permissions } from '../../constants/permissions';
 import { rolesForPermission } from '../../constants/role-permissions';
 import { filterSupervisoryRoles } from '../../repositories/utils/supervisory-roles.utils';
-import { getGradeAsNumber } from '../../utils/get-grade-as-number.util';
+import { getGradeAsNumber, getGradesInRange } from '../../utils/get-grade-as-number.util';
 import { conditionToSql } from '../../utils/condition-to-sql';
 import type { Condition, ConditionEvaluationUser } from '../../types/condition';
 import type { AuthContext } from '../../types/auth-context';
@@ -646,6 +649,150 @@ export function ReportService({
       );
 
       throw new ApiError('Failed to retrieve score overview', {
+        statusCode: StatusCodes.INTERNAL_SERVER_ERROR,
+        code: ApiErrorCode.DATABASE_QUERY_FAILED,
+        context: { userId, administrationId, scopeType, scopeId },
+        cause: error,
+      });
+    }
+  }
+
+  /**
+   * Get faceted score distributions for an administration — per-task
+   * support-level counts and score-bin histograms, split by grade and (at
+   * district scope) by school. Powers the two distribution charts on the
+   * score report page (#1782).
+   *
+   * Authorization mirrors {@link getScoreOverview}: administration-level
+   * `can_read_scores` plus scope-level `can_read_scores`. The class-level
+   * FGA model already enforces that a school-rostered teacher who is not
+   * on `user_classes` for a specific class cannot access that class's
+   * scope — no extra check needed here.
+   *
+   * Bin-edge stability (#1782): bin edges are computed once per task from
+   * the UNFILTERED student population in scope, then reused under
+   * filtering. Filters narrow which cells are populated but do not change
+   * the axes. This keeps the histogram axes stable as the user toggles a
+   * `taskId` or `user.grade` filter.
+   *
+   * At non-district scopes, `supportLevelBySchool` and `scoreBinsBySchool`
+   * are returned as empty arrays. The dashboard's school-facet toggle is
+   * district-only in the UI; empty arrays let the client iterate without
+   * null-guarding.
+   *
+   * Filter applied in JS rather than SQL: bin edges must come from the
+   * unfiltered population, which forces fetching the unfiltered set
+   * anyway. Filtering once in JS over that set is cleaner than a two-pass
+   * SQL approach (one unfiltered for bin edges, one filtered for counts).
+   * It is a deliberate departure from the sibling endpoints' filter-in-SQL
+   * pattern — bounded by the in-scope population size, not by tasks ×
+   * students.
+   */
+  async function getScoreFacets(
+    authContext: AuthContext,
+    administrationId: string,
+    query: ScoreFacetsInput,
+  ): Promise<ScoreFacetsResult> {
+    const { userId } = authContext;
+    const { scopeType, scopeId, filter } = query;
+
+    try {
+      // 1. Administration-level + scope-level can_read_scores
+      await administrationService.verifyAdministrationAccess(
+        authContext,
+        administrationId,
+        FgaRelation.CAN_READ_SCORES,
+      );
+      await authorizeScopeAccess(authContext, administrationId, scopeType, scopeId, FgaRelation.CAN_READ_SCORES);
+
+      // 2. Task metadata + taskId filter (merged across multiple entries — see
+      //    getScoreOverview for the rationale).
+      let taskMetas = await reportRepository.getTaskMetadata(administrationId);
+      const taskIdFilters = filter.filter((f) => f.field === 'taskId');
+      if (taskIdFilters.length > 0) {
+        const allowedTaskIds = new Set(taskIdFilters.flatMap((f) => f.value.split(',').map((v) => v.trim())));
+        taskMetas = taskMetas.filter((t) => allowedTaskIds.has(t.taskId));
+      }
+
+      // 3. Group variants by taskId (multi-variant dedup, same as overview).
+      const taskGroups = groupVariantsByTaskId(taskMetas);
+      if (taskGroups.length === 0) {
+        return { totalStudents: 0, tasks: [], computedAt: new Date().toISOString() };
+      }
+
+      // 4. Fetch UNFILTERED population in scope. Bin edges (step 8) need the
+      //    unfiltered set per the #1782 bin-edge-stability contract; filters
+      //    are applied in JS in step 7.
+      const { totalStudents, students } = await reportRepository.getAllStudentsInScope({ scopeType, scopeId });
+
+      if (totalStudents === 0) {
+        return {
+          totalStudents,
+          tasks: taskGroups.map(({ representative }) => buildEmptyTaskFacet(representative)),
+          computedAt: new Date().toISOString(),
+        };
+      }
+
+      // 5. Scoring versions per variant (drives classification cutoffs).
+      const taskVariantIds = taskMetas.map((t) => t.taskVariantId);
+      const allParams = await taskVariantParameterRepository.getByTaskVariantIds(taskVariantIds);
+      const scoringVersionByVariant = new Map<string, number>();
+      for (const param of allParams) {
+        if (param.name === 'scoringVersion') {
+          const version = typeof param.value === 'number' ? param.value : Number(param.value);
+          if (!isNaN(version)) {
+            scoringVersionByVariant.set(param.taskVariantId, version);
+          }
+        }
+      }
+
+      // 6. Bulk-fetch completed run scores for the full unfiltered population.
+      const studentIds = students.map((s) => s.userId);
+      const scoreRows = await reportRepository.getCompletedRunScores(administrationId, studentIds, taskVariantIds);
+      const scoresByStudentTask = buildScoreLookup(scoreRows);
+
+      // 7. Apply user-level filters in JS. The contract restricts userFilters
+      //    to `user.grade` (via `SCORE_FACETS_FILTER_FIELDS`), so the JS
+      //    predicate only needs to handle that field — defensive default
+      //    rejects unknown fields if they somehow slip through.
+      const userFilters = filter.filter((f) => f.field !== 'taskId');
+      const filteredStudents =
+        userFilters.length > 0
+          ? students.filter((s) => userFilters.every((f) => studentMatchesUserFilter(s, f)))
+          : students;
+
+      // 8. School resolution at district scope. At non-district scopes the
+      //    map stays empty and `aggregateTaskFacet` emits empty *BySchool
+      //    arrays per the contract.
+      const isDistrictScope = scopeType === EntityType.DISTRICT;
+      const schoolsByUser = isDistrictScope
+        ? await reportRepository.getSchoolsForUsers(studentIds)
+        : new Map<string, { schoolId: string; schoolName: string }>();
+
+      // 9. Aggregate per task — bin edges from unfiltered, counts from filtered.
+      const tasks: ServiceTaskScoreFacet[] = taskGroups.map(({ representative, variants }) =>
+        aggregateTaskFacet({
+          representative,
+          variants,
+          unfilteredStudents: students,
+          filteredStudents,
+          scoresByStudentTask,
+          scoringVersionByVariant,
+          schoolsByUser,
+          isDistrictScope,
+        }),
+      );
+
+      return { totalStudents, tasks, computedAt: new Date().toISOString() };
+    } catch (error) {
+      if (error instanceof ApiError) throw error;
+
+      logger.error(
+        { err: error, context: { userId, administrationId, scopeType, scopeId } },
+        'Failed to retrieve score facets',
+      );
+
+      throw new ApiError('Failed to retrieve score facets', {
         statusCode: StatusCodes.INTERNAL_SERVER_ERROR,
         code: ApiErrorCode.DATABASE_QUERY_FAILED,
         context: { userId, administrationId, scopeType, scopeId },
@@ -1338,6 +1485,7 @@ export function ReportService({
     listProgressStudents,
     getProgressOverview,
     getScoreOverview,
+    getScoreFacets,
     listStudentScores,
     getIndividualStudentReport,
     getGuardianStudentReport,
@@ -1803,6 +1951,332 @@ function aggregateTaskGroup(
       developingSkill: { count: developingCount },
       needsExtraSupport: { count: needsSupportCount },
     },
+  };
+}
+
+// --- Score-facets helpers (#1782) ---
+
+/**
+ * Number of raw-score bins per task. Percentile bins are fixed at 10
+ * (width 10, covering 0–100). Raw-score bin width is computed per task
+ * from the unfiltered min/max so the histogram adapts to task scale.
+ */
+const RAW_SCORE_BIN_COUNT = 20;
+
+/** Fixed percentile bins: 10 half-open intervals covering 0–100. */
+function buildPercentileBins(): { binStart: number; binEnd: number }[] {
+  const bins: { binStart: number; binEnd: number }[] = [];
+  for (let i = 0; i < 10; i++) {
+    bins.push({ binStart: i * 10, binEnd: (i + 1) * 10 });
+  }
+  return bins;
+}
+
+/**
+ * Build raw-score bins covering `[min, max]` with `RAW_SCORE_BIN_COUNT`
+ * equal-width intervals. Returns `[]` when no scored students exist in
+ * the unfiltered population (caller emits empty bin arrays in that case);
+ * returns a single bin when all scores collapse to the same value so the
+ * histogram still renders coherently.
+ */
+function buildRawScoreBins(min: number, max: number): { binStart: number; binEnd: number }[] {
+  if (!Number.isFinite(min) || !Number.isFinite(max)) return [];
+  if (min === max) return [{ binStart: min, binEnd: min + 1 }];
+  const step = (max - min) / RAW_SCORE_BIN_COUNT;
+  const bins: { binStart: number; binEnd: number }[] = [];
+  for (let i = 0; i < RAW_SCORE_BIN_COUNT; i++) {
+    bins.push({ binStart: min + i * step, binEnd: min + (i + 1) * step });
+  }
+  return bins;
+}
+
+/**
+ * Assign a numeric value to a bin index. Bins are half-open `[binStart,
+ * binEnd)` except the last bin, which is closed at the top so the maximum
+ * observed value (and percentile = 100) falls into the final bin instead
+ * of being dropped. Returns `-1` when the value sits outside the bin
+ * range (shouldn't happen when bins are derived from min/max but
+ * defensive).
+ */
+function assignBin(value: number, bins: { binStart: number; binEnd: number }[]): number {
+  for (let i = 0; i < bins.length; i++) {
+    const { binStart, binEnd } = bins[i]!;
+    const isLast = i === bins.length - 1;
+    if (value >= binStart && (isLast ? value <= binEnd : value < binEnd)) return i;
+  }
+  return -1;
+}
+
+/**
+ * JS-side filter predicate. The contract restricts user filters on the
+ * facets endpoint to `user.grade` (via `SCORE_FACETS_FILTER_FIELDS`), so
+ * this only needs to handle that field — defensive default rejects
+ * unknowns. Mirrors the SQL semantics in `buildFilterConditions` /
+ * `getGradesInRange` so a request returning row R via this endpoint
+ * also returns row R via the overview / students endpoints when the same
+ * `user.grade` filter is applied.
+ */
+function studentMatchesUserFilter(student: StudentOverviewRow, filter: ParsedFilter): boolean {
+  if (filter.field !== 'user.grade') return false;
+  const grade = student.grade;
+  if (grade === null) return false;
+
+  switch (filter.operator) {
+    case 'eq':
+      return grade === filter.value;
+    case 'neq':
+      return grade !== filter.value;
+    case 'in':
+      return filter.value
+        .split(',')
+        .map((v) => v.trim())
+        .includes(grade);
+    case 'contains':
+      return grade.toLowerCase().includes(filter.value.toLowerCase());
+    case 'gte':
+    case 'lte': {
+      const allowed = getGradesInRange(filter.operator, filter.value);
+      return allowed !== null && allowed.includes(grade);
+    }
+    default:
+      return false;
+  }
+}
+
+/** Zero-state facet for a task with no students in scope. */
+function buildEmptyTaskFacet(task: ReportTaskMeta): ServiceTaskScoreFacet {
+  return {
+    taskId: task.taskId,
+    taskSlug: task.taskSlug,
+    taskName: task.taskName,
+    orderIndex: task.orderIndex,
+    supportLevelByGrade: [],
+    supportLevelBySchool: [],
+    scoreBinsByGrade: [],
+    scoreBinsBySchool: [],
+  };
+}
+
+/** Per-(grade or schoolId) running tally state used inside `aggregateTaskFacet`. */
+type FacetTally = {
+  totalAssessed: number;
+  achievedSkill: number;
+  developingSkill: number;
+  needsExtraSupport: number;
+  rawScoreBinCounts: number[];
+  percentileBinCounts: number[];
+};
+
+function emptyTally(rawBinLen: number, pctBinLen: number): FacetTally {
+  return {
+    totalAssessed: 0,
+    achievedSkill: 0,
+    developingSkill: 0,
+    needsExtraSupport: 0,
+    rawScoreBinCounts: new Array(rawBinLen).fill(0),
+    percentileBinCounts: new Array(pctBinLen).fill(0),
+  };
+}
+
+/** Sort grades by numeric value; unparseable grades go to the end. */
+function compareGrade(a: string, b: string): number {
+  const na = getGradeAsNumber(a) ?? Number.POSITIVE_INFINITY;
+  const nb = getGradeAsNumber(b) ?? Number.POSITIVE_INFINITY;
+  return na - nb;
+}
+
+/**
+ * Aggregate one task into a `ServiceTaskScoreFacet`. Bin edges come from
+ * the unfiltered population (`unfilteredStudents`) so axes stay stable
+ * under filtering; counts come from `filteredStudents`.
+ *
+ * Students without a scored variant are excluded from this task's
+ * breakdown — the facets endpoint reports the assessed cohort only.
+ * Students with a null grade are excluded from `*ByGrade` tallies;
+ * district-scope students with no resolvable school are excluded from
+ * `*BySchool` tallies.
+ *
+ * `rawScore` and `percentile` bins are independently empty when no
+ * scored student in the unfiltered population had that score type — a
+ * raw-only task returns `percentile: []`, a percentile-only task returns
+ * `rawScore: []` per the contract.
+ */
+function aggregateTaskFacet({
+  representative,
+  variants,
+  unfilteredStudents,
+  filteredStudents,
+  scoresByStudentTask,
+  scoringVersionByVariant,
+  schoolsByUser,
+  isDistrictScope,
+}: {
+  representative: ReportTaskMeta;
+  variants: ReportTaskMeta[];
+  unfilteredStudents: StudentOverviewRow[];
+  filteredStudents: StudentOverviewRow[];
+  scoresByStudentTask: ScoreLookup;
+  scoringVersionByVariant: Map<string, number>;
+  schoolsByUser: Map<string, { schoolId: string; schoolName: string }>;
+  isDistrictScope: boolean;
+}): ServiceTaskScoreFacet {
+  // --- 1. Compute bin edges from the unfiltered population ---
+  // We walk the unfiltered set once to find min/max raw score and to
+  // detect whether percentile is defined for this task at all. Tasks
+  // where every scored student emits null for a given score type return
+  // an empty bin array for that mode.
+  let rawScoreMin = Number.POSITIVE_INFINITY;
+  let rawScoreMax = Number.NEGATIVE_INFINITY;
+  let anyPercentileSeen = false;
+
+  for (const student of unfilteredStudents) {
+    const scored = findScoredVariant(student.userId, variants, scoresByStudentTask);
+    if (!scored) continue;
+    const gradeLevel = getGradeAsNumber(student.grade);
+    const fieldNames = resolveScoreFieldNames(scored.variant.taskSlug, gradeLevel);
+    const rawScore = resolveNumericScore(scored.scores, fieldNames.rawScoreFieldNames);
+    const percentile = resolveNumericScore(scored.scores, fieldNames.percentileFieldNames);
+    if (rawScore !== null) {
+      if (rawScore < rawScoreMin) rawScoreMin = rawScore;
+      if (rawScore > rawScoreMax) rawScoreMax = rawScore;
+    }
+    if (percentile !== null) anyPercentileSeen = true;
+  }
+
+  const rawScoreBins = buildRawScoreBins(rawScoreMin, rawScoreMax);
+  const percentileBins = anyPercentileSeen ? buildPercentileBins() : [];
+
+  // --- 2. Walk filtered students, tallying per-grade and per-school ---
+  const byGrade = new Map<string, FacetTally>();
+  const bySchool = new Map<string, FacetTally>();
+  const schoolNameById = new Map<string, string>();
+
+  for (const student of filteredStudents) {
+    const scored = findScoredVariant(student.userId, variants, scoresByStudentTask);
+    if (!scored) continue;
+
+    const scoringVersion = scoringVersionByVariant.get(scored.variant.taskVariantId) ?? null;
+    const gradeLevel = getGradeAsNumber(student.grade);
+    const fieldNames = resolveScoreFieldNames(scored.variant.taskSlug, gradeLevel);
+    const percentile = resolveNumericScore(scored.scores, fieldNames.percentileFieldNames);
+    const rawScore = resolveNumericScore(scored.scores, fieldNames.rawScoreFieldNames);
+    const assessmentSupportLevel = resolveStringScore(scored.scores, ASSESSMENT_SUPPORT_LEVEL_FIELDS);
+
+    const supportLevel = getSupportLevel({
+      grade: student.grade,
+      percentile,
+      rawScore,
+      taskSlug: scored.variant.taskSlug,
+      scoringVersion,
+      assessmentSupportLevel,
+    });
+
+    const tallyBuckets: FacetTally[] = [];
+
+    if (student.grade !== null) {
+      let tally = byGrade.get(student.grade);
+      if (!tally) {
+        tally = emptyTally(rawScoreBins.length, percentileBins.length);
+        byGrade.set(student.grade, tally);
+      }
+      tallyBuckets.push(tally);
+    }
+
+    if (isDistrictScope) {
+      const school = schoolsByUser.get(student.userId);
+      if (school) {
+        schoolNameById.set(school.schoolId, school.schoolName);
+        let tally = bySchool.get(school.schoolId);
+        if (!tally) {
+          tally = emptyTally(rawScoreBins.length, percentileBins.length);
+          bySchool.set(school.schoolId, tally);
+        }
+        tallyBuckets.push(tally);
+      }
+    }
+
+    for (const tally of tallyBuckets) {
+      tally.totalAssessed++;
+      if (supportLevel === 'achievedSkill') tally.achievedSkill++;
+      else if (supportLevel === 'developingSkill') tally.developingSkill++;
+      else if (supportLevel === 'needsExtraSupport') tally.needsExtraSupport++;
+      // null / 'optional' support levels: counted in totalAssessed but not
+      // in a support-level bucket. `optional` shouldn't surface here for
+      // students with completed runs — `getSupportLevel` returns one of
+      // the three classifiable levels (or null) when a score is present.
+
+      if (rawScore !== null && rawScoreBins.length > 0) {
+        const i = assignBin(rawScore, rawScoreBins);
+        if (i >= 0) tally.rawScoreBinCounts[i] = (tally.rawScoreBinCounts[i] ?? 0) + 1;
+      }
+      if (percentile !== null && percentileBins.length > 0) {
+        const i = assignBin(percentile, percentileBins);
+        if (i >= 0) tally.percentileBinCounts[i] = (tally.percentileBinCounts[i] ?? 0) + 1;
+      }
+    }
+  }
+
+  // --- 3. Project tallies into the response shape ---
+  const sortedGrades = Array.from(byGrade.keys()).sort(compareGrade);
+  const sortedSchoolIds = Array.from(bySchool.keys()).sort((a, b) =>
+    (schoolNameById.get(a) ?? '').localeCompare(schoolNameById.get(b) ?? ''),
+  );
+
+  const supportLevelByGrade = sortedGrades.map((grade) => {
+    const t = byGrade.get(grade)!;
+    return {
+      grade,
+      totalAssessed: t.totalAssessed,
+      achievedSkill: { count: t.achievedSkill },
+      developingSkill: { count: t.developingSkill },
+      needsExtraSupport: { count: t.needsExtraSupport },
+    };
+  });
+
+  const scoreBinsByGrade = sortedGrades.map((grade) => {
+    const t = byGrade.get(grade)!;
+    return {
+      grade,
+      rawScore: rawScoreBins.map((bin, i) => ({ ...bin, count: t.rawScoreBinCounts[i] ?? 0 })),
+      percentile: percentileBins.map((bin, i) => ({ ...bin, count: t.percentileBinCounts[i] ?? 0 })),
+    };
+  });
+
+  const supportLevelBySchool = isDistrictScope
+    ? sortedSchoolIds.map((schoolId) => {
+        const t = bySchool.get(schoolId)!;
+        return {
+          schoolId,
+          schoolName: schoolNameById.get(schoolId) ?? null,
+          totalAssessed: t.totalAssessed,
+          achievedSkill: { count: t.achievedSkill },
+          developingSkill: { count: t.developingSkill },
+          needsExtraSupport: { count: t.needsExtraSupport },
+        };
+      })
+    : [];
+
+  const scoreBinsBySchool = isDistrictScope
+    ? sortedSchoolIds.map((schoolId) => {
+        const t = bySchool.get(schoolId)!;
+        return {
+          schoolId,
+          schoolName: schoolNameById.get(schoolId) ?? null,
+          rawScore: rawScoreBins.map((bin, i) => ({ ...bin, count: t.rawScoreBinCounts[i] ?? 0 })),
+          percentile: percentileBins.map((bin, i) => ({ ...bin, count: t.percentileBinCounts[i] ?? 0 })),
+        };
+      })
+    : [];
+
+  return {
+    taskId: representative.taskId,
+    taskSlug: representative.taskSlug,
+    taskName: representative.taskName,
+    orderIndex: representative.orderIndex,
+    supportLevelByGrade,
+    supportLevelBySchool,
+    scoreBinsByGrade,
+    scoreBinsBySchool,
   };
 }
 

--- a/apps/backend/src/services/report/report.service.ts
+++ b/apps/backend/src/services/report/report.service.ts
@@ -761,12 +761,16 @@ export function ReportService({
           ? students.filter((s) => userFilters.every((f) => studentMatchesUserFilter(s, f)))
           : students;
 
-      // 8. School resolution at district scope. At non-district scopes the
-      //    map stays empty and `aggregateTaskFacet` emits empty *BySchool
-      //    arrays per the contract.
+      // 8. School resolution at district scope. The `scopeId` (the
+      //    district's UUID) is required for `getSchoolsForUsers` to apply
+      //    its ltree path filter — without it, a student enrolled in a
+      //    school outside the requested district would surface in the
+      //    per-school breakdown (review finding #1 on #1782). At non-
+      //    district scopes the map stays empty and `aggregateTaskFacet`
+      //    emits empty *BySchool arrays per the contract.
       const isDistrictScope = scopeType === EntityType.DISTRICT;
       const schoolsByUser = isDistrictScope
-        ? await reportRepository.getSchoolsForUsers(studentIds)
+        ? await reportRepository.getSchoolsForUsers(studentIds, scopeId)
         : new Map<string, { schoolId: string; schoolName: string }>();
 
       // 9. Aggregate per task — bin edges from unfiltered, counts from filtered.
@@ -1976,12 +1980,15 @@ function buildPercentileBins(): { binStart: number; binEnd: number }[] {
  * Build raw-score bins covering `[min, max]` with `RAW_SCORE_BIN_COUNT`
  * equal-width intervals. Returns `[]` when no scored students exist in
  * the unfiltered population (caller emits empty bin arrays in that case);
- * returns a single bin when all scores collapse to the same value so the
- * histogram still renders coherently.
+ * returns a single degenerate bin `[min, min]` when all scores collapse
+ * to the same value, so the histogram renders coherently without the bin
+ * label implying a wider range than the data spans. `assignBin` handles
+ * the degenerate-bin case via its "last bin is closed at the top" rule
+ * (`value >= binStart && value <= binEnd`).
  */
 function buildRawScoreBins(min: number, max: number): { binStart: number; binEnd: number }[] {
   if (!Number.isFinite(min) || !Number.isFinite(max)) return [];
-  if (min === max) return [{ binStart: min, binEnd: min + 1 }];
+  if (min === max) return [{ binStart: min, binEnd: min }];
   const step = (max - min) / RAW_SCORE_BIN_COUNT;
   const bins: { binStart: number; binEnd: number }[] = [];
   for (let i = 0; i < RAW_SCORE_BIN_COUNT; i++) {
@@ -2015,6 +2022,13 @@ function assignBin(value: number, bins: { binStart: number; binEnd: number }[]):
  * `getGradesInRange` so a request returning row R via this endpoint
  * also returns row R via the overview / students endpoints when the same
  * `user.grade` filter is applied.
+ *
+ * Parity gotchas the JS path is responsible for matching the SQL path on:
+ * - `in` drops empty values after trim, matching `buildOperatorCondition`
+ *   which uses `inArray` with the empties filtered out
+ * - invalid `gte`/`lte` reference grades (e.g., `Foobar`) throw
+ *   `BAD_REQUEST` rather than silently dropping every student — matches
+ *   the SQL path which throws when `getGradesInRange` returns null
  */
 function studentMatchesUserFilter(student: StudentOverviewRow, filter: ParsedFilter): boolean {
   if (filter.field !== 'user.grade') return false;
@@ -2030,13 +2044,20 @@ function studentMatchesUserFilter(student: StudentOverviewRow, filter: ParsedFil
       return filter.value
         .split(',')
         .map((v) => v.trim())
+        .filter((v) => v.length > 0)
         .includes(grade);
     case 'contains':
       return grade.toLowerCase().includes(filter.value.toLowerCase());
     case 'gte':
     case 'lte': {
       const allowed = getGradesInRange(filter.operator, filter.value);
-      return allowed !== null && allowed.includes(grade);
+      if (allowed === null) {
+        throw new ApiError(`Invalid grade value for ${filter.operator} filter: ${filter.value}`, {
+          statusCode: StatusCodes.BAD_REQUEST,
+          code: ApiErrorCode.REQUEST_VALIDATION_FAILED,
+        });
+      }
+      return allowed.includes(grade);
     }
     default:
       return false;
@@ -2120,20 +2141,33 @@ function aggregateTaskFacet({
   schoolsByUser: Map<string, { schoolId: string; schoolName: string }>;
   isDistrictScope: boolean;
 }): ServiceTaskScoreFacet {
-  // --- 1. Compute bin edges from the unfiltered population ---
-  // We walk the unfiltered set once to find min/max raw score and to
-  // detect whether percentile is defined for this task at all. Tasks
-  // where every scored student emits null for a given score type return
-  // an empty bin array for that mode.
+  // --- 1. Resolve each unfiltered student's scored variant once. Both
+  //         passes below reuse the cached result — `findScoredVariant`
+  //         walks every variant for a task on each call, so caching cuts
+  //         the per-student cost in half at district scale (review
+  //         finding #11 on #1782). The cache also stores the student's
+  //         numeric grade level so field-name resolution stays
+  //         grade-aware in both passes.
+  type ScoredEntry = { variant: ReportTaskMeta; scores: Map<string, string>; gradeLevel: number | null };
+  const scoredByUserId = new Map<string, ScoredEntry>();
+  for (const student of unfilteredStudents) {
+    const scored = findScoredVariant(student.userId, variants, scoresByStudentTask);
+    if (scored) {
+      scoredByUserId.set(student.userId, { ...scored, gradeLevel: getGradeAsNumber(student.grade) });
+    }
+  }
+
+  // --- 2. Compute bin edges from the unfiltered scored cohort ---
+  // Walk the cache once to find min/max raw score and to detect whether
+  // percentile is defined for this task at all. Tasks where every scored
+  // student emits null for a given score type return an empty bin array
+  // for that mode.
   let rawScoreMin = Number.POSITIVE_INFINITY;
   let rawScoreMax = Number.NEGATIVE_INFINITY;
   let anyPercentileSeen = false;
 
-  for (const student of unfilteredStudents) {
-    const scored = findScoredVariant(student.userId, variants, scoresByStudentTask);
-    if (!scored) continue;
-    const gradeLevel = getGradeAsNumber(student.grade);
-    const fieldNames = resolveScoreFieldNames(scored.variant.taskSlug, gradeLevel);
+  for (const [, scored] of scoredByUserId) {
+    const fieldNames = resolveScoreFieldNames(scored.variant.taskSlug, scored.gradeLevel);
     const rawScore = resolveNumericScore(scored.scores, fieldNames.rawScoreFieldNames);
     const percentile = resolveNumericScore(scored.scores, fieldNames.percentileFieldNames);
     if (rawScore !== null) {
@@ -2146,13 +2180,13 @@ function aggregateTaskFacet({
   const rawScoreBins = buildRawScoreBins(rawScoreMin, rawScoreMax);
   const percentileBins = anyPercentileSeen ? buildPercentileBins() : [];
 
-  // --- 2. Walk filtered students, tallying per-grade and per-school ---
+  // --- 3. Walk filtered students, tallying per-grade and per-school ---
   const byGrade = new Map<string, FacetTally>();
   const bySchool = new Map<string, FacetTally>();
   const schoolNameById = new Map<string, string>();
 
   for (const student of filteredStudents) {
-    const scored = findScoredVariant(student.userId, variants, scoresByStudentTask);
+    const scored = scoredByUserId.get(student.userId);
     if (!scored) continue;
 
     const scoringVersion = scoringVersionByVariant.get(scored.variant.taskVariantId) ?? null;

--- a/apps/backend/src/services/report/report.service.ts
+++ b/apps/backend/src/services/report/report.service.ts
@@ -772,6 +772,13 @@ export function ReportService({
       // 3. Group variants by taskId (multi-variant dedup, same as overview).
       const taskGroups = groupVariantsByTaskId(taskMetas);
       if (taskGroups.length === 0) {
+        // TODO(#1782 follow-up): returns totalStudents = 0 when a stale
+        // taskId:in filter excludes every task, rather than the real
+        // in-scope population. Short-circuit fires before step 4's
+        // getAllStudentsInScope call. Minor UX concern (the "X students
+        // in scope" header would lie); behavior is acceptable because
+        // the response's tasks array is also empty so the chart UI
+        // doesn't render a denominator at all.
         return { totalStudents: 0, tasks: [], computedAt: new Date().toISOString() };
       }
 
@@ -2324,7 +2331,7 @@ function aggregateTaskFacet({
     }
   }
 
-  // --- 3. Project tallies into the response shape ---
+  // --- 4. Project tallies into the response shape ---
   const sortedGrades = Array.from(byGrade.keys()).sort(compareGrade);
   const sortedSchoolIds = Array.from(bySchool.keys()).sort((a, b) =>
     (schoolNameById.get(a) ?? '').localeCompare(schoolNameById.get(b) ?? ''),

--- a/apps/backend/src/services/report/report.service.ts
+++ b/apps/backend/src/services/report/report.service.ts
@@ -766,13 +766,17 @@ export function ReportService({
     const { scopeType, scopeId, filter } = query;
 
     try {
-      // 1. Administration-level + scope-level can_read_scores
-      await administrationService.verifyAdministrationAccess(
+      // 1. Administration-level + scope-level can_read_scores.
+      //    `verifyAdministrationAccess` returns the admin record so we can
+      //    thread `adminWindow` through the admin-aware overlap predicate
+      //    introduced by #1792.
+      const administration = await administrationService.verifyAdministrationAccess(
         authContext,
         administrationId,
         FgaRelation.CAN_READ_SCORES,
       );
       await authorizeScopeAccess(authContext, administrationId, scopeType, scopeId, FgaRelation.CAN_READ_SCORES);
+      const adminWindow = toReportAdminWindow(administration);
 
       // 2. Apply taskId filter (multi-entry union, validates unknowns as 400 — see
       //    `applyTaskIdFilter`).
@@ -793,8 +797,14 @@ export function ReportService({
 
       // 4. Fetch UNFILTERED population in scope. Bin edges (step 8) need the
       //    unfiltered set per the #1782 bin-edge-stability contract; filters
-      //    are applied in JS in step 7.
-      const { totalStudents, students } = await reportRepository.getAllStudentsInScope({ scopeType, scopeId });
+      //    are applied in JS in step 7. The admin window is threaded through
+      //    so the strict overlap predicate is applied (#1792); facets does
+      //    not accept the `includeUnenrolledStudents` toggle, so the default
+      //    `false` is correct — see the #1782 ticket for the rationale.
+      const { totalStudents, students } = await reportRepository.getAllStudentsInScope(
+        { scopeType, scopeId },
+        adminWindow,
+      );
 
       if (totalStudents === 0) {
         return {

--- a/apps/backend/src/services/report/report.types.ts
+++ b/apps/backend/src/services/report/report.types.ts
@@ -388,9 +388,9 @@ export interface ServiceTaskScoreFacet {
   taskSlug: string;
   taskName: string;
   orderIndex: number;
-  supportLevelByGrade: ServiceSupportLevelDistribution & { grade: string; totalAssessed: number };
+  supportLevelByGrade: (ServiceSupportLevelDistribution & { grade: string; totalAssessed: number })[];
   supportLevelBySchool:
-    | (ServiceSupportLevelDistribution & { schoolId: string; schoolName: string | undefined; totalAssessed: number })
+    | (ServiceSupportLevelDistribution & { schoolId: string; schoolName: string | undefined; totalAssessed: number })[]
     | null;
   scoreBinsByGrade: {
     grade: string;

--- a/apps/backend/src/services/report/report.types.ts
+++ b/apps/backend/src/services/report/report.types.ts
@@ -133,6 +133,7 @@ export interface ScoreOverviewInput {
 export interface ScoreFacetsInput {
   scopeType: ScopeType;
   scopeId: string;
+  filter: ParsedFilter[];
 }
 
 /** Support level distribution counts for a single category. */
@@ -383,28 +384,44 @@ interface ServiceScoreBin {
   count: number;
 }
 
+/**
+ * Per-task aggregation in `ScoreFacetsResult`.
+ *
+ * `*BySchool` arrays are always returned (never null). They are empty
+ * arrays at non-district scope — the dashboard's school-facet toggle is
+ * district-only, so callers can iterate without null-guarding. The
+ * contract types these the same way (`z.array(...)`, not `.nullable()`).
+ *
+ * `schoolName` is nullable because it is a derived field — for a user
+ * whose org membership doesn't resolve to a school name, the column is
+ * null. Matches `ReportUserInfoSchema.schoolName` convention.
+ *
+ * `grade` uses the raw `users.grade` string (`Kindergarten`, `1`...`12`,
+ * etc.), matching the score-overview and student-scores endpoints so the
+ * frontend can join across them without remapping.
+ */
 export interface ServiceTaskScoreFacet {
   taskId: string;
   taskSlug: string;
   taskName: string;
   orderIndex: number;
   supportLevelByGrade: (ServiceSupportLevelDistribution & { grade: string; totalAssessed: number })[];
-  supportLevelBySchool:
-    | (ServiceSupportLevelDistribution & { schoolId: string; schoolName: string | undefined; totalAssessed: number })[]
-    | null;
+  supportLevelBySchool: (ServiceSupportLevelDistribution & {
+    schoolId: string;
+    schoolName: string | null;
+    totalAssessed: number;
+  })[];
   scoreBinsByGrade: {
     grade: string;
     rawScore: ServiceScoreBin[];
     percentile: ServiceScoreBin[];
   }[];
-  scoreBinsBySchool:
-    | {
-        schoolId: string;
-        schoolName: string | undefined;
-        rawScore: ServiceScoreBin[];
-        percentile: ServiceScoreBin[];
-      }[]
-    | null;
+  scoreBinsBySchool: {
+    schoolId: string;
+    schoolName: string | null;
+    rawScore: ServiceScoreBin[];
+    percentile: ServiceScoreBin[];
+  }[];
 }
 
 /** Return type for getScoreFacets. */

--- a/apps/backend/src/services/report/report.types.ts
+++ b/apps/backend/src/services/report/report.types.ts
@@ -129,9 +129,21 @@ export interface ScoreOverviewInput {
   filter: ParsedFilter[];
 }
 
+/** Query input for getScoreFacets. */
+export interface ScoreFacetsInput {
+  scopeType: ScopeType;
+  scopeId: string;
+}
+
 /** Support level distribution counts for a single category. */
 export interface ServiceSupportLevelEntry {
   count: number;
+}
+
+interface ServiceSupportLevelDistribution {
+  achievedSkill: ServiceSupportLevelEntry;
+  developingSkill: ServiceSupportLevelEntry;
+  needsExtraSupport: ServiceSupportLevelEntry;
 }
 
 /** Per-task score overview with support level distribution. */
@@ -148,17 +160,12 @@ export interface ServiceTaskScoreOverview {
     optional: number;
   };
   /** Support level distribution (only for assessed students) */
-  supportLevels: {
-    achievedSkill: ServiceSupportLevelEntry;
-    developingSkill: ServiceSupportLevelEntry;
-    needsExtraSupport: ServiceSupportLevelEntry;
-  };
+  supportLevels: ServiceSupportLevelDistribution;
 }
 
-/** Return type for getScoreOverview. */
-export interface ScoreOverviewResult {
+interface ScoreReportResult<T> {
   totalStudents: number;
-  tasks: ServiceTaskScoreOverview[];
+  tasks: T[];
   /** ISO 8601 timestamp when the aggregation was computed */
   computedAt: string;
 }
@@ -364,3 +371,41 @@ export interface GuardianStudentReportResult {
   administrations: ServiceGuardianAdministrationEntry[];
   longitudinalScores: Record<string, ServiceHistoricalScore[]>;
 }
+
+// --- Score facets / distribution ---
+
+/** Return type for getScoreOverview. */
+export type ScoreOverviewResult = ScoreReportResult<ServiceTaskScoreOverview>;
+
+interface ServiceScoreBin {
+  binStart: number;
+  binEnd: number;
+  count: number;
+}
+
+export interface ServiceTaskScoreFacet {
+  taskId: string;
+  taskSlug: string;
+  taskName: string;
+  orderIndex: number;
+  supportLevelByGrade: ServiceSupportLevelDistribution & { grade: string; totalAssessed: number };
+  supportLevelBySchool:
+    | (ServiceSupportLevelDistribution & { schoolId: string; schoolName: string | undefined; totalAssessed: number })
+    | null;
+  scoreBinsByGrade: {
+    grade: string;
+    rawScore: ServiceScoreBin[];
+    percentile: ServiceScoreBin[];
+  }[];
+  scoreBinsBySchool:
+    | {
+        schoolId: string;
+        schoolName: string | undefined;
+        rawScore: ServiceScoreBin[];
+        percentile: ServiceScoreBin[];
+      }[]
+    | null;
+}
+
+/** Return type for getScoreFacets. */
+export type ScoreFacetsResult = ScoreReportResult<ServiceTaskScoreFacet>;

--- a/apps/backend/src/services/report/report.types.ts
+++ b/apps/backend/src/services/report/report.types.ts
@@ -438,5 +438,22 @@ export interface ServiceTaskScoreFacet {
   }[];
 }
 
-/** Return type for getScoreFacets. */
-export type ScoreFacetsResult = ScoreReportResult<ServiceTaskScoreFacet>;
+/**
+ * Return type for getScoreFacets.
+ *
+ * Standalone rather than `ScoreReportResult<ServiceTaskScoreFacet>` because
+ * the facets endpoint does not expose `exclusions` — the rostering-ended
+ * exclusion count belongs to the list endpoints whose result rows are
+ * paginated against a denominator the user sees. The facets payload is a
+ * fixed-size aggregation; surfacing an exclusion count here would invite
+ * a wrong interpretation (e.g., "Lincoln Elementary's per-grade chart
+ * excludes 7 students" — but those 7 students wouldn't have been visible
+ * in the chart even without rostering-ended). Mirror the contract shape
+ * in `ScoreFacetsResponseSchema` exactly.
+ */
+export interface ScoreFacetsResult {
+  totalStudents: number;
+  tasks: ServiceTaskScoreFacet[];
+  /** ISO 8601 timestamp when the aggregation was computed */
+  computedAt: string;
+}

--- a/apps/backend/src/test-support/repositories/report.repository.ts
+++ b/apps/backend/src/test-support/repositories/report.repository.ts
@@ -19,6 +19,7 @@ export function createMockReportRepository(): MockedObject<ReportRepository> {
     getAllStudentsInScope: vi.fn(),
     getCompletedRunScores: vi.fn(),
     getSchoolNamesForUsers: vi.fn(),
+    getSchoolsForUsers: vi.fn(),
     getStudentScores: vi.fn(),
     verifyStudentInScope: vi.fn(),
     getHistoricalRunsForUser: vi.fn(),

--- a/packages/api-contract/src/v1/administrations/reports/scores/contract.ts
+++ b/packages/api-contract/src/v1/administrations/reports/scores/contract.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 import {
   ScoreOverviewQuerySchema,
   ScoreOverviewResponseSchema,
+  ScoreDistributionResponseSchema,
   StudentScoresQuerySchema,
   StudentScoresResponseSchema,
   IndividualStudentReportQuerySchema,
@@ -126,7 +127,7 @@ export const ScoreReportsContract = c.router({
     pathParams: z.object({ id: z.string().uuid() }),
     query: ScoreOverviewQuerySchema,
     responses: {
-      200: SuccessEnvelopeSchema(ScoreOverviewResponseSchema),
+      200: SuccessEnvelopeSchema(ScoreDistributionResponseSchema),
       400: ErrorEnvelopeSchema,
       401: ErrorEnvelopeSchema,
       403: ErrorEnvelopeSchema,

--- a/packages/api-contract/src/v1/administrations/reports/scores/contract.ts
+++ b/packages/api-contract/src/v1/administrations/reports/scores/contract.ts
@@ -1,9 +1,9 @@
 import { initContract } from '@ts-rest/core';
 import { z } from 'zod';
-import { ReportScopeQuerySchema } from '../common';
 import {
   ScoreOverviewQuerySchema,
   ScoreOverviewResponseSchema,
+  ScoreFacetsQuerySchema,
   ScoreFacetsResponseSchema,
   StudentScoresQuerySchema,
   StudentScoresResponseSchema,
@@ -126,7 +126,7 @@ export const ScoreReportsContract = c.router({
     method: 'GET',
     path: '/:id/reports/scores/facets',
     pathParams: z.object({ id: z.string().uuid() }),
-    query: ReportScopeQuerySchema,
+    query: ScoreFacetsQuerySchema,
     responses: {
       200: SuccessEnvelopeSchema(ScoreFacetsResponseSchema),
       400: ErrorEnvelopeSchema,
@@ -139,12 +139,21 @@ export const ScoreReportsContract = c.router({
     summary: 'Get score distribution facets for an administration',
     description:
       'Returns aggregated support level, raw score, and percentile distributions per task for all students in scope. ' +
-      'Includes grade-level and school-level aggregations. ' +
-      'Not paginated — aggregates across the full population. ' +
-      'Scoped to a specific org, class, or group via scopeType/scopeId.\n\n' +
+      'Includes grade-level and school-level aggregations. At non-district scopes, the school-faceted arrays ' +
+      "(`supportLevelBySchool`, `scoreBinsBySchool`) are returned as empty arrays — the dashboard's school-facet " +
+      'toggle is district-only.\n\n' +
+      'Not paginated — aggregates across the full population. Scoped to a specific org, class, or group via ' +
+      'scopeType/scopeId.\n\n' +
+      'Bin edges are computed once per task from the unfiltered student population in scope, then reused under ' +
+      'filtering — toggling a `taskId` or `user.grade` filter narrows which bars are populated without redrawing ' +
+      'the axis.\n\n' +
+      'Filter support matches what `/reports/scores/overview` actually implements today: `taskId:in` and ' +
+      '`user.grade` (eq/neq/in/gte/lte/contains; gte/lte are grade-ordinal via the shared grade utility). ' +
+      '`user.schoolName` filtering is deferred to a follow-up PR that fixes the overview + students + facets ' +
+      'endpoints in one pass.\n\n' +
       'Status codes:\n' +
       '- 200: Aggregated statistics returned successfully\n' +
-      '- 400: Invalid scope (scopeId not assigned to this administration)\n' +
+      '- 400: Invalid scope (scopeId not assigned to this administration), unknown task ID in filter, or invalid filter\n' +
       '- 401: Missing or invalid authentication token\n' +
       '- 403: User lacks can_read_scores at the requested administration or scope level\n' +
       '- 404: Administration not found\n' +

--- a/packages/api-contract/src/v1/administrations/reports/scores/contract.ts
+++ b/packages/api-contract/src/v1/administrations/reports/scores/contract.ts
@@ -1,9 +1,10 @@
 import { initContract } from '@ts-rest/core';
 import { z } from 'zod';
+import { ReportScopeQuerySchema } from '../common';
 import {
   ScoreOverviewQuerySchema,
   ScoreOverviewResponseSchema,
-  ScoreDistributionResponseSchema,
+  ScoreFacetsResponseSchema,
   StudentScoresQuerySchema,
   StudentScoresResponseSchema,
   IndividualStudentReportQuerySchema,
@@ -121,13 +122,13 @@ export const ScoreReportsContract = c.router({
       '- 404: Administration not found, or student not in scope (or rostering-ended)\n' +
       '- 500: Internal server error',
   },
-  getScoreDistributions: {
+  getScoreFacets: {
     method: 'GET',
     path: '/:id/reports/scores/facets',
     pathParams: z.object({ id: z.string().uuid() }),
-    query: ScoreOverviewQuerySchema,
+    query: ReportScopeQuerySchema,
     responses: {
-      200: SuccessEnvelopeSchema(ScoreDistributionResponseSchema),
+      200: SuccessEnvelopeSchema(ScoreFacetsResponseSchema),
       400: ErrorEnvelopeSchema,
       401: ErrorEnvelopeSchema,
       403: ErrorEnvelopeSchema,
@@ -137,7 +138,8 @@ export const ScoreReportsContract = c.router({
     strictStatusCodes: true,
     summary: 'Get score distribution facets for an administration',
     description:
-      'Returns aggregated support level distributions per task for all students in scope. ' +
+      'Returns aggregated support level, raw score, and percentile distributions per task for all students in scope. ' +
+      'Includes grade-level and school-level aggregations. ' +
       'Not paginated — aggregates across the full population. ' +
       'Scoped to a specific org, class, or group via scopeType/scopeId.\n\n' +
       'Status codes:\n' +

--- a/packages/api-contract/src/v1/administrations/reports/scores/contract.ts
+++ b/packages/api-contract/src/v1/administrations/reports/scores/contract.ts
@@ -120,4 +120,31 @@ export const ScoreReportsContract = c.router({
       '- 404: Administration not found, or student not in scope (or rostering-ended)\n' +
       '- 500: Internal server error',
   },
+  getScoreDistributions: {
+    method: 'GET',
+    path: '/:id/reports/scores/facets',
+    pathParams: z.object({ id: z.string().uuid() }),
+    query: ScoreOverviewQuerySchema,
+    responses: {
+      200: SuccessEnvelopeSchema(ScoreOverviewResponseSchema),
+      400: ErrorEnvelopeSchema,
+      401: ErrorEnvelopeSchema,
+      403: ErrorEnvelopeSchema,
+      404: ErrorEnvelopeSchema,
+      500: ErrorEnvelopeSchema,
+    },
+    strictStatusCodes: true,
+    summary: 'Get score distribution facets for an administration',
+    description:
+      'Returns aggregated support level distributions per task for all students in scope. ' +
+      'Not paginated — aggregates across the full population. ' +
+      'Scoped to a specific org, class, or group via scopeType/scopeId.\n\n' +
+      'Status codes:\n' +
+      '- 200: Aggregated statistics returned successfully\n' +
+      '- 400: Invalid scope (scopeId not assigned to this administration)\n' +
+      '- 401: Missing or invalid authentication token\n' +
+      '- 403: User lacks can_read_scores at the requested administration or scope level\n' +
+      '- 404: Administration not found\n' +
+      '- 500: Internal server error',
+  },
 });

--- a/packages/api-contract/src/v1/administrations/reports/scores/contract.ts
+++ b/packages/api-contract/src/v1/administrations/reports/scores/contract.ts
@@ -40,7 +40,7 @@ export const ScoreReportsContract = c.router({
       'Scoped to a specific org, class, or group via scopeType/scopeId.\n\n' +
       'Status codes:\n' +
       '- 200: Aggregated statistics returned successfully\n' +
-      '- 400: Invalid scope (scopeId not assigned to this administration)\n' +
+      '- 400: Invalid scope (scopeId not assigned to this administration), or unknown task ID in filter\n' +
       '- 401: Missing or invalid authentication token\n' +
       '- 403: User lacks can_read_scores at the requested administration or scope level\n' +
       '- 404: Administration not found\n' +

--- a/packages/api-contract/src/v1/administrations/reports/scores/schema.ts
+++ b/packages/api-contract/src/v1/administrations/reports/scores/schema.ts
@@ -39,6 +39,12 @@ export const SupportLevelEntrySchema = z.object({
 
 export type SupportLevelEntry = z.infer<typeof SupportLevelEntrySchema>;
 
+const SupportLevelSchema = z.object({
+  achievedSkill: SupportLevelEntrySchema,
+  developingSkill: SupportLevelEntrySchema,
+  needsExtraSupport: SupportLevelEntrySchema,
+});
+
 /**
  * Per-task score overview with support level distribution.
  */
@@ -51,11 +57,7 @@ export const TaskScoreOverviewSchema = ReportTaskMetadataSchema.extend({
     optional: z.number().int(),
   }),
   /** Support level distribution (only for assessed students) */
-  supportLevels: z.object({
-    achievedSkill: SupportLevelEntrySchema,
-    developingSkill: SupportLevelEntrySchema,
-    needsExtraSupport: SupportLevelEntrySchema,
-  }),
+  supportLevels: SupportLevelSchema,
 });
 
 export type TaskScoreOverview = z.infer<typeof TaskScoreOverviewSchema>;
@@ -375,3 +377,54 @@ export type IndividualStudentReportResponse = z.infer<typeof IndividualStudentRe
 export const IndividualStudentReportQuerySchema = ReportScopeQuerySchema;
 
 export type IndividualStudentReportQuery = z.infer<typeof IndividualStudentReportQuerySchema>;
+
+/**
+ * Schemas part of the score distribution response
+ */
+const SupportLevelByGradeSchema = SupportLevelSchema.extend({
+  grade: z.string(),
+  totalAssessed: z.number().int(),
+});
+
+// AMY TODO: Why is it optional for schoolName?
+const SupportLevelBySchoolSchema = SupportLevelSchema.extend({
+  schoolId: z.string().uuid(),
+  schoolName: z.string().nullable().optional(),
+  totalAssessed: z.number().int(),
+});
+
+const ScoreBinSchema = z.object({
+  binStart: z.number(),
+  binEnd: z.number(),
+  count: z.number().int(),
+});
+
+const ScoreBinsByGradeSchema = z.object({
+  grade: z.string(),
+  rawScore: z.array(ScoreBinSchema),
+  percentile: z.array(ScoreBinSchema),
+});
+
+const ScoreBinsBySchoolSchema = z.object({
+  schoolId: z.string().uuid(),
+  schoolName: z.string().nullable().optional(),
+  rawScore: z.array(ScoreBinSchema),
+  percentile: z.array(ScoreBinSchema),
+});
+
+const TaskScoreDistributionSchema = ReportTaskMetadataSchema.extend({
+  supportLevelByGrade: z.array(SupportLevelByGradeSchema),
+  supportLevelBySchool: z.array(SupportLevelBySchoolSchema),
+  scoreBinsByGrade: z.array(ScoreBinsByGradeSchema),
+  scoreBinsBySchool: z.array(ScoreBinsBySchoolSchema),
+});
+
+/**
+ * Response schema for score distribution facets endpoint
+ */
+export const ScoreDistributionResponseSchema = z.object({
+  totalStudents: z.number().int(),
+  tasks: z.array(TaskScoreDistributionSchema),
+  /** Server timestamp when the aggregation was computed (ISO 8601) */
+  computedAt: z.string().datetime(),
+});

--- a/packages/api-contract/src/v1/administrations/reports/scores/schema.ts
+++ b/packages/api-contract/src/v1/administrations/reports/scores/schema.ts
@@ -378,18 +378,54 @@ export const IndividualStudentReportQuerySchema = ReportScopeQuerySchema;
 
 export type IndividualStudentReportQuery = z.infer<typeof IndividualStudentReportQuerySchema>;
 
+// --- Score Facets schemas ---
+
 /**
- * Schemas part of the score distribution response
+ * Filter fields for the score facets endpoint. Matches the actual filter
+ * surface of `/reports/scores/overview` so callers can transfer queries
+ * between the two endpoints without translation.
+ *
+ * - `taskId`: limit which tasks are included in the aggregation (`in` operator)
+ * - `user.grade`: filter the student population by grade before aggregation
+ *
+ * Note: `user.schoolName` filtering is deferred to a follow-up that fixes
+ * the overview + students + facets endpoints in one pass (per #1782 ticket
+ * rewrite). Aliased to `SCORE_OVERVIEW_FILTER_FIELDS` for now; split the
+ * alias when divergence becomes necessary.
+ */
+export const SCORE_FACETS_FILTER_FIELDS = SCORE_OVERVIEW_FILTER_FIELDS;
+
+export type ScoreFacetsFilterField = (typeof SCORE_FACETS_FILTER_FIELDS)[number];
+
+/**
+ * Query schema for the score facets endpoint.
+ * Combines scope and filter parameters. Not paginated — this is an aggregation.
+ */
+export const ScoreFacetsQuerySchema = ReportScopeQuerySchema.merge(createFilterQuerySchema(SCORE_FACETS_FILTER_FIELDS));
+
+export type ScoreFacetsQuery = z.infer<typeof ScoreFacetsQuerySchema>;
+
+/**
+ * Per-grade aggregation entry. Each entry covers students with a completed
+ * run for the task at the given grade. `grade` uses the raw `users.grade`
+ * representation (`Kindergarten`, `1`...`12`, etc.) — matches sibling
+ * endpoints so the frontend can join across them without remapping.
  */
 const SupportLevelByGradeSchema = SupportLevelSchema.extend({
   grade: z.string(),
   totalAssessed: z.number().int(),
 });
 
-// AMY TODO: Why is it optional for schoolName?
+/**
+ * Per-school aggregation entry. `schoolName` is nullable because it is a
+ * derived field — see `ReportUserInfoSchema` for the precedent. The entry
+ * itself is always present when the school appears in the aggregation;
+ * the field is nullable for users whose org/class membership can't resolve
+ * a school name.
+ */
 const SupportLevelBySchoolSchema = SupportLevelSchema.extend({
   schoolId: z.string().uuid(),
-  schoolName: z.string().nullable().optional(),
+  schoolName: z.string().nullable(),
   totalAssessed: z.number().int(),
 });
 
@@ -407,16 +443,23 @@ const ScoreBinsByGradeSchema = z.object({
 
 const ScoreBinsBySchoolSchema = z.object({
   schoolId: z.string().uuid(),
-  schoolName: z.string(),
+  schoolName: z.string().nullable(),
   rawScore: z.array(ScoreBinSchema),
   percentile: z.array(ScoreBinSchema),
 });
 
+/**
+ * Per-task aggregation. The `*BySchool` arrays are intentionally returned
+ * as empty arrays at non-district scope (the dashboard's school-facet
+ * toggle is district-only in the UI), not as null and not omitted — this
+ * keeps the contract shape stable and lets callers iterate without
+ * null-guarding.
+ */
 const TaskScoreFacetSchema = ReportTaskMetadataSchema.extend({
   supportLevelByGrade: z.array(SupportLevelByGradeSchema),
-  supportLevelBySchool: z.array(SupportLevelBySchoolSchema).nullable(),
+  supportLevelBySchool: z.array(SupportLevelBySchoolSchema),
   scoreBinsByGrade: z.array(ScoreBinsByGradeSchema),
-  scoreBinsBySchool: z.array(ScoreBinsBySchoolSchema).nullable(),
+  scoreBinsBySchool: z.array(ScoreBinsBySchoolSchema),
 });
 
 /**

--- a/packages/api-contract/src/v1/administrations/reports/scores/schema.ts
+++ b/packages/api-contract/src/v1/administrations/reports/scores/schema.ts
@@ -412,7 +412,7 @@ const ScoreBinsBySchoolSchema = z.object({
   percentile: z.array(ScoreBinSchema),
 });
 
-const TaskScoreDistributionSchema = ReportTaskMetadataSchema.extend({
+const TaskScoreFacetSchema = ReportTaskMetadataSchema.extend({
   supportLevelByGrade: z.array(SupportLevelByGradeSchema),
   supportLevelBySchool: z.array(SupportLevelBySchoolSchema),
   scoreBinsByGrade: z.array(ScoreBinsByGradeSchema),
@@ -422,9 +422,9 @@ const TaskScoreDistributionSchema = ReportTaskMetadataSchema.extend({
 /**
  * Response schema for score distribution facets endpoint
  */
-export const ScoreDistributionResponseSchema = z.object({
+export const ScoreFacetsResponseSchema = z.object({
   totalStudents: z.number().int(),
-  tasks: z.array(TaskScoreDistributionSchema),
+  tasks: z.array(TaskScoreFacetSchema),
   /** Server timestamp when the aggregation was computed (ISO 8601) */
   computedAt: z.string().datetime(),
 });

--- a/packages/api-contract/src/v1/administrations/reports/scores/schema.ts
+++ b/packages/api-contract/src/v1/administrations/reports/scores/schema.ts
@@ -407,16 +407,16 @@ const ScoreBinsByGradeSchema = z.object({
 
 const ScoreBinsBySchoolSchema = z.object({
   schoolId: z.string().uuid(),
-  schoolName: z.string().nullable().optional(),
+  schoolName: z.string(),
   rawScore: z.array(ScoreBinSchema),
   percentile: z.array(ScoreBinSchema),
 });
 
 const TaskScoreFacetSchema = ReportTaskMetadataSchema.extend({
   supportLevelByGrade: z.array(SupportLevelByGradeSchema),
-  supportLevelBySchool: z.array(SupportLevelBySchoolSchema),
+  supportLevelBySchool: z.array(SupportLevelBySchoolSchema).nullable(),
   scoreBinsByGrade: z.array(ScoreBinsByGradeSchema),
-  scoreBinsBySchool: z.array(ScoreBinsBySchoolSchema),
+  scoreBinsBySchool: z.array(ScoreBinsBySchoolSchema).nullable(),
 });
 
 /**


### PR DESCRIPTION
## Summary

This PR adds `GET /v1/administrations/:administrationId/reports/scores/facets`, a new score reporting endpoint that returns per-task faceted distributions of support levels and score histograms split by grade and (at district scope) by school. It powers the two distribution charts at the bottom of the score-report page in the dashboard. Resolves [1782](https://github.com/yeatmanlab/roar-project-management/issues/1782)

The branch was started by @amyyeung17 with the initial contract + types scaffolding (5 commits); the remaining commits reconcile the contract/types against the rewritten ticket, and implements the service / repository / route / controller layers plus a unit + integration test suite.

## What the endpoint returns

Per task, four arrays — all always present, never null:

- `supportLevelByGrade` — counts of students classified into the three support levels (`achievedSkill` / `developingSkill` / `needsExtraSupport`), bucketed by `users.grade` (raw enum form: `Kindergarten`, `1`–`12`, etc., matching sibling endpoints)
- `supportLevelBySchool` — same but bucketed by school, with `schoolId` for stable client-side keying and `schoolName: string | null`
- `scoreBinsByGrade` — parallel `rawScore` and `percentile` bin arrays per grade, with `{ binStart, binEnd, count }` entries
- `scoreBinsBySchool` — same, per school

At the response root: `totalStudents` (the full in-scope population, matching what `/reports/scores/students` would paginate over) and `computedAt` (ISO timestamp).

```mermaid
flowchart LR
  s([request]) --> auth[admin + scope FGA]
  auth --> u[fetch UNFILTERED population in scope]
  u --> b[compute bin edges per task<br/>min/max from unfiltered scores]
  u --> sf[apply user.grade filter in JS]
  sf --> agg[aggregate per task ×<br/>grade × school]
  b --> agg
  agg --> r([response])
```

## Bin-edge stability

The headline correctness property of this endpoint: bin edges (`binStart` / `binEnd`) are computed once per task from the **unfiltered** student population in scope. Applying a `taskId:in` or `user.grade` filter narrows which cells are populated but does not change the axes. A request with no filter and a request with a filter return the same `binStart` / `binEnd` values; only the `count` values differ.

This is enforced in the service: `getAllStudentsInScope` is called with no `filterCondition`, then the `user.grade` filter is applied in JS to derive the cohort that drives the counts. The unfiltered cohort drives bin edges (`aggregateTaskFacet` walks it once to find raw-score min/max and whether percentile is populated).

Percentile bins are fixed (10 bins of width 10, covering 0–100); raw-score bins are computed from the unfiltered task min/max with `RAW_SCORE_BIN_COUNT = 20`. Bins are half-open `[binStart, binEnd)` except the last bin, which is closed at the top so the maximum observed value (and percentile = 100) lands in the final bin.

## Aggregation in JS rather than SQL (deliberate divergence)

Two pieces of this endpoint could in principle be pushed to SQL — the `user.grade` filter and the bin-edge / per-(grade × school) aggregation — but are deliberately implemented in JavaScript instead. Below is the reasoning and an honest accounting of where the codebase's existing patterns sit.

**The siblings' positions are mixed.** `/reports/scores/overview` does score resolution and support-level classification entirely in JS via the scoring service (`getSupportLevel`, `resolveScoreFieldNames`, `resolveNumericScore`). `/reports/scores/students` is a hybrid: it does *response-payload* classification in JS (same path as overview) **and** builds per-variant SQL `CASE` expressions for sort/filter against `scores.<taskId>.supportLevel` via `resolveScoringRulesForVariant`. The precedent for SQL-side classification therefore exists for ordering, but neither sibling does the full "resolve + classify + aggregate" pipeline in SQL.

**Source-of-truth duplication.** Score-field resolution (which column holds `swr`'s raw score? `roarScore`. Version-conditional. Per-task.) and the branching in `getSupportLevel` (percentile-vs-raw-score path, version-resolved cutoffs, grade-bucket boundary) are non-trivial business logic that lives in the scoring service backed by JSON config in `apps/backend/src/services/scoring/configs/`. `resolveScoringRulesForVariant` already pre-resolves these into a form a repository can build SQL from — so the duplication concern is partially mitigated by existing infrastructure. Still, every endpoint that takes the SQL path adds a code path that has to be kept in sync.

**Bin-filter ordering is the same either way.** `width_bucket` would do the binning, but bin edges still have to come from the unfiltered cohort and the `user.grade` filter still has to apply only to counts. The SQL shape doesn't simplify the bin-stability contract.

**Performance.** The bottleneck under the current approach is the FDW round-trip for `run_scores` rows, not the in-JS aggregation. At 50K students × ~10 tasks the wire cost dominates; moving aggregation to SQL saves tens of milliseconds of JS work but not the data transit. The meaningful performance win lives one layer down, where a materialized resolved-scores table would let *all three endpoints* skip both the FDW pull and the per-request resolution.

**Net decision.** Keep JS to ship the endpoint without introducing a divergent SQL path. If we later want SQL-backed aggregation, the right scope is "migrate the three score-reporting endpoints together onto a materialized resolved-scores view", not "do it one endpoint at a time". See the deferred follow-up below.

The JS implementation:

- `getAllStudentsInScope` is called with the captured admin window (so #1786's strict overlap applies) but with no `filterCondition` — bin edges must come from the unfiltered population per the bin-stability contract.
- `studentMatchesUserFilter` applies `user.grade` in JS to derive the cohort that drives counts. `taskId:in` is applied to `taskMetas` before student fetching; the contract's `createFilterQuerySchema(SCORE_FACETS_FILTER_FIELDS)` rejects every other field at the Zod layer.
- `gte` / `lte` route through the same `getGradesInRange` helper the SQL path uses, so semantics stay consistent across endpoints.
- `aggregateTaskFacet` walks the unfiltered cohort once for bin edges, walks the filtered cohort once for tallies (with `findScoredVariant` cached between the two passes), then projects into the response shape.

## Filter scope

The endpoint accepts the filters that `/reports/scores/overview` *actually* implements today, not what its earlier contract advertised:

- `taskId:in:<uuids>` — repeatable, entries are unioned (matches overview behavior)
- `user.grade:eq` / `:neq` / `:in` / `:gte` / `:lte` / `:contains` — `gte`/`lte` are grade-ordinal via `getGradesInRange`

`user.schoolName` filtering is **deferred to a follow-on PR**. Overview doesn't support it; `/reports/scores/students` advertises it in the contract but its service rejects with 400. Adding it here would create a third inconsistent implementation; the follow-on PR will fix overview + students + facets in one pass.

Grade values are the raw `users.grade` strings (`Kindergarten`, `1`–`12`, etc.), not the display-normalized `K`/`1`/... form. Passing display-form values returns 400. This matches `/reports/scores/overview` and `/reports/scores/students` so the dashboard can join across endpoints without remapping.

## Non-district scopes return empty `*BySchool` arrays

At school / class / group scope, `supportLevelBySchool` and `scoreBinsBySchool` are returned as **empty arrays**, not null and not omitted. The dashboard's school-facet toggle is district-only (gated `v-if="orgType === 'district'"` in `TaskReport.vue`); the school dimension is unreachable through the UI at other scopes. Empty arrays let the frontend iterate without null-guarding. The school-resolution repository call (`getSchoolsForUsers`) is skipped entirely at non-district scopes.

## Authorization

Identical to `/reports/scores/overview`:

1. `verifyAdministrationAccess(..., FgaRelation.CAN_READ_SCORES)` — administration-level
2. `authorizeScopeAccess(..., FgaRelation.CAN_READ_SCORES)` — scope-level

The FGA model already enforces that class-level `educator_tier` does **not** inherit from the parent school. A school-rostered teacher who is not directly on `user_classes` for class C cannot read C's scope, even when C is inside their school. No additional service-level check is needed; the integration suite includes a regression test (`school-rostered teacher requesting an unassigned class within their school returns 403`) that pins this.

## Admin-aware overlap (inherited from #1786)

The merge from `project/backend-refactor` brought in #1786 (admin-aware enrollment overlap, issue [1792](https://github.com/yeatmanlab/roar-project-management/issues/1792)), which made `getAllStudentsInScope`'s `admin: ReportAdminWindow` parameter required. The facets endpoint captures the administration record from `verifyAdministrationAccess` (which #1786 changed to return it), projects it via `toReportAdminWindow(administration)`, and threads it through. With the admin window passed, `buildStudentInScopeQuery` applies the strict overlap predicate (`enrollment.start <= LEAST(admin.dateEnd, NOW()) AND enrollment.end > LEAST(admin.dateEnd, NOW()) OR enrollment.end IS NULL`) — so a past-administration's report now correctly includes the students who were actually enrolled during the admin's window, not whoever happens to be enrolled today.

Facets deliberately does **not** accept the `includeUnenrolledStudents` toggle that #1786 added to the four list-style reporting endpoints — the ticket scopes it as "strict-only" because the facets payload is a fixed-size aggregation, not a paginated list whose denominator the user can see. If product wants the toggle here later, revisit alongside overview rather than diverging.

## Repository

One new method: `getSchoolsForUsers(userIds): Map<userId, { schoolId, schoolName }>`. Mirrors the existing `getSchoolNamesForUsers` (used by the per-student endpoint at district scope) but additionally returns the `schoolId` for client-side keying. Both methods use NOW-based enrollment deliberately — the row-level `user_orgs` schema has no historical school snapshot, so a past-admin report at district scope shows a transferred student's *current* school name. Documented on `getSchoolNamesForUsers`'s JSDoc (#1786 caveat). If a `user_org_history` table ever lands, both methods get updated together.

## Files

```
apps/backend/src/
  services/report/
    report.service.ts            # new getScoreFacets + helpers
                                  # (aggregateTaskFacet, buildPercentileBins,
                                  #  buildRawScoreBins, assignBin,
                                  #  studentMatchesUserFilter, compareGrade)
    report.service.test.ts       # new describe('getScoreFacets')
    report.types.ts              # ServiceTaskScoreFacet, ScoreFacetsResult,
                                  # ScoreFacetsInput (with filter: ParsedFilter[])
  repositories/
    report.repository.ts         # new getSchoolsForUsers
  controllers/
    administrations.controller.ts # new getScoreFacets thin handler
    administrations.controller.test.ts # add getScoreFacets to ReportService mock
    users.controller.test.ts          # add getScoreFacets to ReportService mock
  routes/
    administrations.ts           # register getScoreFacets handler
    reports.integration.test.ts  # new describe('GET .../scores/facets')
  test-support/repositories/
    report.repository.ts         # add getSchoolsForUsers to mock factory

packages/api-contract/src/v1/administrations/reports/scores/
  schema.ts                      # ScoreFacetsQuerySchema (taskId + user.grade),
                                  # ScoreFacetsResponseSchema, sub-schemas
                                  # (schoolName nullable, *BySchool arrays
                                  #  always present)
  contract.ts                    # getScoreFacets route
```

## Test coverage

**Unit** (`report.service.test.ts → getScoreFacets`):

- 5 authorization tests (admin 404, admin 403, scope 400, scope 403, super-admin bypass)
- 2 shape tests (empty population, computedAt parseable)
- 2 filter routing tests (`taskId:in` narrowing, multi-entry union)
- 4 per-grade aggregation tests (counts, ordinal sort, null grades excluded, raw enum preserved)
- 2 per-school aggregation tests (counts with schoolId, no-school students excluded) + a regression guard that the service passes `scopeId` through to `getSchoolsForUsers` so its ltree filter is applied
- 1 parametric "empty `*BySchool` at school/class/group" test
- 1 "district student with no resolvable school appears in `*ByGrade` but not `*BySchool`" test
- 4 percentile bin tests (10 fixed bins, empty when no percentile, percentile=100 lands in final bin, **bin-edge stability under filter** for percentile)
- 3 raw-score bin tests (end-to-end edges from unfiltered min/max for `swr` at grade ≥ 6, **bin-edge stability under filter** for variable-edge bins, `min === max` single-point bin fallback)
- 1 multi-filter AND test (`taskId:in` + `user.grade:eq`)
- 1 null-supportLevel invariant test (`<= totalAssessed` rather than strict equality for tasks with no scoring config)
- 1 grade-ordinal `gte` filter test
- 2 error-wrapping tests

**Integration** (`reports.integration.test.ts → GET .../scores/facets`):

- Full authorization matrix: 401, super-admin, admin, site-admin, principal at school, principal at district = 403, educator at district = 403, student/caregiver = 403, cross-district admin = 403, class teacher → school scope = 403, **school-rostered teacher → unassigned class = 403** (FGA class-level non-inheritance regression guard)
- 4 scope-validation tests (unassigned scope, missing scopeType, missing scopeId, non-existent admin)
- 1 contract-level filter rejection test (`user.schoolName` returns 400)
- Response shape at district / school / class / group scopes; verifies empty `*BySchool` at the three non-district scopes
- 4 FDW-backed aggregation tests using `RunFactory` + `RunScoreFactory`: per-grade tally, per-school schoolId mapping, **bin-edge stability under filter end-to-end** (for percentile), totalStudents matches population

Score field names used in tests are hoisted into a `ScoreField` namespace at the top of the test file (with JSDoc pointing at the JSON config files in `services/scoring/configs/`) rather than scattered as magic-string literals. The constants are test-local rather than scoring-service exports to avoid introducing a parallel source of truth with the JSON config.

## Deferred follow-ups (from review)

Review findings filed for visibility rather than fixed in this PR:

- **Variant-slug heterogeneity within a `taskGroup`.** `aggregateTaskGroup` (and the new `aggregateTaskFacet`) use the representative variant's `taskSlug` in the response but resolve bin field names from each scored student's actual variant. If a future task ever has variants with different slugs (e.g., grade-specific scoring families), the response advertises one slug while bin edges were drawn from heterogeneous score scales. This is a pre-existing shape inherited from `getScoreOverview`, not new in this PR.
- **`schoolName: z.string().nullable()` as dead-code defense.** `orgs.name` is `NOT NULL` and the repository's inner join means the `?? null` branch can never fire today. Kept nullable to match `ReportUserInfoSchema` precedent for cross-endpoint consistency.
- **Narrow `getAllStudentsInScope` projection.** The repository currently returns full `StudentOverviewRow` (DOB, race, ethnicity, etc.) for every in-scope student. The facets endpoint only consumes `userId` and `grade`. A narrower repo method would reduce PII transit and improve performance at district scale. Out of scope for this PR.
- **Migrate score-reporting aggregation to a SQL-backed pipeline.** All three endpoints (`overview`, `students`, `facets`) currently resolve scores and classify support levels in JS via the scoring service. The natural step at the next performance ceiling is a materialized `(user_id, task_id, raw_score, percentile, support_level)` view — recomputed from `run_scores` on trial events (#1745 lays adjacent groundwork) — that all three endpoints can `GROUP BY` and `width_bucket()` over without duplicating scoring logic in SQL. Tracked separately so the three endpoints migrate together rather than facets diverging in isolation.

Resolves [1782](https://github.com/yeatmanlab/roar-project-management/issues/1782)

## Types of changes

What types of changes does this pull request introduce?

<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (non-breaking change that does not add functionality but makes code cleaner or more efficient)
- [ ] Documentation Update
- [x] Tests (new or updated tests)
- [ ] Style (changes to code styling)
- [ ] CI (continuous integration changes)
- [ ] Repository Maintenance
- [ ] Other (please describe below)

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask.  We're here
to help! This is simply a reminder of what we are going to look for before
merging your code.
-->

- [x] I have read the [guidelines for contributing](https://github.com/yeatmanlab/roar-dashboard/blob/main/.github/CONTRIBUTING.md).
- [x] The changes in this PR are as small as they can be. They represent one and only one fix or enhancement.
- [x] Linting checks pass with my changes.
- [x] Any existing unit tests pass with my changes.
- [x] Any existing end-to-end tests pass with my changes.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] If this PR fixes an existing issue, I have added a unit or end-to-end test that will detect if this issue reoccurs.
- [x] I have added JSDoc comments as appropriate.
- [ ] I have added the necessary documentation to the [roar-docs repository](https://github.com/yeatmanlab/roar-docs).
- [x] I have shared this PR on the roar-pr-reviews channel (if I have access)
- [x] I have linked relevant issues (if any)