### PR TITLE
Add RunScoresRepository with natural-key upsert

### DIFF
--- a/apps/backend/migrations/assessment/0021_add_run_scores_natural_key_unique.sql
+++ b/apps/backend/migrations/assessment/0021_add_run_scores_natural_key_unique.sql
@@ -1,0 +1,23 @@
+-- Add a natural-key UNIQUE constraint on app.run_scores so we can use
+-- INSERT ... ON CONFLICT (run_id, type, domain, name, assessment_stage) DO UPDATE
+-- to upsert score rows from the writeTrial path.
+--
+-- The constraint also enforces the read-path invariant in report.repository.ts that
+-- assumes at most one current score row per natural key — drift here would silently
+-- corrupt reporting.
+--
+-- assessment_stage is nullable. Without NULLS NOT DISTINCT, two rows with identical
+-- (run_id, type, domain, name) and a NULL assessment_stage would both be allowed
+-- (Postgres treats NULL as distinct in unique constraints by default). NULLS NOT
+-- DISTINCT (Postgres 15+) makes NULLs equal for uniqueness purposes.
+--
+-- Pre-flight: this migration will fail if duplicates already exist. Run
+--   SELECT run_id, type, domain, name, assessment_stage, COUNT(*)
+--   FROM app.run_scores
+--   GROUP BY 1, 2, 3, 4, 5
+--   HAVING COUNT(*) > 1;
+-- against the target environment first and remediate before applying.
+
+ALTER TABLE "app"."run_scores"
+  ADD CONSTRAINT "run_scores_natural_key_unique"
+  UNIQUE NULLS NOT DISTINCT ("run_id", "type", "domain", "name", "assessment_stage");

--- a/apps/backend/migrations/assessment/0022_add_platform_admin_to_user_role.sql
+++ b/apps/backend/migrations/assessment/0022_add_platform_admin_to_user_role.sql
@@ -1,0 +1,11 @@
+-- Add `platform_admin` to the assessment-side `user_role` enum.
+--
+-- The shared Drizzle enum definition in `apps/backend/src/db/schema/enums.ts` already
+-- includes `platform_admin`, and the core DB has the equivalent migration
+-- (core/0062_young_tomas.sql), but the assessment-side migration was never generated.
+-- This brings the two enum copies back in sync.
+--
+-- Surfaced incidentally by `db:gen:assess` while validating the run_scores natural-key
+-- unique constraint migration (0021).
+
+ALTER TYPE "app"."user_role" ADD VALUE 'platform_admin' BEFORE 'principal';

--- a/apps/backend/migrations/assessment/meta/0021_snapshot.json
+++ b/apps/backend/migrations/assessment/meta/0021_snapshot.json
@@ -1,0 +1,895 @@
+{
+  "id": "a1314e7c-0697-4a39-9023-3becff80bdcb",
+  "prevId": "b2c3d4e5-f6a7-4b8c-9d0e-1f2a3b4c5d6e",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "app.runs": {
+      "name": "runs",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "task_variant_id": {
+          "name": "task_variant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "task_version": {
+          "name": "task_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "administration_id": {
+          "name": "administration_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "use_for_reporting": {
+          "name": "use_for_reporting",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "reliable_run": {
+          "name": "reliable_run",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "engagement_flags": {
+          "name": "engagement_flags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_anonymous": {
+          "name": "is_anonymous",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aborted_at": {
+          "name": "aborted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_by": {
+          "name": "deleted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "runs_user_administration_task_idx": {
+          "name": "runs_user_administration_task_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "administration_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "task_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runs_user_id_idx": {
+          "name": "runs_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runs_user_reporting_run_idx": {
+          "name": "runs_user_reporting_run_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"app\".\"runs\".\"use_for_reporting\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "runs_deleted_by_required": {
+          "name": "runs_deleted_by_required",
+          "value": "\"app\".\"runs\".\"deleted_at\" IS NULL OR \"app\".\"runs\".\"deleted_by\" IS NOT NULL"
+        },
+        "runs_anonymous_administration_id": {
+          "name": "runs_anonymous_administration_id",
+          "value": "(\"app\".\"runs\".\"is_anonymous\" = true AND \"app\".\"runs\".\"administration_id\" = '00000000-0000-0000-0000-000000000000'::uuid) OR (\"app\".\"runs\".\"is_anonymous\" = false AND \"app\".\"runs\".\"administration_id\" != '00000000-0000-0000-0000-000000000000'::uuid)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "app.run_trials": {
+      "name": "run_trials",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assessment_stage": {
+          "name": "assessment_stage",
+          "type": "assessment_stage",
+          "typeSchema": "app",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "audio_feedback": {
+          "name": "audio_feedback",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "block": {
+          "name": "block",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "block_id": {
+          "name": "block_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "button_response": {
+          "name": "button_response",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "corpus_id": {
+          "name": "corpus_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "correct": {
+          "name": "correct",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "correct_response": {
+          "name": "correct_response",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "difficulty": {
+          "name": "difficulty",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "goal": {
+          "name": "goal",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "internal_node_id": {
+          "name": "internal_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "item": {
+          "name": "item",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "keyboard_response": {
+          "name": "keyboard_response",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "realpseudo": {
+          "name": "realpseudo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response": {
+          "name": "response",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response_input": {
+          "name": "response_input",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response_source": {
+          "name": "response_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response_time_ms": {
+          "name": "response_time_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_time_unix": {
+          "name": "start_time_unix",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stim": {
+          "name": "stim",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stimulus": {
+          "name": "stimulus",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stimulus_rule": {
+          "name": "stimulus_rule",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "story": {
+          "name": "story",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subtask": {
+          "name": "subtask",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "theta_estimate": {
+          "name": "theta_estimate",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "theta_estimate2": {
+          "name": "theta_estimate2",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "theta_std_err": {
+          "name": "theta_std_err",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "theta_std_err2": {
+          "name": "theta_std_err2",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thetas": {
+          "name": "thetas",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "theta_std_errs": {
+          "name": "theta_std_errs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "item_parameters": {
+          "name": "item_parameters",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "time_elapsed": {
+          "name": "time_elapsed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trial_num_block": {
+          "name": "trial_num_block",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trial_num_total": {
+          "name": "trial_num_total",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trial_index": {
+          "name": "trial_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trial_type": {
+          "name": "trial_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "truefalse": {
+          "name": "truefalse",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "word": {
+          "name": "word",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "run_trials_run_id_idx": {
+          "name": "run_trials_run_id_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "run_trials_run_trial_idx": {
+          "name": "run_trials_run_trial_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "trial_index",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "run_trials_run_id_runs_id_fk": {
+          "name": "run_trials_run_id_runs_id_fk",
+          "tableFrom": "run_trials",
+          "tableTo": "runs",
+          "schemaTo": "app",
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.run_trial_interactions": {
+      "name": "run_trial_interactions",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "trial_id": {
+          "name": "trial_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "interaction_type": {
+          "name": "interaction_type",
+          "type": "trial_interaction_type",
+          "typeSchema": "app",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "time_ms": {
+          "name": "time_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "run_trial_interactions_trial_id_idx": {
+          "name": "run_trial_interactions_trial_id_idx",
+          "columns": [
+            {
+              "expression": "trial_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "run_trial_interactions_trial_id_run_trials_id_fk": {
+          "name": "run_trial_interactions_trial_id_run_trials_id_fk",
+          "tableFrom": "run_trial_interactions",
+          "tableTo": "run_trials",
+          "schemaTo": "app",
+          "columnsFrom": ["trial_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.run_scores": {
+      "name": "run_scores",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "score_type",
+          "typeSchema": "app",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "domain": {
+          "name": "domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assessment_stage": {
+          "name": "assessment_stage",
+          "type": "assessment_stage",
+          "typeSchema": "app",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category_score": {
+          "name": "category_score",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "run_scores_run_id_idx": {
+          "name": "run_scores_run_id_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "run_scores_run_id_type_idx": {
+          "name": "run_scores_run_id_type_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "run_scores_run_id_runs_id_fk": {
+          "name": "run_scores_run_id_runs_id_fk",
+          "tableFrom": "run_scores",
+          "tableTo": "runs",
+          "schemaTo": "app",
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "run_scores_natural_key_unique": {
+          "name": "run_scores_natural_key_unique",
+          "nullsNotDistinct": true,
+          "columns": ["run_id", "type", "domain", "name", "assessment_stage"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "app.agreement_type": {
+      "name": "agreement_type",
+      "schema": "app",
+      "values": ["tos", "assent", "consent"]
+    },
+    "app.assessment_stage": {
+      "name": "assessment_stage",
+      "schema": "app",
+      "values": ["practice", "test"]
+    },
+    "app.assignment_progress": {
+      "name": "assignment_progress",
+      "schema": "app",
+      "values": ["assigned", "started", "completed"]
+    },
+    "app.auth_provider": {
+      "name": "auth_provider",
+      "schema": "app",
+      "values": ["password", "google", "oidc.clever", "oidc.classlink", "oidc.nycps"]
+    },
+    "app.class_type": {
+      "name": "class_type",
+      "schema": "app",
+      "values": ["homeroom", "scheduled", "other"]
+    },
+    "app.free_reduced_lunch_status": {
+      "name": "free_reduced_lunch_status",
+      "schema": "app",
+      "values": ["Free", "Reduced", "Paid"]
+    },
+    "app.grade": {
+      "name": "grade",
+      "schema": "app",
+      "values": [
+        "1",
+        "2",
+        "3",
+        "4",
+        "5",
+        "6",
+        "7",
+        "8",
+        "9",
+        "10",
+        "11",
+        "12",
+        "13",
+        "PreKindergarten",
+        "TransitionalKindergarten",
+        "Kindergarten",
+        "InfantToddler",
+        "Preschool",
+        "PostGraduate",
+        "Ungraded",
+        "Other",
+        ""
+      ]
+    },
+    "app.group_type": {
+      "name": "group_type",
+      "schema": "app",
+      "values": ["cohort", "community", "business"]
+    },
+    "app.org_type": {
+      "name": "org_type",
+      "schema": "app",
+      "values": ["national", "state", "local", "district", "school", "department"]
+    },
+    "app.rostering_entity_status": {
+      "name": "rostering_entity_status",
+      "schema": "app",
+      "values": ["enrolled", "unenrolled", "failed", "skipped"]
+    },
+    "app.rostering_entity_type": {
+      "name": "rostering_entity_type",
+      "schema": "app",
+      "values": ["org", "class", "course", "user"]
+    },
+    "app.rostering_provider": {
+      "name": "rostering_provider",
+      "schema": "app",
+      "values": ["classlink", "clever", "dashboard", "nycps", "csv"]
+    },
+    "app.rostering_run_type": {
+      "name": "rostering_run_type",
+      "schema": "app",
+      "values": ["full", "incremental", "retry"]
+    },
+    "app.school_level": {
+      "name": "school_level",
+      "schema": "app",
+      "values": ["early_childhood", "elementary", "middle", "high", "postsecondary"]
+    },
+    "app.score_type": {
+      "name": "score_type",
+      "schema": "app",
+      "values": ["computed", "raw"]
+    },
+    "app.task_variant_status": {
+      "name": "task_variant_status",
+      "schema": "app",
+      "values": ["draft", "published", "deprecated"]
+    },
+    "app.trial_interaction_type": {
+      "name": "trial_interaction_type",
+      "schema": "app",
+      "values": ["focus", "blur", "fullscreen_enter", "fullscreen_exit"]
+    },
+    "app.user_family_role": {
+      "name": "user_family_role",
+      "schema": "app",
+      "values": ["parent", "child"]
+    },
+    "app.user_role": {
+      "name": "user_role",
+      "schema": "app",
+      "values": [
+        "administrator",
+        "aide",
+        "counselor",
+        "district_administrator",
+        "guardian",
+        "parent",
+        "principal",
+        "proctor",
+        "relative",
+        "site_administrator",
+        "student",
+        "system_administrator",
+        "teacher"
+      ]
+    },
+    "app.user_type": {
+      "name": "user_type",
+      "schema": "app",
+      "values": ["student", "educator", "caregiver", "admin"]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/backend/migrations/assessment/meta/0022_snapshot.json
+++ b/apps/backend/migrations/assessment/meta/0022_snapshot.json
@@ -1,0 +1,896 @@
+{
+  "id": "116b9815-2e34-44a5-8a1e-1cfaa0954482",
+  "prevId": "a1314e7c-0697-4a39-9023-3becff80bdcb",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "app.runs": {
+      "name": "runs",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "task_variant_id": {
+          "name": "task_variant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "task_version": {
+          "name": "task_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "administration_id": {
+          "name": "administration_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "use_for_reporting": {
+          "name": "use_for_reporting",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "reliable_run": {
+          "name": "reliable_run",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "engagement_flags": {
+          "name": "engagement_flags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_anonymous": {
+          "name": "is_anonymous",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aborted_at": {
+          "name": "aborted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_by": {
+          "name": "deleted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "runs_user_administration_task_idx": {
+          "name": "runs_user_administration_task_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "administration_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "task_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runs_user_id_idx": {
+          "name": "runs_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runs_user_reporting_run_idx": {
+          "name": "runs_user_reporting_run_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"app\".\"runs\".\"use_for_reporting\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "runs_deleted_by_required": {
+          "name": "runs_deleted_by_required",
+          "value": "\"app\".\"runs\".\"deleted_at\" IS NULL OR \"app\".\"runs\".\"deleted_by\" IS NOT NULL"
+        },
+        "runs_anonymous_administration_id": {
+          "name": "runs_anonymous_administration_id",
+          "value": "(\"app\".\"runs\".\"is_anonymous\" = true AND \"app\".\"runs\".\"administration_id\" = '00000000-0000-0000-0000-000000000000'::uuid) OR (\"app\".\"runs\".\"is_anonymous\" = false AND \"app\".\"runs\".\"administration_id\" != '00000000-0000-0000-0000-000000000000'::uuid)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "app.run_trials": {
+      "name": "run_trials",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assessment_stage": {
+          "name": "assessment_stage",
+          "type": "assessment_stage",
+          "typeSchema": "app",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "audio_feedback": {
+          "name": "audio_feedback",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "block": {
+          "name": "block",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "block_id": {
+          "name": "block_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "button_response": {
+          "name": "button_response",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "corpus_id": {
+          "name": "corpus_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "correct": {
+          "name": "correct",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "correct_response": {
+          "name": "correct_response",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "difficulty": {
+          "name": "difficulty",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "goal": {
+          "name": "goal",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "internal_node_id": {
+          "name": "internal_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "item": {
+          "name": "item",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "keyboard_response": {
+          "name": "keyboard_response",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "realpseudo": {
+          "name": "realpseudo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response": {
+          "name": "response",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response_input": {
+          "name": "response_input",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response_source": {
+          "name": "response_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response_time_ms": {
+          "name": "response_time_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_time_unix": {
+          "name": "start_time_unix",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stim": {
+          "name": "stim",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stimulus": {
+          "name": "stimulus",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stimulus_rule": {
+          "name": "stimulus_rule",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "story": {
+          "name": "story",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subtask": {
+          "name": "subtask",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "theta_estimate": {
+          "name": "theta_estimate",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "theta_estimate2": {
+          "name": "theta_estimate2",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "theta_std_err": {
+          "name": "theta_std_err",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "theta_std_err2": {
+          "name": "theta_std_err2",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thetas": {
+          "name": "thetas",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "theta_std_errs": {
+          "name": "theta_std_errs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "item_parameters": {
+          "name": "item_parameters",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "time_elapsed": {
+          "name": "time_elapsed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trial_num_block": {
+          "name": "trial_num_block",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trial_num_total": {
+          "name": "trial_num_total",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trial_index": {
+          "name": "trial_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trial_type": {
+          "name": "trial_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "truefalse": {
+          "name": "truefalse",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "word": {
+          "name": "word",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "run_trials_run_id_idx": {
+          "name": "run_trials_run_id_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "run_trials_run_trial_idx": {
+          "name": "run_trials_run_trial_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "trial_index",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "run_trials_run_id_runs_id_fk": {
+          "name": "run_trials_run_id_runs_id_fk",
+          "tableFrom": "run_trials",
+          "tableTo": "runs",
+          "schemaTo": "app",
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.run_trial_interactions": {
+      "name": "run_trial_interactions",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "trial_id": {
+          "name": "trial_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "interaction_type": {
+          "name": "interaction_type",
+          "type": "trial_interaction_type",
+          "typeSchema": "app",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "time_ms": {
+          "name": "time_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "run_trial_interactions_trial_id_idx": {
+          "name": "run_trial_interactions_trial_id_idx",
+          "columns": [
+            {
+              "expression": "trial_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "run_trial_interactions_trial_id_run_trials_id_fk": {
+          "name": "run_trial_interactions_trial_id_run_trials_id_fk",
+          "tableFrom": "run_trial_interactions",
+          "tableTo": "run_trials",
+          "schemaTo": "app",
+          "columnsFrom": ["trial_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.run_scores": {
+      "name": "run_scores",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "score_type",
+          "typeSchema": "app",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "domain": {
+          "name": "domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assessment_stage": {
+          "name": "assessment_stage",
+          "type": "assessment_stage",
+          "typeSchema": "app",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category_score": {
+          "name": "category_score",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "run_scores_run_id_idx": {
+          "name": "run_scores_run_id_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "run_scores_run_id_type_idx": {
+          "name": "run_scores_run_id_type_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "run_scores_run_id_runs_id_fk": {
+          "name": "run_scores_run_id_runs_id_fk",
+          "tableFrom": "run_scores",
+          "tableTo": "runs",
+          "schemaTo": "app",
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "run_scores_natural_key_unique": {
+          "name": "run_scores_natural_key_unique",
+          "nullsNotDistinct": true,
+          "columns": ["run_id", "type", "domain", "name", "assessment_stage"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "app.agreement_type": {
+      "name": "agreement_type",
+      "schema": "app",
+      "values": ["tos", "assent", "consent"]
+    },
+    "app.assessment_stage": {
+      "name": "assessment_stage",
+      "schema": "app",
+      "values": ["practice", "test"]
+    },
+    "app.assignment_progress": {
+      "name": "assignment_progress",
+      "schema": "app",
+      "values": ["assigned", "started", "completed"]
+    },
+    "app.auth_provider": {
+      "name": "auth_provider",
+      "schema": "app",
+      "values": ["password", "google", "oidc.clever", "oidc.classlink", "oidc.nycps"]
+    },
+    "app.class_type": {
+      "name": "class_type",
+      "schema": "app",
+      "values": ["homeroom", "scheduled", "other"]
+    },
+    "app.free_reduced_lunch_status": {
+      "name": "free_reduced_lunch_status",
+      "schema": "app",
+      "values": ["Free", "Reduced", "Paid"]
+    },
+    "app.grade": {
+      "name": "grade",
+      "schema": "app",
+      "values": [
+        "1",
+        "2",
+        "3",
+        "4",
+        "5",
+        "6",
+        "7",
+        "8",
+        "9",
+        "10",
+        "11",
+        "12",
+        "13",
+        "PreKindergarten",
+        "TransitionalKindergarten",
+        "Kindergarten",
+        "InfantToddler",
+        "Preschool",
+        "PostGraduate",
+        "Ungraded",
+        "Other",
+        ""
+      ]
+    },
+    "app.group_type": {
+      "name": "group_type",
+      "schema": "app",
+      "values": ["cohort", "community", "business"]
+    },
+    "app.org_type": {
+      "name": "org_type",
+      "schema": "app",
+      "values": ["national", "state", "local", "district", "school", "department"]
+    },
+    "app.rostering_entity_status": {
+      "name": "rostering_entity_status",
+      "schema": "app",
+      "values": ["enrolled", "unenrolled", "failed", "skipped"]
+    },
+    "app.rostering_entity_type": {
+      "name": "rostering_entity_type",
+      "schema": "app",
+      "values": ["org", "class", "course", "user"]
+    },
+    "app.rostering_provider": {
+      "name": "rostering_provider",
+      "schema": "app",
+      "values": ["classlink", "clever", "dashboard", "nycps", "csv"]
+    },
+    "app.rostering_run_type": {
+      "name": "rostering_run_type",
+      "schema": "app",
+      "values": ["full", "incremental", "retry"]
+    },
+    "app.school_level": {
+      "name": "school_level",
+      "schema": "app",
+      "values": ["early_childhood", "elementary", "middle", "high", "postsecondary"]
+    },
+    "app.score_type": {
+      "name": "score_type",
+      "schema": "app",
+      "values": ["computed", "raw"]
+    },
+    "app.task_variant_status": {
+      "name": "task_variant_status",
+      "schema": "app",
+      "values": ["draft", "published", "deprecated"]
+    },
+    "app.trial_interaction_type": {
+      "name": "trial_interaction_type",
+      "schema": "app",
+      "values": ["focus", "blur", "fullscreen_enter", "fullscreen_exit"]
+    },
+    "app.user_family_role": {
+      "name": "user_family_role",
+      "schema": "app",
+      "values": ["parent", "child"]
+    },
+    "app.user_role": {
+      "name": "user_role",
+      "schema": "app",
+      "values": [
+        "administrator",
+        "aide",
+        "counselor",
+        "district_administrator",
+        "guardian",
+        "parent",
+        "platform_admin",
+        "principal",
+        "proctor",
+        "relative",
+        "site_administrator",
+        "student",
+        "system_administrator",
+        "teacher"
+      ]
+    },
+    "app.user_type": {
+      "name": "user_type",
+      "schema": "app",
+      "values": ["student", "educator", "caregiver", "admin"]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/backend/migrations/assessment/meta/_journal.json
+++ b/apps/backend/migrations/assessment/meta/_journal.json
@@ -148,6 +148,13 @@
       "when": 1774857600000,
       "tag": "0020_drop_fdw_views",
       "breakpoints": true
+    },
+    {
+      "idx": 21,
+      "version": "7",
+      "when": 1774944000000,
+      "tag": "0021_add_run_scores_natural_key_unique",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/backend/migrations/assessment/meta/_journal.json
+++ b/apps/backend/migrations/assessment/meta/_journal.json
@@ -155,6 +155,13 @@
       "when": 1774944000000,
       "tag": "0021_add_run_scores_natural_key_unique",
       "breakpoints": true
+    },
+    {
+      "idx": 22,
+      "version": "7",
+      "when": 1778238129337,
+      "tag": "0022_add_platform_admin_to_user_role",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/backend/src/constants/run-scores.ts
+++ b/apps/backend/src/constants/run-scores.ts
@@ -1,0 +1,63 @@
+/**
+ * Run scores constants
+ *
+ * Centralizes the magic strings used as natural-key components in `app.run_scores`.
+ *
+ * The recompute path (`RunService.recomputeBestRunForVariant`) and the upsert path
+ * (`RunScoresRepository.upsertMany` and its callers) both look up score rows by
+ * `(type, domain, name, assessmentStage)`. Inlining string literals in either place
+ * makes typos a runtime bug and refactors fragile — these constants give us one
+ * source of truth.
+ *
+ * Values mirror the keys the assessment SDK has historically written to
+ * `runData.scores.raw.composite.test.*` in the Firestore data model and are
+ * preserved here for compatibility with existing reporting expectations.
+ */
+
+/**
+ * `app.run_scores.type` enum values. Mirrors `score_type` in the DB.
+ */
+export const SCORE_TYPE = {
+  COMPUTED: 'computed',
+  RAW: 'raw',
+} as const;
+
+export type ScoreTypeValue = (typeof SCORE_TYPE)[keyof typeof SCORE_TYPE];
+
+/**
+ * `app.run_scores.domain` values used by CAT scoring.
+ *
+ * Domain names are open-ended on the schema side (text column) — this set captures
+ * the values the recompute and CAT scoring paths look up by name. Add new entries
+ * here when extending domain coverage.
+ */
+export const SCORE_DOMAIN = {
+  COMPOSITE: 'composite',
+} as const;
+
+export type ScoreDomainValue = (typeof SCORE_DOMAIN)[keyof typeof SCORE_DOMAIN];
+
+/**
+ * `app.run_scores.assessment_stage` enum values. Mirrors `assessment_stage` in the DB.
+ */
+export const ASSESSMENT_STAGE = {
+  PRACTICE: 'practice',
+  TEST: 'test',
+} as const;
+
+export type AssessmentStageValue = (typeof ASSESSMENT_STAGE)[keyof typeof ASSESSMENT_STAGE];
+
+/**
+ * `app.run_scores.name` values referenced by the best-run recompute logic.
+ *
+ * These are the score names the four-tier ranking compares within tier 2 and tier 4
+ * (lowest `thetaSE`, then highest `numAttempted`). Other code paths may reference
+ * additional score names — keep this list to ones the backend actually consumes by
+ * name in queries.
+ */
+export const SCORE_NAME = {
+  THETA_SE: 'thetaSE',
+  NUM_ATTEMPTED: 'numAttempted',
+} as const;
+
+export type ScoreNameValue = (typeof SCORE_NAME)[keyof typeof SCORE_NAME];

--- a/apps/backend/src/db/schema/assessment/run-scores.ts
+++ b/apps/backend/src/db/schema/assessment/run-scores.ts
@@ -56,6 +56,16 @@ export const runScores = db.table(
 
     // - Lookup for scores by run ID and type
     p.index('run_scores_run_id_type_idx').on(table.runId, table.type),
+
+    // Constraints
+    // - Natural-key unique constraint enabling ON CONFLICT upserts.
+    //   `assessment_stage` is nullable; `nullsNotDistinct()` ensures rows with the same
+    //   (run_id, type, domain, name) and a NULL stage are treated as duplicates rather
+    //   than distinct rows. Requires Postgres 15+.
+    p
+      .unique('run_scores_natural_key_unique')
+      .on(table.runId, table.type, table.domain, table.name, table.assessmentStage)
+      .nullsNotDistinct(),
   ],
 );
 

--- a/apps/backend/src/repositories/run-scores.repository.integration.test.ts
+++ b/apps/backend/src/repositories/run-scores.repository.integration.test.ts
@@ -1,0 +1,339 @@
+/**
+ * Integration tests for RunScoresRepository.
+ *
+ * Tests `upsertMany` against the real assessment database, exercising the
+ * `ON CONFLICT (run_id, type, domain, name, assessment_stage) DO UPDATE`
+ * path and the `NULLS NOT DISTINCT` constraint that lets a NULL stage
+ * still participate in the natural key.
+ *
+ * Uses RunFactory to seed parent runs (run_id has a FK with cascade delete);
+ * uses RunScoreFactory only when the test wants to pre-seed score rows
+ * outside the upsert path under test.
+ */
+import { describe, it, expect, beforeAll } from 'vitest';
+import { eq, and } from 'drizzle-orm';
+import { AssessmentDbClient } from '../db/clients';
+import { runScores } from '../db/schema/assessment';
+import { RunFactory } from '../test-support/factories/run.factory';
+import { RunScoresRepository } from './run-scores.repository';
+import { SCORE_TYPE, SCORE_DOMAIN, ASSESSMENT_STAGE, SCORE_NAME } from '../constants/run-scores';
+
+describe('RunScoresRepository', () => {
+  let repository: RunScoresRepository;
+
+  beforeAll(() => {
+    repository = new RunScoresRepository();
+  });
+
+  describe('upsertMany', () => {
+    it('returns an empty array for empty input', async () => {
+      const result = await repository.upsertMany({ data: [] });
+
+      expect(result).toEqual([]);
+    });
+
+    it('inserts a single new score row', async () => {
+      const run = await RunFactory.create();
+
+      const result = await repository.upsertMany({
+        data: [
+          {
+            runId: run.id,
+            type: SCORE_TYPE.RAW,
+            domain: SCORE_DOMAIN.COMPOSITE,
+            name: SCORE_NAME.THETA_SE,
+            value: '0.5',
+            assessmentStage: ASSESSMENT_STAGE.TEST,
+            categoryScore: null,
+          },
+        ],
+      });
+
+      expect(result).toHaveLength(1);
+      expect(result[0]!.id).toBeDefined();
+
+      const rows = await AssessmentDbClient.select().from(runScores).where(eq(runScores.runId, run.id));
+
+      expect(rows).toHaveLength(1);
+      expect(rows[0]!.value).toBe('0.5');
+      expect(rows[0]!.assessmentStage).toBe(ASSESSMENT_STAGE.TEST);
+    });
+
+    it('inserts multiple new score rows in one call', async () => {
+      const run = await RunFactory.create();
+
+      const result = await repository.upsertMany({
+        data: [
+          {
+            runId: run.id,
+            type: SCORE_TYPE.RAW,
+            domain: SCORE_DOMAIN.COMPOSITE,
+            name: SCORE_NAME.THETA_SE,
+            value: '0.5',
+            assessmentStage: ASSESSMENT_STAGE.TEST,
+          },
+          {
+            runId: run.id,
+            type: SCORE_TYPE.RAW,
+            domain: SCORE_DOMAIN.COMPOSITE,
+            name: SCORE_NAME.NUM_ATTEMPTED,
+            value: '12',
+            assessmentStage: ASSESSMENT_STAGE.TEST,
+          },
+        ],
+      });
+
+      expect(result).toHaveLength(2);
+
+      const rows = await AssessmentDbClient.select().from(runScores).where(eq(runScores.runId, run.id));
+
+      expect(rows).toHaveLength(2);
+      const byName = new Map(rows.map((r) => [r.name, r.value]));
+      expect(byName.get(SCORE_NAME.THETA_SE)).toBe('0.5');
+      expect(byName.get(SCORE_NAME.NUM_ATTEMPTED)).toBe('12');
+    });
+
+    it('updates the existing row when re-sent with the same natural key', async () => {
+      const run = await RunFactory.create();
+
+      // First write
+      await repository.upsertMany({
+        data: [
+          {
+            runId: run.id,
+            type: SCORE_TYPE.RAW,
+            domain: SCORE_DOMAIN.COMPOSITE,
+            name: SCORE_NAME.THETA_SE,
+            value: '0.5',
+            assessmentStage: ASSESSMENT_STAGE.TEST,
+          },
+        ],
+      });
+
+      // Second write — same natural key, new value
+      await repository.upsertMany({
+        data: [
+          {
+            runId: run.id,
+            type: SCORE_TYPE.RAW,
+            domain: SCORE_DOMAIN.COMPOSITE,
+            name: SCORE_NAME.THETA_SE,
+            value: '0.3',
+            assessmentStage: ASSESSMENT_STAGE.TEST,
+          },
+        ],
+      });
+
+      const rows = await AssessmentDbClient.select().from(runScores).where(eq(runScores.runId, run.id));
+
+      // Still exactly one row — the conflict path replaced the value rather than inserting.
+      expect(rows).toHaveLength(1);
+      expect(rows[0]!.value).toBe('0.3');
+    });
+
+    it('treats two NULL assessment_stage rows with otherwise-identical natural keys as the same row', async () => {
+      const run = await RunFactory.create();
+
+      // First write with NULL stage
+      await repository.upsertMany({
+        data: [
+          {
+            runId: run.id,
+            type: SCORE_TYPE.RAW,
+            domain: SCORE_DOMAIN.COMPOSITE,
+            name: SCORE_NAME.THETA_SE,
+            value: '0.5',
+            assessmentStage: null,
+          },
+        ],
+      });
+
+      // Second write with NULL stage — should update, not insert (NULLS NOT DISTINCT)
+      await repository.upsertMany({
+        data: [
+          {
+            runId: run.id,
+            type: SCORE_TYPE.RAW,
+            domain: SCORE_DOMAIN.COMPOSITE,
+            name: SCORE_NAME.THETA_SE,
+            value: '0.4',
+            assessmentStage: null,
+          },
+        ],
+      });
+
+      const rows = await AssessmentDbClient.select().from(runScores).where(eq(runScores.runId, run.id));
+
+      expect(rows).toHaveLength(1);
+      expect(rows[0]!.value).toBe('0.4');
+      expect(rows[0]!.assessmentStage).toBeNull();
+    });
+
+    it('treats different assessment_stage values as distinct rows for the same (run, type, domain, name)', async () => {
+      const run = await RunFactory.create();
+
+      await repository.upsertMany({
+        data: [
+          {
+            runId: run.id,
+            type: SCORE_TYPE.RAW,
+            domain: SCORE_DOMAIN.COMPOSITE,
+            name: SCORE_NAME.THETA_SE,
+            value: '0.5',
+            assessmentStage: ASSESSMENT_STAGE.PRACTICE,
+          },
+          {
+            runId: run.id,
+            type: SCORE_TYPE.RAW,
+            domain: SCORE_DOMAIN.COMPOSITE,
+            name: SCORE_NAME.THETA_SE,
+            value: '0.7',
+            assessmentStage: ASSESSMENT_STAGE.TEST,
+          },
+        ],
+      });
+
+      const rows = await AssessmentDbClient.select().from(runScores).where(eq(runScores.runId, run.id));
+
+      expect(rows).toHaveLength(2);
+      const byStage = new Map(rows.map((r) => [r.assessmentStage, r.value]));
+      expect(byStage.get(ASSESSMENT_STAGE.PRACTICE)).toBe('0.5');
+      expect(byStage.get(ASSESSMENT_STAGE.TEST)).toBe('0.7');
+    });
+
+    it('updates category_score on conflict', async () => {
+      const run = await RunFactory.create();
+
+      // Insert with categoryScore=false
+      await repository.upsertMany({
+        data: [
+          {
+            runId: run.id,
+            type: SCORE_TYPE.COMPUTED,
+            domain: SCORE_DOMAIN.COMPOSITE,
+            name: 'support_level',
+            value: 'developingSkill',
+            assessmentStage: ASSESSMENT_STAGE.TEST,
+            categoryScore: false,
+          },
+        ],
+      });
+
+      // Re-upsert with categoryScore=true
+      await repository.upsertMany({
+        data: [
+          {
+            runId: run.id,
+            type: SCORE_TYPE.COMPUTED,
+            domain: SCORE_DOMAIN.COMPOSITE,
+            name: 'support_level',
+            value: 'achievedSkill',
+            assessmentStage: ASSESSMENT_STAGE.TEST,
+            categoryScore: true,
+          },
+        ],
+      });
+
+      const rows = await AssessmentDbClient.select().from(runScores).where(eq(runScores.runId, run.id));
+
+      expect(rows).toHaveLength(1);
+      expect(rows[0]!.value).toBe('achievedSkill');
+      expect(rows[0]!.categoryScore).toBe(true);
+    });
+
+    it('isolates scores by run_id', async () => {
+      const runA = await RunFactory.create();
+      const runB = await RunFactory.create();
+
+      await repository.upsertMany({
+        data: [
+          {
+            runId: runA.id,
+            type: SCORE_TYPE.RAW,
+            domain: SCORE_DOMAIN.COMPOSITE,
+            name: SCORE_NAME.THETA_SE,
+            value: '0.5',
+            assessmentStage: ASSESSMENT_STAGE.TEST,
+          },
+          {
+            runId: runB.id,
+            type: SCORE_TYPE.RAW,
+            domain: SCORE_DOMAIN.COMPOSITE,
+            name: SCORE_NAME.THETA_SE,
+            value: '0.7',
+            assessmentStage: ASSESSMENT_STAGE.TEST,
+          },
+        ],
+      });
+
+      const allForA = await AssessmentDbClient.select().from(runScores).where(eq(runScores.runId, runA.id));
+      const allForB = await AssessmentDbClient.select().from(runScores).where(eq(runScores.runId, runB.id));
+
+      expect(allForA).toHaveLength(1);
+      expect(allForB).toHaveLength(1);
+      expect(allForA[0]!.value).toBe('0.5');
+      expect(allForB[0]!.value).toBe('0.7');
+    });
+
+    it('participates in a caller-provided transaction (commit path)', async () => {
+      const run = await RunFactory.create();
+      const repo = repository;
+
+      await repo.runTransaction({
+        fn: async (tx) => {
+          await repo.upsertMany({
+            transaction: tx,
+            data: [
+              {
+                runId: run.id,
+                type: SCORE_TYPE.RAW,
+                domain: SCORE_DOMAIN.COMPOSITE,
+                name: SCORE_NAME.THETA_SE,
+                value: '0.42',
+                assessmentStage: ASSESSMENT_STAGE.TEST,
+              },
+            ],
+          });
+        },
+      });
+
+      const rows = await AssessmentDbClient.select()
+        .from(runScores)
+        .where(and(eq(runScores.runId, run.id), eq(runScores.name, SCORE_NAME.THETA_SE)));
+
+      expect(rows).toHaveLength(1);
+      expect(rows[0]!.value).toBe('0.42');
+    });
+
+    it('rolls back upserted rows when the caller-provided transaction throws', async () => {
+      const run = await RunFactory.create();
+      const repo = repository;
+      const caughtError = await repo
+        .runTransaction({
+          fn: async (tx) => {
+            await repo.upsertMany({
+              transaction: tx,
+              data: [
+                {
+                  runId: run.id,
+                  type: SCORE_TYPE.RAW,
+                  domain: SCORE_DOMAIN.COMPOSITE,
+                  name: SCORE_NAME.THETA_SE,
+                  value: 'should-not-persist',
+                  assessmentStage: ASSESSMENT_STAGE.TEST,
+                },
+              ],
+            });
+            throw new Error('intentional rollback');
+          },
+        })
+        .catch((e) => e);
+
+      expect(caughtError).toBeInstanceOf(Error);
+
+      const rows = await AssessmentDbClient.select().from(runScores).where(eq(runScores.runId, run.id));
+
+      expect(rows).toHaveLength(0);
+    });
+  });
+});

--- a/apps/backend/src/repositories/run-scores.repository.test.ts
+++ b/apps/backend/src/repositories/run-scores.repository.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest';
+import { RunScoresRepository } from './run-scores.repository';
+
+/**
+ * RunScoresRepository unit tests
+ *
+ * Smoke-level tests verifying that the repository extends BaseRepository
+ * and exposes the upsertMany method. Behavioral tests live in the
+ * integration suite where ON CONFLICT semantics can be exercised against
+ * a real database.
+ */
+describe('RunScoresRepository', () => {
+  it('should be instantiable', () => {
+    const repository = new RunScoresRepository();
+
+    expect(repository).toBeDefined();
+    expect(repository).toBeInstanceOf(RunScoresRepository);
+  });
+
+  it('should have standard repository methods', () => {
+    const repository = new RunScoresRepository();
+
+    expect(typeof repository.create).toBe('function');
+    expect(typeof repository.getById).toBe('function');
+    expect(typeof repository.update).toBe('function');
+    expect(typeof repository.delete).toBe('function');
+    expect(typeof repository.runTransaction).toBe('function');
+  });
+
+  it('should expose upsertMany', () => {
+    const repository = new RunScoresRepository();
+
+    expect(typeof repository.upsertMany).toBe('function');
+  });
+
+  it('upsertMany returns empty array for empty input without hitting the database', async () => {
+    const repository = new RunScoresRepository();
+
+    // Empty input is a no-op; this should not require a live DB connection.
+    const result = await repository.upsertMany({ data: [] });
+
+    expect(result).toEqual([]);
+  });
+});

--- a/apps/backend/src/repositories/run-scores.repository.ts
+++ b/apps/backend/src/repositories/run-scores.repository.ts
@@ -38,15 +38,17 @@ export class RunScoresRepository extends BaseRepository<RunScore, typeof runScor
    * Upsert one or more score rows by their natural key.
    *
    * Existing rows matching `(run_id, type, domain, name, assessment_stage)` are updated
-   * with the incoming `value`, `category_score`, and `updated_at`; rows with no match
-   * are inserted. Returns the resulting row IDs (newly inserted or pre-existing).
+   * with the incoming `value` and `category_score`; rows with no match are inserted.
+   * `updated_at` is bumped automatically by the `run_scores_set_updated_at` trigger.
    *
    * Idempotent: replaying the same input produces the same final state.
    *
    * Returns an empty array on empty input.
    *
    * @param params - Score rows to upsert and optional transaction context
-   * @returns Array of `{ id }` for each affected row, in input order
+   * @returns Array of `{ id }` for each affected row. Postgres does not formally guarantee
+   *          ordering of `RETURNING` rows for multi-value inserts, so callers should not
+   *          rely on a specific correspondence between input and output indices.
    */
   async upsertMany(params: RunScoresUpsertManyParams): Promise<{ id: string }[]> {
     const { data, transaction } = params;

--- a/apps/backend/src/repositories/run-scores.repository.ts
+++ b/apps/backend/src/repositories/run-scores.repository.ts
@@ -1,0 +1,74 @@
+import { sql } from 'drizzle-orm';
+import type { NodePgDatabase } from 'drizzle-orm/node-postgres';
+import { AssessmentDbClient } from '../db/clients';
+import type * as AssessmentDbSchema from '../db/schema/assessment';
+import { BaseRepository } from './base.repository';
+import type { RunScore, NewRunScore } from '../db/schema';
+import { runScores } from '../db/schema/assessment';
+import type { Transaction } from './interfaces/base.repository.interface';
+
+/**
+ * Parameters for upserting many run-score rows.
+ */
+export interface RunScoresUpsertManyParams {
+  /** Score rows to upsert. */
+  data: NewRunScore[];
+
+  /** Optional transaction context — pass when called inside an existing transaction. */
+  transaction?: Transaction;
+}
+
+/**
+ * Run Scores Repository
+ *
+ * Provides data access methods for the `app.run_scores` table.
+ *
+ * The natural key `(run_id, type, domain, name, assessment_stage)` is enforced by a
+ * unique constraint with `NULLS NOT DISTINCT`, which lets `upsertMany` use
+ * `ON CONFLICT ... DO UPDATE` to replace the current value for any given score
+ * within a run. This matches the read-path invariant in `report.repository.ts`
+ * that assumes at most one current row per natural key.
+ */
+export class RunScoresRepository extends BaseRepository<RunScore, typeof runScores> {
+  constructor(db: NodePgDatabase<typeof AssessmentDbSchema> = AssessmentDbClient) {
+    super(db, runScores);
+  }
+
+  /**
+   * Upsert one or more score rows by their natural key.
+   *
+   * Existing rows matching `(run_id, type, domain, name, assessment_stage)` are updated
+   * with the incoming `value`, `category_score`, and `updated_at`; rows with no match
+   * are inserted. Returns the resulting row IDs (newly inserted or pre-existing).
+   *
+   * Idempotent: replaying the same input produces the same final state.
+   *
+   * Returns an empty array on empty input.
+   *
+   * @param params - Score rows to upsert and optional transaction context
+   * @returns Array of `{ id }` for each affected row, in input order
+   */
+  async upsertMany(params: RunScoresUpsertManyParams): Promise<{ id: string }[]> {
+    const { data, transaction } = params;
+    if (data.length === 0) return [];
+
+    const db = transaction ?? this.db;
+
+    const result = await db
+      .insert(runScores)
+      .values(data)
+      .onConflictDoUpdate({
+        target: [runScores.runId, runScores.type, runScores.domain, runScores.name, runScores.assessmentStage],
+        set: {
+          // EXCLUDED references the row that would have been inserted; this lets the update
+          // pick up the incoming value instead of leaving the prior one in place.
+          // updated_at is bumped automatically by the run_scores_set_updated_at trigger.
+          value: sql`excluded.value`,
+          categoryScore: sql`excluded.category_score`,
+        },
+      })
+      .returning({ id: runScores.id });
+
+    return result;
+  }
+}

--- a/apps/backend/src/test-support/factories/run-score.factory.ts
+++ b/apps/backend/src/test-support/factories/run-score.factory.ts
@@ -3,6 +3,7 @@ import { faker } from '@faker-js/faker';
 import type { RunScore, NewRunScore } from '../../db/schema/assessment';
 import { AssessmentDbClient } from '../../db/clients';
 import { runScores } from '../../db/schema/assessment';
+import { SCORE_TYPE } from '../../constants/run-scores';
 
 /**
  * Factory for creating RunScore test objects in the assessment database.
@@ -35,7 +36,7 @@ export const RunScoreFactory = Factory.define<RunScore>(({ onCreate }) => {
   return {
     id: faker.string.uuid(),
     runId: faker.string.uuid(),
-    type: 'computed',
+    type: SCORE_TYPE.COMPUTED,
     domain: 'default',
     name: 'score',
     value: '0',

--- a/apps/backend/src/test-support/repositories/index.ts
+++ b/apps/backend/src/test-support/repositories/index.ts
@@ -15,6 +15,7 @@ export {
   createMockRunTrialInteractionsRepository,
   MockRunTrialInteractionsRepository,
 } from './run-trial-interactions.repository';
+export { createMockRunScoresRepository, MockRunScoresRepository } from './run-scores.repository';
 export { createMockAdministrationRepository, MockAdministrationRepository } from './administration.repository';
 export {
   createMockAdministrationTaskVariantRepository,

--- a/apps/backend/src/test-support/repositories/run-scores.repository.ts
+++ b/apps/backend/src/test-support/repositories/run-scores.repository.ts
@@ -1,0 +1,17 @@
+import { vi } from 'vitest';
+import type { MockedObject } from 'vitest';
+import { createMockBaseRepositoryMethods } from './base.repository';
+import type { RunScoresRepository } from '../../repositories/run-scores.repository';
+
+/**
+ * Mock Run Scores Repository
+ * Returns a mocked version of RunScoresRepository with all methods as vi.fn() mocks.
+ */
+export function createMockRunScoresRepository(): MockedObject<RunScoresRepository> {
+  return {
+    ...createMockBaseRepositoryMethods(),
+    upsertMany: vi.fn(),
+  } as MockedObject<RunScoresRepository>;
+}
+
+export type MockRunScoresRepository = ReturnType<typeof createMockRunScoresRepository>;


### PR DESCRIPTION
## Summary

This PR is the foundation of #1784, "Write run-level scores on `trial` and `complete` run events." It adds a `RunScoresRepository` with an `upsertMany` method, plus the unique constraint and constants those upserts depend on. **No callers yet** — the contract change and `RunEventService.writeTrial` extension land in the next PR in the chain.

Splitting this off keeps the diff focused on infrastructure: schema, migration, repository, tests. The next PR can then be reviewed purely as wiring.

## Schema and migration

`app.run_scores` previously had only a UUID primary key. To support `INSERT ... ON CONFLICT DO UPDATE` on the natural key, this PR adds a `UNIQUE NULLS NOT DISTINCT (run_id, type, domain, name, assessment_stage)` constraint:

- The constraint enforces the invariant the read path in `report.repository.ts` already assumes — at most one current row per natural key. Before this, the assumption was hope-based; after, it's a foreign-key-grade guarantee.
- `assessment_stage` is nullable. Without `NULLS NOT DISTINCT`, two rows with the same `(run_id, type, domain, name)` and a `NULL` stage would coexist (Postgres treats `NULL` as distinct in unique constraints by default). `NULLS NOT DISTINCT` makes them collapse to one row, which matches CAT scoring semantics where the absence of a stage is the same "kind of" score every time.

`NULLS NOT DISTINCT` requires Postgres 15+. CI is on `postgres:18` and the IaC default in `roar-iac` is `POSTGRES_18`, so this is safe.

The migration is hand-written rather than generated. `drizzle-kit generate` couldn't run during development (sandbox tooling issue), but the schema (`run-scores.ts`), SQL (`migrations/assessment/0021_add_run_scores_natural_key_unique.sql`), snapshot (`meta/0021_snapshot.json`), and journal entry are all in place. Running `db:gen:assess` should be a no-op; if it produces a new migration file, that's drift between the hand-written snapshot and what drizzle-kit computes — flag it in review.

The migration's comment includes the pre-flight duplicate-detection query for any environment that could already have duplicates. `run_scores` is currently never written to outside test fixtures, so prod should be empty.

## Constants

`apps/backend/src/constants/run-scores.ts` introduces:

- `SCORE_TYPE` — `computed`, `raw` (mirrors the `score_type` enum)
- `SCORE_DOMAIN` — `composite` (will grow as more domains land)
- `ASSESSMENT_STAGE` — `practice`, `test` (mirrors the `assessment_stage` enum)
- `SCORE_NAME` — `THETA_SE`, `NUM_ATTEMPTED`

Promoted now because both this PR's upsert path and the upcoming `recompute use_for_reporting` ticket reference the same magic strings (`thetaSE`, `numAttempted`, `composite`, `test`). One source of truth keeps the natural key consistent across producers and consumers.

`SCORE_NAME` is intentionally narrow — only the names backend code references by string in queries. Other names live in assessment configs and don't need backend-side constants.

## Repository

`RunScoresRepository extends BaseRepository<RunScore, typeof runScores>`. Single new method:

```ts
async upsertMany(params: { data: NewRunScore[]; transaction?: Transaction }): Promise<{ id: string }[]>
```

Body:

```ts
return db
  .insert(runScores)
  .values(data)
  .onConflictDoUpdate({
    target: [runScores.runId, runScores.type, runScores.domain, runScores.name, runScores.assessmentStage],
    set: {
      value: sql`excluded.value`,
      categoryScore: sql`excluded.category_score`,
    },
  })
  .returning({ id: runScores.id });
```

Notes:

- `excluded.*` references the row Postgres tried to insert; this is how the update picks up the incoming values rather than leaving the prior ones in place.
- `updated_at` is intentionally not set in the application code — the existing `run_scores_set_updated_at` trigger handles it on UPDATE, and `created_at` has `DEFAULT now()` on the column. The general convention going forward: don't set `createdAt`/`updatedAt` from the backend; let DB defaults and triggers own them.
- `data.length === 0` short-circuits to `[]` without hitting the DB.
- Accepts an optional transaction so the upcoming `writeTrial` extension can run trial + interactions + scores atomically.

## Tests

**Unit tests** (`run-scores.repository.test.ts`) — smoke level: instantiability, method shape, empty-input no-op without a DB connection.

**Integration tests** (`run-scores.repository.integration.test.ts`) — exercise the constraint and conflict path against a real DB:

- `returns an empty array for empty input`
- `inserts a single new score row`
- `inserts multiple new score rows in one call`
- `updates the existing row when re-sent with the same natural key` — verifies the upsert path (one row before, one row after, value replaced)
- `treats two NULL assessment_stage rows with otherwise-identical natural keys as the same row` — covers the `NULLS NOT DISTINCT` semantics
- `treats different assessment_stage values as distinct rows for the same (run, type, domain, name)`
- `updates category_score on conflict`
- `isolates scores by run_id`
- `participates in a caller-provided transaction (commit path)` — proves the `transaction` param is wired through
- `rolls back upserted rows when the caller-provided transaction throws` — proves rollback semantics

## Tests support

`createMockRunScoresRepository` added under `test-support/repositories/`, exported from the index, ready for the next PR's service-level unit tests to consume.

## Out of scope

- `ScoreEntrySchema` and the `RunTrialEventSchema` extension — next PR in the chain.
- `RunEventService.writeTrial` upserting scores — next PR in the chain.
- Per-trial score history (`run_trial_scores`) — separate, future ticket.
- Recompute of `use_for_reporting` — separate, independent ticket (#1785).

## Risks

- **Hand-written snapshot.** If `drizzle-kit generate` on a reviewer's machine produces a new migration file, the hand-written snapshot doesn't match drizzle-kit's computed state. Reconcile before merge.
- **Pre-flight duplicates.** The migration will fail on a non-empty `run_scores` table that contains duplicates on the natural key. Production currently has no production writers to this table, but the comment in the SQL file includes the detection query for any environment that might.

Refs [1784](https://github.com/yeatmanlab/roar-project-management/issues/1784)

## Types of changes

What types of changes does this pull request introduce?

<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (non-breaking change that does not add functionality but makes code cleaner or more efficient)
- [ ] Documentation Update
- [x] Tests (new or updated tests)
- [ ] Style (changes to code styling)
- [ ] CI (continuous integration changes)
- [ ] Repository Maintenance
- [ ] Other (please describe below)

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask.  We're here
to help! This is simply a reminder of what we are going to look for before
merging your code.
-->

- [x] I have read the [guidelines for contributing](https://github.com/yeatmanlab/roar-dashboard/blob/main/.github/CONTRIBUTING.md).
- [x] The changes in this PR are as small as they can be. They represent one and only one fix or enhancement.
- [x] Linting checks pass with my changes.
- [x] Any existing unit tests pass with my changes.
- [x] Any existing end-to-end tests pass with my changes.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] If this PR fixes an existing issue, I have added a unit or end-to-end test that will detect if this issue reoccurs.
- [x] I have added JSDoc comments as appropriate.
- [ ] I have added the necessary documentation to the [roar-docs repository](https://github.com/yeatmanlab/roar-docs).
- [x] I have shared this PR on the roar-pr-reviews channel (if I have access)
- [x] I have linked relevant issues (if any)