### PR TITLE
Use `streamedListObjects` in `AuthorizationService.listAccessibleObjects`

### DIFF
--- a/apps/backend/src/repositories/utils/fga-filter-ids.utils.integration.test.ts
+++ b/apps/backend/src/repositories/utils/fga-filter-ids.utils.integration.test.ts
@@ -1,0 +1,133 @@
+/**
+ * Integration tests for `withFgaFilterIds`.
+ *
+ * The unit test uses a fake DB to verify call structure (chunking, callback
+ * shape, error propagation). These integration tests verify behavior the unit
+ * test can't: that the temp table is created, populated, and dropped on
+ * commit/rollback against a real Postgres connection.
+ *
+ * Without these, we'd be relying on Postgres's `ON COMMIT DROP` and session-scope
+ * semantics being correctly invoked — but we'd never have proven they are.
+ */
+import { describe, it, expect } from 'vitest';
+import { sql } from 'drizzle-orm';
+import { CoreDbClient } from '../../test-support/db';
+import { withFgaFilterIds } from './fga-filter-ids.utils';
+
+const SAMPLE_UUIDS = [
+  '11111111-1111-1111-1111-111111111111',
+  '22222222-2222-2222-2222-222222222222',
+  '33333333-3333-3333-3333-333333333333',
+];
+
+describe('withFgaFilterIds (integration)', () => {
+  it('materializes ids into a temp table that the callback can read', async () => {
+    const rows = await withFgaFilterIds(CoreDbClient, SAMPLE_UUIDS, async (tx) => {
+      const result = await tx.execute<{ id: string }>(sql`SELECT id::text AS id FROM fga_filter_ids ORDER BY id`);
+      return result.rows.map((r) => r.id);
+    });
+
+    expect(rows).toEqual(SAMPLE_UUIDS);
+  });
+
+  it('drops the temp table on commit so subsequent transactions see it gone', async () => {
+    // Run once to create + commit + drop the table.
+    await withFgaFilterIds(CoreDbClient, SAMPLE_UUIDS, async () => 'first-tx');
+
+    // The temp table should not exist outside the transaction. Open a fresh
+    // transaction and ask Postgres directly: if the table still existed, this
+    // SELECT would succeed; instead it must error with the Postgres "undefined
+    // table" error (SQLSTATE 42P01 — "relation X does not exist"). The Drizzle
+    // pg adapter wraps the underlying pg error in a `DrizzleQueryError`, so
+    // the SQLSTATE code and human-readable message live on `error.cause`.
+    // Asserting on both pins the failure mode so a future implementation that
+    // swapped `ON COMMIT DROP` for `ON COMMIT DELETE ROWS` (leaving the table
+    // in place but empty) would fail this test.
+    await expect(
+      CoreDbClient.transaction(async (tx) => {
+        return tx.execute(sql`SELECT 1 FROM fga_filter_ids LIMIT 1`);
+      }),
+    ).rejects.toMatchObject({
+      cause: {
+        message: expect.stringMatching(/relation .*fga_filter_ids.* does not exist/i),
+        code: '42P01',
+      },
+    });
+  });
+
+  it('drops the temp table on rollback so subsequent transactions see it gone', async () => {
+    // Force the callback to throw → transaction rolls back. The ON COMMIT DROP
+    // semantics also drop the table on rollback, so the next transaction must
+    // not see it.
+    await expect(
+      withFgaFilterIds(CoreDbClient, SAMPLE_UUIDS, async () => {
+        throw new Error('forced rollback');
+      }),
+    ).rejects.toThrow('forced rollback');
+
+    await expect(
+      CoreDbClient.transaction(async (tx) => {
+        return tx.execute(sql`SELECT 1 FROM fga_filter_ids LIMIT 1`);
+      }),
+    ).rejects.toMatchObject({
+      cause: {
+        message: expect.stringMatching(/relation .*fga_filter_ids.* does not exist/i),
+        code: '42P01',
+      },
+    });
+  });
+
+  it("isolates concurrent transactions — one session does not see another session's temp table", async () => {
+    // Two `withFgaFilterIds` calls running in parallel must each see only their
+    // own ids. The temp table is session-scoped; pg pool checks out separate
+    // connections so the two transactions don't share state.
+    const idsA = ['aaaaaaaa-0001-0001-0001-000000000001'];
+    const idsB = ['bbbbbbbb-0002-0002-0002-000000000002'];
+
+    const [resultA, resultB] = await Promise.all([
+      withFgaFilterIds(CoreDbClient, idsA, async (tx) => {
+        const r = await tx.execute<{ id: string }>(sql`SELECT id::text AS id FROM fga_filter_ids ORDER BY id`);
+        return r.rows.map((row) => row.id);
+      }),
+      withFgaFilterIds(CoreDbClient, idsB, async (tx) => {
+        const r = await tx.execute<{ id: string }>(sql`SELECT id::text AS id FROM fga_filter_ids ORDER BY id`);
+        return r.rows.map((row) => row.id);
+      }),
+    ]);
+
+    expect(resultA).toEqual(idsA);
+    expect(resultB).toEqual(idsB);
+  });
+
+  it('supports an INNER JOIN against fga_filter_ids — the canonical consumer pattern', async () => {
+    // Synthetic 1-row VALUES set, joined against the temp table. This mimics
+    // what production consumers will do (join real tables against fga_filter_ids
+    // to filter by FGA-resolved IDs) without requiring a fixture row in the
+    // schema-managed tables.
+    const rows = await withFgaFilterIds(CoreDbClient, SAMPLE_UUIDS, async (tx) => {
+      const result = await tx.execute<{ id: string }>(sql`
+        SELECT v.id::text AS id
+        FROM (VALUES
+          (${SAMPLE_UUIDS[0]}::uuid),
+          (${SAMPLE_UUIDS[1]}::uuid),
+          ('99999999-9999-9999-9999-999999999999'::uuid)
+        ) AS v(id)
+        INNER JOIN fga_filter_ids fga ON fga.id = v.id
+        ORDER BY v.id
+      `);
+      return result.rows.map((r) => r.id);
+    });
+
+    // The third VALUES row isn't in the temp table, so the JOIN excludes it.
+    expect(rows).toEqual([SAMPLE_UUIDS[0], SAMPLE_UUIDS[1]]);
+  });
+
+  it('handles an empty ids array (temp table exists but has no rows)', async () => {
+    const count = await withFgaFilterIds(CoreDbClient, [], async (tx) => {
+      const result = await tx.execute<{ n: string }>(sql`SELECT COUNT(*)::text AS n FROM fga_filter_ids`);
+      return Number(result.rows[0]!.n);
+    });
+
+    expect(count).toBe(0);
+  });
+});

--- a/apps/backend/src/repositories/utils/fga-filter-ids.utils.test.ts
+++ b/apps/backend/src/repositories/utils/fga-filter-ids.utils.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it, vi } from 'vitest';
+import { collectStreamedFgaObjects, withFgaFilterIds } from './fga-filter-ids.utils';
+
+describe('withFgaFilterIds', () => {
+  /**
+   * Helper that simulates the minimal Drizzle surface withFgaFilterIds needs:
+   * `db.transaction(callback)` and a `tx.execute(...)` method that records the
+   * SQL fragments it received. Returning a `tx`-like object lets the unit test
+   * run without a real Postgres connection.
+   */
+  interface FakeTx {
+    execute: ReturnType<typeof vi.fn>;
+  }
+
+  function createFakeDb() {
+    const executeCalls: { sql: string; params: unknown[] }[] = [];
+    const tx: FakeTx = {
+      execute: vi.fn(async (query: { queryChunks?: unknown[] }) => {
+        // Best-effort string capture for assertions; the real Drizzle SQL object
+        // exposes queryChunks but here we only need to know that execute fired.
+        executeCalls.push({
+          sql: JSON.stringify(query?.queryChunks ?? query),
+          params: [],
+        });
+        return undefined;
+      }),
+    };
+
+    const db = {
+      transaction: vi.fn(async <R>(cb: (tx: FakeTx) => Promise<R>) => cb(tx)),
+    };
+
+    return { db, tx, executeCalls };
+  }
+
+  it('opens a transaction and creates the temp table', async () => {
+    const { db, tx } = createFakeDb();
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await withFgaFilterIds(db as any, ['id-1'], async () => 'ok');
+
+    expect(db.transaction).toHaveBeenCalledTimes(1);
+    expect(tx.execute).toHaveBeenCalled();
+  });
+
+  it('skips inserts when the ids array is empty but still creates the temp table', async () => {
+    const { db, tx } = createFakeDb();
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const result = await withFgaFilterIds(db as any, [], async () => 'callback-result');
+
+    expect(result).toBe('callback-result');
+    // exactly one execute (the CREATE TEMP TABLE), no INSERT
+    expect(tx.execute).toHaveBeenCalledTimes(1);
+  });
+
+  it('chunks inserts when ids exceed the chunk size', async () => {
+    const { db, tx } = createFakeDb();
+    // Generate 12,000 ids, chunk size is 5000 → 1 create + 3 inserts = 4 execute calls
+    const ids = Array.from({ length: 12_000 }, (_, i) => `id-${i}`);
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await withFgaFilterIds(db as any, ids, async () => undefined);
+
+    expect(tx.execute).toHaveBeenCalledTimes(1 + 3);
+  });
+
+  it('returns the callback result', async () => {
+    const { db } = createFakeDb();
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const result = await withFgaFilterIds(db as any, ['id-1'], async () => ({ count: 42 }));
+
+    expect(result).toEqual({ count: 42 });
+  });
+});
+
+describe('collectStreamedFgaObjects', () => {
+  it('collects all objects from an async generator', async () => {
+    async function* gen() {
+      yield { object: 'administration:abc' };
+      yield { object: 'administration:def' };
+      yield { object: 'administration:ghi' };
+    }
+
+    const result = await collectStreamedFgaObjects(gen());
+
+    expect(result).toEqual(['administration:abc', 'administration:def', 'administration:ghi']);
+  });
+
+  it('returns an empty array for an empty generator', async () => {
+    async function* gen() {
+      // intentionally yields nothing
+    }
+
+    const result = await collectStreamedFgaObjects(gen());
+
+    expect(result).toEqual([]);
+  });
+
+  it('propagates errors from the generator', async () => {
+    async function* gen() {
+      yield { object: 'administration:abc' };
+      throw new Error('stream failed');
+    }
+
+    await expect(collectStreamedFgaObjects(gen())).rejects.toThrow('stream failed');
+  });
+});

--- a/apps/backend/src/repositories/utils/fga-filter-ids.utils.test.ts
+++ b/apps/backend/src/repositories/utils/fga-filter-ids.utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
-import { collectStreamedFgaObjects, withFgaFilterIds } from './fga-filter-ids.utils';
+import { withFgaFilterIds } from './fga-filter-ids.utils';
 
 describe('withFgaFilterIds', () => {
   /**
@@ -65,6 +65,26 @@ describe('withFgaFilterIds', () => {
     expect(tx.execute).toHaveBeenCalledTimes(1 + 3);
   });
 
+  // Boundary tests: exact chunk-size, one-over, and one-under. Off-by-one errors
+  // around the chunking loop would silently double-insert or drop rows, so these
+  // are explicit even if they look redundant.
+  it.each([
+    { length: 4_999, expectedInserts: 1 },
+    { length: 5_000, expectedInserts: 1 },
+    { length: 5_001, expectedInserts: 2 },
+    { length: 10_000, expectedInserts: 2 },
+    { length: 10_001, expectedInserts: 3 },
+  ])('chunks correctly at boundary: $length ids → $expectedInserts INSERT(s)', async ({ length, expectedInserts }) => {
+    const { db, tx } = createFakeDb();
+    const ids = Array.from({ length }, (_, i) => `id-${i}`);
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await withFgaFilterIds(db as any, ids, async () => undefined);
+
+    // 1 CREATE TEMP TABLE + N INSERTs
+    expect(tx.execute).toHaveBeenCalledTimes(1 + expectedInserts);
+  });
+
   it('returns the callback result', async () => {
     const { db } = createFakeDb();
 
@@ -73,37 +93,46 @@ describe('withFgaFilterIds', () => {
 
     expect(result).toEqual({ count: 42 });
   });
-});
 
-describe('collectStreamedFgaObjects', () => {
-  it('collects all objects from an async generator', async () => {
-    async function* gen() {
-      yield { object: 'administration:abc' };
-      yield { object: 'administration:def' };
-      yield { object: 'administration:ghi' };
-    }
+  it('propagates errors from the callback so the transaction rolls back', async () => {
+    const { db } = createFakeDb();
+    const callbackError = new Error('callback exploded');
 
-    const result = await collectStreamedFgaObjects(gen());
+    await expect(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      withFgaFilterIds(db as any, ['id-1'], async () => {
+        throw callbackError;
+      }),
+    ).rejects.toThrow('callback exploded');
 
-    expect(result).toEqual(['administration:abc', 'administration:def', 'administration:ghi']);
+    // The transaction was opened — rollback is the responsibility of Drizzle's
+    // transaction wrapper, but we verify here that the error is not swallowed.
+    expect(db.transaction).toHaveBeenCalledTimes(1);
   });
 
-  it('returns an empty array for an empty generator', async () => {
-    async function* gen() {
-      // intentionally yields nothing
-    }
+  it('does not catch DB errors during temp-table creation', async () => {
+    // If the CREATE TEMP TABLE fails (e.g., permissions, connection drop),
+    // the error must propagate so the caller can wrap it appropriately
+    // — the helper does not silently swallow infrastructure failures.
+    const ddlError = new Error('cannot create temp table');
+    const tx: FakeTx = {
+      execute: vi.fn(async () => {
+        throw ddlError;
+      }),
+    };
+    const db = {
+      transaction: vi.fn(async <R>(cb: (tx: FakeTx) => Promise<R>) => cb(tx)),
+    };
 
-    const result = await collectStreamedFgaObjects(gen());
+    let callbackInvoked = false;
+    await expect(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      withFgaFilterIds(db as any, ['id-1'], async () => {
+        callbackInvoked = true;
+        return 'unreachable';
+      }),
+    ).rejects.toThrow('cannot create temp table');
 
-    expect(result).toEqual([]);
-  });
-
-  it('propagates errors from the generator', async () => {
-    async function* gen() {
-      yield { object: 'administration:abc' };
-      throw new Error('stream failed');
-    }
-
-    await expect(collectStreamedFgaObjects(gen())).rejects.toThrow('stream failed');
+    expect(callbackInvoked).toBe(false);
   });
 });

--- a/apps/backend/src/repositories/utils/fga-filter-ids.utils.ts
+++ b/apps/backend/src/repositories/utils/fga-filter-ids.utils.ts
@@ -1,6 +1,8 @@
 import { sql } from 'drizzle-orm';
 import type { NodePgDatabase } from 'drizzle-orm/node-postgres';
+import type { NodePgQueryResultHKT } from 'drizzle-orm/node-postgres';
 import type { PgTransaction } from 'drizzle-orm/pg-core';
+import type { TablesRelationalConfig } from 'drizzle-orm/relations';
 
 /**
  * Maximum number of UUIDs to insert per `INSERT ... VALUES (...)` statement.
@@ -15,10 +17,17 @@ const FGA_FILTER_INSERT_CHUNK_SIZE = 5000;
  *
  * Why `unknown`/dynamic schema? Repositories may use either the core or assessment
  * Drizzle schemas, and `withFgaFilterIds` is schema-agnostic — it only issues raw
- * `sql` template literals and never accesses typed schema columns.
+ * `sql` template literals and never accesses typed schema columns. The
+ * `NodePgQueryResultHKT` is preserved (rather than `any`) so that
+ * `tx.execute<TRow>(...)` returns `Promise<QueryResult<TRow>>` and callers get
+ * properly-typed `result.rows[]`.
  */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export type FgaFilterTx = PgTransaction<any, any, any>;
+export type FgaFilterTx = PgTransaction<
+  NodePgQueryResultHKT,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  Record<string, any>,
+  TablesRelationalConfig
+>;
 
 /**
  * Run `callback` inside a Drizzle transaction with the given UUIDs materialized
@@ -36,9 +45,12 @@ export type FgaFilterTx = PgTransaction<any, any, any>;
  *   - The planner picks worse plans than it would for a temp-table JOIN.
  *
  * The administration / district / school domains are low-cardinality (a user
- * rarely has access to thousands of administrations). The user / class domains
- * will hit this scale as soon as they migrate to FGA — those repositories
- * should adopt `withFgaFilterIds()`.
+ * rarely has access to thousands of administrations). The class domain will
+ * hit this scale as soon as `AdministrationService.getAdministrationTree`'s
+ * class branch migrates to FGA-driven listing — that repository should adopt
+ * `withFgaFilterIds()`. The user domain is intentionally untouched: the FGA
+ * model has no `type user` relations, so there are no
+ * `listAccessibleObjects(..., FgaType.USER)` calls to migrate.
  *
  * ## Behavior
  *
@@ -53,19 +65,29 @@ export type FgaFilterTx = PgTransaction<any, any, any>;
  *    literals or via Drizzle's `sql` helper.
  *
  * If `ids` is empty, the temp table is still created (so callbacks that reference
- * it don't fail) but no rows are inserted. The expectation is that the caller
- * short-circuits the empty case before invoking this helper, but the no-row
- * fallback keeps the helper robust.
+ * it don't fail) but no rows are inserted. **Callers should short-circuit the
+ * empty case before invoking this helper** — otherwise you pay for a
+ * transaction + DDL round-trip just to materialize a guaranteed-empty JOIN
+ * result. The no-row fallback exists to keep the helper robust against rare
+ * race conditions; it is not an optimized path.
  *
  * @param db - Drizzle database client (any schema)
- * @param ids - FGA-resolved UUIDs to materialize
+ * @param ids - FGA-resolved UUIDs to materialize. **Must be distinct** — the
+ *              temp table declares `id uuid PRIMARY KEY`, so duplicate UUIDs
+ *              will fail the INSERT with a Postgres `23505` (unique-violation)
+ *              error. FGA's `streamedListObjects` returns distinct objects
+ *              (it's a set operation), so this is normally satisfied by
+ *              construction. If you merge results from multiple FGA calls or
+ *              concatenate generator runs, de-dupe via `new Set(ids)` first.
  * @param callback - Invoked with the transaction handle so SQL inside it can
  *                   `INNER JOIN fga_filter_ids` to filter results
  * @returns The value returned by `callback`
  *
  * @example
  * ```typescript
- * const ids = await collectStreamedFgaIds(generator);
+ * // Collect a high-cardinality FGA stream into an array first (use
+ * // `collectStreamedFgaObjects` from `services/authorization/helpers/`),
+ * // then feed it into the temp-table join.
  * const items = await withFgaFilterIds(db, ids, async (tx) => {
  *   return tx.execute(sql`
  *     SELECT u.* FROM users u
@@ -99,25 +121,4 @@ export async function withFgaFilterIds<R>(
 
     return callback(tx as FgaFilterTx);
   });
-}
-
-/**
- * Collect an async generator of FGA streamed-list-objects responses into an
- * array of fully-qualified object strings.
- *
- * Production callers usually want this when they need a single materialized
- * list of object IDs. For very high-cardinality cases prefer iterating the
- * generator directly so you don't hold the whole list in memory.
- *
- * @param generator - Generator yielding `{ object: string }` chunks (the SDK's
- *                    `StreamedListObjectsResponse` shape)
- * @returns Promise resolving to an array of fully-qualified FGA object strings
- *          (e.g., `['administration:abc-123', 'administration:def-456']`)
- */
-export async function collectStreamedFgaObjects(generator: AsyncIterable<{ object: string }>): Promise<string[]> {
-  const objects: string[] = [];
-  for await (const chunk of generator) {
-    objects.push(chunk.object);
-  }
-  return objects;
 }

--- a/apps/backend/src/repositories/utils/fga-filter-ids.utils.ts
+++ b/apps/backend/src/repositories/utils/fga-filter-ids.utils.ts
@@ -1,0 +1,123 @@
+import { sql } from 'drizzle-orm';
+import type { NodePgDatabase } from 'drizzle-orm/node-postgres';
+import type { PgTransaction } from 'drizzle-orm/pg-core';
+
+/**
+ * Maximum number of UUIDs to insert per `INSERT ... VALUES (...)` statement.
+ *
+ * Postgres has a hard limit of ~65,535 parameters per query; chunking keeps each
+ * insert well under that ceiling and avoids large query plans.
+ */
+const FGA_FILTER_INSERT_CHUNK_SIZE = 5000;
+
+/**
+ * Drizzle transaction handle, narrowed to the surface this helper needs.
+ *
+ * Why `unknown`/dynamic schema? Repositories may use either the core or assessment
+ * Drizzle schemas, and `withFgaFilterIds` is schema-agnostic — it only issues raw
+ * `sql` template literals and never accesses typed schema columns.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type FgaFilterTx = PgTransaction<any, any, any>;
+
+/**
+ * Run `callback` inside a Drizzle transaction with the given UUIDs materialized
+ * into a session-scoped temp table named `fga_filter_ids` so SQL can `INNER JOIN`
+ * against them instead of `WHERE id IN (...)`.
+ *
+ * ## When to use this helper
+ *
+ * Prefer `inArray()` (and `BaseRepository.getByIds()`) for low-cardinality FGA
+ * results — typically ≤ ~500 ids — where the planner handles `IN (...)` well.
+ *
+ * Switch to `withFgaFilterIds()` for high-cardinality FGA results (thousands of
+ * ids), where:
+ *   - The bind-parameter cost of `IN (...)` becomes significant.
+ *   - The planner picks worse plans than it would for a temp-table JOIN.
+ *
+ * The administration / district / school domains are low-cardinality (a user
+ * rarely has access to thousands of administrations). The user / class domains
+ * will hit this scale as soon as they migrate to FGA — those repositories
+ * should adopt `withFgaFilterIds()`.
+ *
+ * ## Behavior
+ *
+ * 1. Opens a transaction.
+ * 2. Creates `TEMP TABLE fga_filter_ids (id uuid PRIMARY KEY) ON COMMIT DROP`.
+ *    The table is local to the session and dropped automatically when the
+ *    transaction commits or rolls back, so concurrent requests don't collide.
+ * 3. Bulk-inserts `ids` in chunks of {@link FGA_FILTER_INSERT_CHUNK_SIZE} via
+ *    parameterized `INSERT ... VALUES ($1), ($2), ...`.
+ * 4. Invokes `callback(tx)` with the transaction handle. Compose your `INNER
+ *    JOIN fga_filter_ids fga ON fga.id = <table>.id` inside `sql\`...\`` template
+ *    literals or via Drizzle's `sql` helper.
+ *
+ * If `ids` is empty, the temp table is still created (so callbacks that reference
+ * it don't fail) but no rows are inserted. The expectation is that the caller
+ * short-circuits the empty case before invoking this helper, but the no-row
+ * fallback keeps the helper robust.
+ *
+ * @param db - Drizzle database client (any schema)
+ * @param ids - FGA-resolved UUIDs to materialize
+ * @param callback - Invoked with the transaction handle so SQL inside it can
+ *                   `INNER JOIN fga_filter_ids` to filter results
+ * @returns The value returned by `callback`
+ *
+ * @example
+ * ```typescript
+ * const ids = await collectStreamedFgaIds(generator);
+ * const items = await withFgaFilterIds(db, ids, async (tx) => {
+ *   return tx.execute(sql`
+ *     SELECT u.* FROM users u
+ *     INNER JOIN fga_filter_ids fga ON fga.id = u.id
+ *     WHERE u.rostering_ended IS NULL
+ *     ORDER BY u.name_last
+ *   `);
+ * });
+ * ```
+ */
+export async function withFgaFilterIds<R>(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  db: NodePgDatabase<any>,
+  ids: readonly string[],
+  callback: (tx: FgaFilterTx) => Promise<R>,
+): Promise<R> {
+  return db.transaction(async (tx) => {
+    await tx.execute(sql`CREATE TEMP TABLE fga_filter_ids (id uuid PRIMARY KEY) ON COMMIT DROP`);
+
+    if (ids.length > 0) {
+      for (let offset = 0; offset < ids.length; offset += FGA_FILTER_INSERT_CHUNK_SIZE) {
+        const chunk = ids.slice(offset, offset + FGA_FILTER_INSERT_CHUNK_SIZE);
+        // Build a single multi-row INSERT with parameterized placeholders
+        const valuesSql = sql.join(
+          chunk.map((id) => sql`(${id}::uuid)`),
+          sql`, `,
+        );
+        await tx.execute(sql`INSERT INTO fga_filter_ids (id) VALUES ${valuesSql}`);
+      }
+    }
+
+    return callback(tx as FgaFilterTx);
+  });
+}
+
+/**
+ * Collect an async generator of FGA streamed-list-objects responses into an
+ * array of fully-qualified object strings.
+ *
+ * Production callers usually want this when they need a single materialized
+ * list of object IDs. For very high-cardinality cases prefer iterating the
+ * generator directly so you don't hold the whole list in memory.
+ *
+ * @param generator - Generator yielding `{ object: string }` chunks (the SDK's
+ *                    `StreamedListObjectsResponse` shape)
+ * @returns Promise resolving to an array of fully-qualified FGA object strings
+ *          (e.g., `['administration:abc-123', 'administration:def-456']`)
+ */
+export async function collectStreamedFgaObjects(generator: AsyncIterable<{ object: string }>): Promise<string[]> {
+  const objects: string[] = [];
+  for await (const chunk of generator) {
+    objects.push(chunk.object);
+  }
+  return objects;
+}

--- a/apps/backend/src/services/authorization/authorization.service.test.ts
+++ b/apps/backend/src/services/authorization/authorization.service.test.ts
@@ -311,6 +311,123 @@ describe('AuthorizationService', () => {
     });
   });
 
+  describe('hasAnyPermission', () => {
+    it('returns false without calling the SDK when the objects array is empty', async () => {
+      const service = AuthorizationService({ client: mockClient as unknown as OpenFgaClient });
+
+      const result = await service.hasAnyPermission('user-123', 'can_read', []);
+
+      expect(result).toBe(false);
+      expect(mockClient.batchCheck).not.toHaveBeenCalled();
+    });
+
+    it('returns true when at least one batch check is allowed', async () => {
+      mockClient.batchCheck.mockResolvedValueOnce({
+        result: [{ allowed: false }, { allowed: true }],
+      });
+      const service = AuthorizationService({ client: mockClient as unknown as OpenFgaClient });
+
+      const result = await service.hasAnyPermission('user-123', 'can_read', [
+        'administration:aaa',
+        'administration:bbb',
+      ]);
+
+      expect(result).toBe(true);
+      expect(mockClient.batchCheck).toHaveBeenCalledWith({
+        checks: [
+          {
+            user: 'user:user-123',
+            relation: 'can_read',
+            object: 'administration:aaa',
+            context: { current_time: expect.any(String) },
+          },
+          {
+            user: 'user:user-123',
+            relation: 'can_read',
+            object: 'administration:bbb',
+            context: { current_time: expect.any(String) },
+          },
+        ],
+      });
+    });
+
+    it('returns false when no batch check is allowed', async () => {
+      mockClient.batchCheck.mockResolvedValueOnce({
+        result: [{ allowed: false }, { allowed: false }],
+      });
+      const service = AuthorizationService({ client: mockClient as unknown as OpenFgaClient });
+
+      const result = await service.hasAnyPermission('user-123', 'can_read', [
+        'administration:aaa',
+        'administration:bbb',
+      ]);
+
+      expect(result).toBe(false);
+    });
+
+    it('returns false when batch check results have no `allowed` property set', async () => {
+      // FGA returns omitted `allowed` for deny — exercises the `=== true` strictness
+      // in the production code (so `undefined` is correctly treated as false).
+      mockClient.batchCheck.mockResolvedValueOnce({
+        result: [{}, {}],
+      });
+      const service = AuthorizationService({ client: mockClient as unknown as OpenFgaClient });
+
+      const result = await service.hasAnyPermission('user-123', 'can_read', ['administration:aaa']);
+
+      expect(result).toBe(false);
+    });
+
+    it('wraps batch check errors in ApiError with EXTERNAL_SERVICE_FAILED', async () => {
+      const sdkError = new Error('FGA batch check failed');
+      mockClient.batchCheck.mockRejectedValueOnce(sdkError);
+      const service = AuthorizationService({ client: mockClient as unknown as OpenFgaClient });
+
+      await expect(service.hasAnyPermission('user-123', 'can_read', ['administration:aaa'])).rejects.toThrow(
+        expect.objectContaining({
+          message: ApiErrorMessage.EXTERNAL_SERVICE_UNAVAILABLE,
+          statusCode: StatusCodes.INTERNAL_SERVER_ERROR,
+          code: ApiErrorCode.EXTERNAL_SERVICE_FAILED,
+        }),
+      );
+    });
+
+    it('logs error context when the batch check fails', async () => {
+      const sdkError = new Error('FGA batch check failed');
+      mockClient.batchCheck.mockRejectedValueOnce(sdkError);
+      const service = AuthorizationService({ client: mockClient as unknown as OpenFgaClient });
+
+      await service
+        .hasAnyPermission('user-123', 'can_read', ['administration:aaa', 'administration:bbb'])
+        .catch(() => {});
+
+      expect(logger.error).toHaveBeenCalledWith(
+        { err: sdkError, context: { userId: 'user-123', relation: 'can_read', objectCount: 2 } },
+        'FGA batch check failed',
+      );
+    });
+
+    it('includes context in the thrown ApiError', async () => {
+      const sdkError = new Error('FGA batch check failed');
+      mockClient.batchCheck.mockRejectedValueOnce(sdkError);
+      const service = AuthorizationService({ client: mockClient as unknown as OpenFgaClient });
+
+      try {
+        await service.hasAnyPermission('user-123', 'can_read', ['administration:aaa', 'administration:bbb']);
+        expect.fail('Expected hasAnyPermission to throw');
+      } catch (error) {
+        expect(error).toBeInstanceOf(ApiError);
+        const apiError = error as ApiError;
+        expect(apiError.context).toEqual({
+          userId: 'user-123',
+          relation: 'can_read',
+          objectCount: 2,
+        });
+        expect(apiError.cause).toBe(sdkError);
+      }
+    });
+  });
+
   describe('listAccessibleObjects', () => {
     it('collects streamed object IDs into an array', async () => {
       const objects = ['administration:aaa', 'administration:bbb'];
@@ -372,6 +489,29 @@ describe('AuthorizationService', () => {
         'FGA streamed list accessible objects failed',
       );
     });
+
+    it('wraps synchronous SDK setup errors in ApiError with EXTERNAL_SERVICE_FAILED', async () => {
+      // Simulate the SDK throwing before iteration begins (e.g., network setup,
+      // bad credentials). The error is raised from `client.streamedListObjects(...)`
+      // itself, not from a `for await` step.
+      const sdkError = new Error('FGA streamedListObjects setup failed');
+      mockClient.streamedListObjects.mockImplementation(() => {
+        throw sdkError;
+      });
+      const service = AuthorizationService({ client: mockClient as unknown as OpenFgaClient });
+
+      await expect(service.listAccessibleObjects('user-123', 'can_read', 'administration')).rejects.toThrow(
+        expect.objectContaining({
+          message: ApiErrorMessage.EXTERNAL_SERVICE_UNAVAILABLE,
+          statusCode: StatusCodes.INTERNAL_SERVER_ERROR,
+          code: ApiErrorCode.EXTERNAL_SERVICE_FAILED,
+        }),
+      );
+      expect(logger.error).toHaveBeenCalledWith(
+        { err: sdkError, context: { userId: 'user-123', relation: 'can_read', type: 'administration' } },
+        'FGA streamed list accessible objects failed',
+      );
+    });
   });
 
   describe('listAccessibleObjectsStreamed', () => {
@@ -417,6 +557,59 @@ describe('AuthorizationService', () => {
       await expect(async () => {
         for await (const chunk of service.listAccessibleObjectsStreamed('user-123', 'can_read', 'administration')) {
           // touch chunk so the loop variable is used
+          void chunk.object;
+        }
+      }).rejects.toThrow(
+        expect.objectContaining({
+          message: ApiErrorMessage.EXTERNAL_SERVICE_UNAVAILABLE,
+          code: ApiErrorCode.EXTERNAL_SERVICE_FAILED,
+        }),
+      );
+    });
+
+    it('yields nothing when the FGA stream is empty', async () => {
+      mockStreamedListObjects(mockClient, []);
+      const service = AuthorizationService({ client: mockClient as unknown as OpenFgaClient });
+
+      const collected: string[] = [];
+      for await (const chunk of service.listAccessibleObjectsStreamed('user-123', 'can_read', 'administration')) {
+        collected.push(chunk.object);
+      }
+
+      expect(collected).toEqual([]);
+    });
+
+    it('logs error context when the stream fails mid-iteration', async () => {
+      const sdkError = new Error('FGA streamed iteration failed');
+      mockStreamedListObjectsError(mockClient, sdkError);
+      const service = AuthorizationService({ client: mockClient as unknown as OpenFgaClient });
+
+      try {
+        for await (const chunk of service.listAccessibleObjectsStreamed('user-123', 'can_read', 'administration')) {
+          void chunk.object;
+        }
+      } catch {
+        // swallow — assertion is on the logger call
+      }
+
+      expect(logger.error).toHaveBeenCalledWith(
+        { err: sdkError, context: { userId: 'user-123', relation: 'can_read', type: 'administration' } },
+        'FGA streamed list accessible objects failed',
+      );
+    });
+
+    it('wraps synchronous SDK setup errors in ApiError with EXTERNAL_SERVICE_FAILED', async () => {
+      // The generator function awaits `client.streamedListObjects` lazily on first
+      // iteration. If the SDK throws synchronously at call time, the error must still
+      // be wrapped in ApiError when the consumer iterates.
+      const sdkError = new Error('FGA streamedListObjects setup failed');
+      mockClient.streamedListObjects.mockImplementation(() => {
+        throw sdkError;
+      });
+      const service = AuthorizationService({ client: mockClient as unknown as OpenFgaClient });
+
+      await expect(async () => {
+        for await (const chunk of service.listAccessibleObjectsStreamed('user-123', 'can_read', 'administration')) {
           void chunk.object;
         }
       }).rejects.toThrow(

--- a/apps/backend/src/services/authorization/authorization.service.test.ts
+++ b/apps/backend/src/services/authorization/authorization.service.test.ts
@@ -6,7 +6,11 @@ import { ApiErrorCode } from '../../enums/api-error-code.enum';
 import { ApiErrorMessage } from '../../enums/api-error-message.enum';
 import { ApiError } from '../../errors/api-error';
 import type { MockFgaClient } from '../../test-support/clients/fga.client';
-import { createMockFgaClient } from '../../test-support/clients/fga.client';
+import {
+  createMockFgaClient,
+  mockStreamedListObjects,
+  mockStreamedListObjectsError,
+} from '../../test-support/clients/fga.client';
 import { AuthorizationService } from './authorization.service';
 
 let mockClient: MockFgaClient;
@@ -308,15 +312,15 @@ describe('AuthorizationService', () => {
   });
 
   describe('listAccessibleObjects', () => {
-    it('returns object IDs from the FGA client', async () => {
+    it('collects streamed object IDs into an array', async () => {
       const objects = ['administration:aaa', 'administration:bbb'];
-      mockClient.listObjects.mockResolvedValueOnce({ objects });
+      mockStreamedListObjects(mockClient, objects);
       const service = AuthorizationService({ client: mockClient as unknown as OpenFgaClient });
 
       const result = await service.listAccessibleObjects('user-123', 'can_read', 'administration');
 
       expect(result).toEqual(objects);
-      expect(mockClient.listObjects).toHaveBeenCalledWith({
+      expect(mockClient.streamedListObjects).toHaveBeenCalledWith({
         user: 'user:user-123',
         relation: 'can_read',
         type: 'administration',
@@ -325,7 +329,7 @@ describe('AuthorizationService', () => {
     });
 
     it('returns an empty array when no objects are accessible', async () => {
-      mockClient.listObjects.mockResolvedValueOnce({ objects: [] });
+      mockStreamedListObjects(mockClient, []);
       const service = AuthorizationService({ client: mockClient as unknown as OpenFgaClient });
 
       const result = await service.listAccessibleObjects('user-123', 'can_read', 'administration');
@@ -333,9 +337,18 @@ describe('AuthorizationService', () => {
       expect(result).toEqual([]);
     });
 
-    it('wraps FGA client errors in ApiError with EXTERNAL_SERVICE_FAILED', async () => {
-      const sdkError = new Error('FGA listObjects failed');
-      mockClient.listObjects.mockRejectedValueOnce(sdkError);
+    it('does not call the deprecated listObjects API', async () => {
+      mockStreamedListObjects(mockClient, ['administration:aaa']);
+      const service = AuthorizationService({ client: mockClient as unknown as OpenFgaClient });
+
+      await service.listAccessibleObjects('user-123', 'can_read', 'administration');
+
+      expect(mockClient.listObjects).not.toHaveBeenCalled();
+    });
+
+    it('wraps streamed-list errors in ApiError with EXTERNAL_SERVICE_FAILED', async () => {
+      const sdkError = new Error('FGA streamedListObjects failed');
+      mockStreamedListObjectsError(mockClient, sdkError);
       const service = AuthorizationService({ client: mockClient as unknown as OpenFgaClient });
 
       await expect(service.listAccessibleObjects('user-123', 'can_read', 'administration')).rejects.toThrow(
@@ -347,16 +360,70 @@ describe('AuthorizationService', () => {
       );
     });
 
-    it('logs error when FGA client fails', async () => {
-      const sdkError = new Error('FGA listObjects failed');
-      mockClient.listObjects.mockRejectedValueOnce(sdkError);
+    it('logs error when the FGA stream fails', async () => {
+      const sdkError = new Error('FGA streamedListObjects failed');
+      mockStreamedListObjectsError(mockClient, sdkError);
       const service = AuthorizationService({ client: mockClient as unknown as OpenFgaClient });
 
       await service.listAccessibleObjects('user-123', 'can_read', 'administration').catch(() => {});
 
       expect(logger.error).toHaveBeenCalledWith(
         { err: sdkError, context: { userId: 'user-123', relation: 'can_read', type: 'administration' } },
-        'FGA list accessible objects failed',
+        'FGA streamed list accessible objects failed',
+      );
+    });
+  });
+
+  describe('listAccessibleObjectsStreamed', () => {
+    it('yields objects from the FGA stream as a generator', async () => {
+      const objects = ['administration:aaa', 'administration:bbb', 'administration:ccc'];
+      mockStreamedListObjects(mockClient, objects);
+      const service = AuthorizationService({ client: mockClient as unknown as OpenFgaClient });
+
+      const collected: string[] = [];
+      for await (const chunk of service.listAccessibleObjectsStreamed('user-123', 'can_read', 'administration')) {
+        collected.push(chunk.object);
+      }
+
+      expect(collected).toEqual(objects);
+    });
+
+    it('passes current_time context to the SDK', async () => {
+      mockStreamedListObjects(mockClient, ['administration:aaa']);
+      const service = AuthorizationService({ client: mockClient as unknown as OpenFgaClient });
+
+      // Drain the generator
+      let count = 0;
+      for await (const chunk of service.listAccessibleObjectsStreamed('user-123', 'can_read', 'administration')) {
+        if (chunk.object) count += 1;
+      }
+      expect(count).toBe(1);
+
+      expect(mockClient.streamedListObjects).toHaveBeenCalledWith(
+        expect.objectContaining({
+          user: 'user:user-123',
+          relation: 'can_read',
+          type: 'administration',
+          context: { current_time: expect.any(String) },
+        }),
+      );
+    });
+
+    it('wraps iteration errors in ApiError with EXTERNAL_SERVICE_FAILED', async () => {
+      const sdkError = new Error('FGA streamed iteration failed');
+      mockStreamedListObjectsError(mockClient, sdkError);
+      const service = AuthorizationService({ client: mockClient as unknown as OpenFgaClient });
+
+      await expect(async () => {
+        for await (const chunk of service.listAccessibleObjectsStreamed('user-123', 'can_read', 'administration')) {
+          // touch chunk so the loop variable is used
+          void chunk.object;
+        }
+      }).rejects.toThrow(
+        expect.objectContaining({
+          message: ApiErrorMessage.EXTERNAL_SERVICE_UNAVAILABLE,
+          code: ApiErrorCode.EXTERNAL_SERVICE_FAILED,
+        }),
       );
     });
   });

--- a/apps/backend/src/services/authorization/authorization.service.ts
+++ b/apps/backend/src/services/authorization/authorization.service.ts
@@ -17,7 +17,8 @@ import { FgaType } from './fga-constants';
  * logged but not thrown, because the Postgres write has already succeeded and the
  * backfill endpoint (#06) will reconcile stale tuples.
  *
- * Permission checks (`hasPermission`, `listAccessibleObjects`) propagate errors to
+ * Permission checks (`hasPermission`, `requirePermission`, `hasAnyPermission`,
+ * `listAccessibleObjects`, `listAccessibleObjectsStreamed`) propagate errors to
  * callers — they are used in request-time authorization and must fail visibly.
  *
  * @param client - The OpenFGA client instance
@@ -155,10 +156,12 @@ export function AuthorizationService({
    * hitting the server-side cap on `listObjects` (default
    * `OPENFGA_LIST_OBJECTS_MAX_RESULTS = 1000`).
    *
-   * Use this directly for **high-cardinality domains** (users, classes) where the
+   * Use this directly for the **high-cardinality `class` domain** where the
    * caller wants to feed the IDs into a temp-table join rather than holding the
-   * full set in memory. For low-cardinality domains the convenience wrapper
-   * {@link listAccessibleObjects} collects the stream into a `string[]`.
+   * full set in memory. For low-cardinality domains (administration / district /
+   * school / group) the convenience wrapper {@link listAccessibleObjects}
+   * collects the stream into a `string[]`. The `user` domain has no FGA
+   * relations and is not a consumer of `listAccessibleObjects` at all.
    *
    * Errors thrown while iterating are wrapped in `ApiError` with the same
    * `EXTERNAL_SERVICE_FAILED` code as `listObjects` — this means consumers don't
@@ -211,10 +214,9 @@ export function AuthorizationService({
    * `client.listObjects`).
    *
    * Suitable for **low-cardinality domains** (administrations, districts,
-   * schools) where holding the full ID set in memory is fine. For
-   * high-cardinality domains (users, classes) iterate
-   * {@link listAccessibleObjectsStreamed} directly and feed the stream into a
-   * temp-table join via `withFgaFilterIds`.
+   * schools, groups) where holding the full ID set in memory is fine. For the
+   * high-cardinality `class` domain, iterate {@link listAccessibleObjectsStreamed}
+   * directly and feed the stream into a temp-table join via `withFgaFilterIds`.
    *
    * Passes `current_time` context so the `active_membership` condition evaluates
    * correctly for time-bound tuples.

--- a/apps/backend/src/services/authorization/authorization.service.ts
+++ b/apps/backend/src/services/authorization/authorization.service.ts
@@ -1,5 +1,5 @@
 import { StatusCodes } from 'http-status-codes';
-import type { OpenFgaClient, TupleKey, TupleKeyWithoutCondition } from '@openfga/sdk';
+import type { OpenFgaClient, StreamedListObjectsResponse, TupleKey, TupleKeyWithoutCondition } from '@openfga/sdk';
 import { FgaClient } from '../../clients/fga.client';
 import { ApiErrorCode } from '../../enums/api-error-code.enum';
 import { ApiErrorMessage } from '../../enums/api-error-message.enum';
@@ -149,13 +149,75 @@ export function AuthorizationService({
   }
 
   /**
-   * List all objects of a given type that a user has a specific relation on.
+   * Stream all objects of a given type that a user has a specific relation on.
+   *
+   * Wraps the FGA SDK's `streamedListObjects` so callers can iterate without
+   * hitting the server-side cap on `listObjects` (default
+   * `OPENFGA_LIST_OBJECTS_MAX_RESULTS = 1000`).
+   *
+   * Use this directly for **high-cardinality domains** (users, classes) where the
+   * caller wants to feed the IDs into a temp-table join rather than holding the
+   * full set in memory. For low-cardinality domains the convenience wrapper
+   * {@link listAccessibleObjects} collects the stream into a `string[]`.
+   *
+   * Errors thrown while iterating are wrapped in `ApiError` with the same
+   * `EXTERNAL_SERVICE_FAILED` code as `listObjects` — this means consumers don't
+   * have to add error handling around the `for await` loop.
    *
    * Passes `current_time` context so the `active_membership` condition evaluates
    * correctly for time-bound tuples.
    *
-   * Unlike tuple writes, errors propagate to callers — this is used in
-   * request-time authorization and must fail visibly.
+   * @param userId - The user ID (without the `user:` prefix)
+   * @param relation - The FGA relation to check (e.g., `can_read`)
+   * @param type - The FGA object type (e.g., `administration`)
+   * @returns AsyncGenerator yielding `StreamedListObjectsResponse` chunks, each with
+   *          a fully-qualified FGA object string in `.object`
+   * @throws {ApiError} EXTERNAL_SERVICE_UNAVAILABLE if the FGA stream fails
+   */
+  async function* listAccessibleObjectsStreamed(
+    userId: string,
+    relation: FgaRelation,
+    type: FgaType,
+  ): AsyncGenerator<StreamedListObjectsResponse> {
+    try {
+      const stream = client.streamedListObjects({
+        user: `${FgaType.USER}:${userId}`,
+        relation,
+        type,
+        context: { current_time: new Date().toISOString() },
+      });
+
+      for await (const chunk of stream) {
+        yield chunk;
+      }
+    } catch (error) {
+      logger.error({ err: error, context: { userId, relation, type } }, 'FGA streamed list accessible objects failed');
+      throw new ApiError(ApiErrorMessage.EXTERNAL_SERVICE_UNAVAILABLE, {
+        statusCode: StatusCodes.INTERNAL_SERVER_ERROR,
+        code: ApiErrorCode.EXTERNAL_SERVICE_FAILED,
+        context: { userId, relation, type },
+        cause: error,
+      });
+    }
+  }
+
+  /**
+   * List all objects of a given type that a user has a specific relation on.
+   *
+   * Convenience wrapper around {@link listAccessibleObjectsStreamed} that
+   * collects the stream into a `string[]`. The implementation uses
+   * `streamedListObjects` under the hood so result sets are not silently
+   * truncated by `OPENFGA_LIST_OBJECTS_MAX_RESULTS` (the cap that affects
+   * `client.listObjects`).
+   *
+   * Suitable for **low-cardinality domains** (administrations, districts,
+   * schools) where holding the full ID set in memory is fine. For
+   * high-cardinality domains (users, classes) iterate
+   * {@link listAccessibleObjectsStreamed} directly and feed the stream into a
+   * temp-table join via `withFgaFilterIds`.
+   *
+   * Passes `current_time` context so the `active_membership` condition evaluates
+   * correctly for time-bound tuples.
    *
    * @param userId - The user ID (without the `user:` prefix)
    * @param relation - The FGA relation to check (e.g., `can_read`)
@@ -164,23 +226,11 @@ export function AuthorizationService({
    * @throws {ApiError} EXTERNAL_SERVICE_UNAVAILABLE if the FGA list fails
    */
   async function listAccessibleObjects(userId: string, relation: FgaRelation, type: FgaType): Promise<string[]> {
-    try {
-      const result = await client.listObjects({
-        user: `${FgaType.USER}:${userId}`,
-        relation,
-        type,
-        context: { current_time: new Date().toISOString() },
-      });
-      return result.objects;
-    } catch (error) {
-      logger.error({ err: error, context: { userId, relation, type } }, 'FGA list accessible objects failed');
-      throw new ApiError(ApiErrorMessage.EXTERNAL_SERVICE_UNAVAILABLE, {
-        statusCode: StatusCodes.INTERNAL_SERVER_ERROR,
-        code: ApiErrorCode.EXTERNAL_SERVICE_FAILED,
-        context: { userId, relation, type },
-        cause: error,
-      });
+    const objects: string[] = [];
+    for await (const chunk of listAccessibleObjectsStreamed(userId, relation, type)) {
+      objects.push(chunk.object);
     }
+    return objects;
   }
 
   /**
@@ -233,6 +283,7 @@ export function AuthorizationService({
     hasPermission,
     requirePermission,
     listAccessibleObjects,
+    listAccessibleObjectsStreamed,
     hasAnyPermission,
   };
 }

--- a/apps/backend/src/services/authorization/helpers/collect-streamed-fga-objects.helper.test.ts
+++ b/apps/backend/src/services/authorization/helpers/collect-streamed-fga-objects.helper.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import { collectStreamedFgaObjects } from './collect-streamed-fga-objects.helper';
+
+describe('collectStreamedFgaObjects', () => {
+  it('collects all objects from an async generator', async () => {
+    async function* gen() {
+      yield { object: 'administration:abc' };
+      yield { object: 'administration:def' };
+      yield { object: 'administration:ghi' };
+    }
+
+    const result = await collectStreamedFgaObjects(gen());
+
+    expect(result).toEqual(['administration:abc', 'administration:def', 'administration:ghi']);
+  });
+
+  it('returns an empty array for an empty generator', async () => {
+    async function* gen() {
+      // intentionally yields nothing
+    }
+
+    const result = await collectStreamedFgaObjects(gen());
+
+    expect(result).toEqual([]);
+  });
+
+  it('propagates errors from the generator', async () => {
+    async function* gen() {
+      yield { object: 'administration:abc' };
+      throw new Error('stream failed');
+    }
+
+    await expect(collectStreamedFgaObjects(gen())).rejects.toThrow('stream failed');
+  });
+});

--- a/apps/backend/src/services/authorization/helpers/collect-streamed-fga-objects.helper.ts
+++ b/apps/backend/src/services/authorization/helpers/collect-streamed-fga-objects.helper.ts
@@ -1,0 +1,39 @@
+/**
+ * Collect an async generator of FGA streamed-list-objects responses into an
+ * array of fully-qualified object strings.
+ *
+ * Pairs with `AuthorizationService.listAccessibleObjectsStreamed`, which
+ * yields chunks shaped like the FGA SDK's `StreamedListObjectsResponse`
+ * (`{ object: string }`). Use this helper when the caller needs a single
+ * materialized list of object IDs (e.g., for a low-cardinality consumer that
+ * wants the convenience of `string[]`). For very high-cardinality cases
+ * prefer iterating the generator directly so the full list never lives in
+ * memory at once.
+ *
+ * ## Why this lives in `services/authorization/helpers/`
+ *
+ * The function is FGA-domain-specific (its input shape is the SDK's stream
+ * response) but layer-neutral — it doesn't touch the database. Co-locating
+ * it with the other FGA helpers (`extract-fga-object-id.helper.ts`) keeps
+ * services from importing across the service/repository layer boundary just
+ * to drain a stream.
+ *
+ * @param generator - Generator yielding `{ object: string }` chunks (the SDK's
+ *                    `StreamedListObjectsResponse` shape)
+ * @returns Promise resolving to an array of fully-qualified FGA object strings
+ *          (e.g., `['administration:abc-123', 'administration:def-456']`)
+ *
+ * @example
+ * ```typescript
+ * const ids = await collectStreamedFgaObjects(
+ *   authorizationService.listAccessibleObjectsStreamed(userId, FgaRelation.CAN_READ, FgaType.CLASS),
+ * );
+ * ```
+ */
+export async function collectStreamedFgaObjects(generator: AsyncIterable<{ object: string }>): Promise<string[]> {
+  const objects: string[] = [];
+  for await (const chunk of generator) {
+    objects.push(chunk.object);
+  }
+  return objects;
+}

--- a/apps/backend/src/test-support/clients/fga.client.ts
+++ b/apps/backend/src/test-support/clients/fga.client.ts
@@ -15,6 +15,7 @@ export interface MockFgaClient {
   deleteTuples: Mock;
   read: Mock;
   check: Mock;
+  batchCheck: Mock;
   listObjects: Mock;
   streamedListObjects: Mock;
 }
@@ -49,6 +50,7 @@ export function createMockFgaClient(): MockFgaClient {
     deleteTuples: vi.fn(),
     read: vi.fn().mockResolvedValue({ tuples: [], continuation_token: '' }),
     check: vi.fn().mockResolvedValue({ allowed: false }),
+    batchCheck: vi.fn().mockResolvedValue({ result: [] }),
     listObjects: vi.fn().mockResolvedValue({ objects: [] }),
     streamedListObjects: vi.fn().mockImplementation(makeEmptyStreamedListObjects()),
   };

--- a/apps/backend/src/test-support/clients/fga.client.ts
+++ b/apps/backend/src/test-support/clients/fga.client.ts
@@ -1,6 +1,6 @@
 import { vi } from 'vitest';
 import type { Mock } from 'vitest';
-import type { ReadResponse, TupleKey } from '@openfga/sdk';
+import type { ReadResponse, StreamedListObjectsResponse, TupleKey } from '@openfga/sdk';
 
 /**
  * Typed mock of the OpenFGA client methods used in tests.
@@ -16,13 +16,30 @@ export interface MockFgaClient {
   read: Mock;
   check: Mock;
   listObjects: Mock;
+  streamedListObjects: Mock;
+}
+
+/**
+ * Default `streamedListObjects` factory: returns an async generator that yields
+ * the configured object IDs (default: none).
+ *
+ * Tests that need a specific stream can override per-call via
+ * `mockStreamedListObjects(client, [...ids])` or `client.streamedListObjects.mockImplementationOnce(...)`.
+ */
+function makeEmptyStreamedListObjects(): () => AsyncGenerator<StreamedListObjectsResponse> {
+  return async function* () {
+    // intentionally empty — yields no objects
+  };
 }
 
 /**
  * Creates a typed mock of the OpenFGA client methods used in tests.
  *
- * Returns only the methods the codebase actually calls (`writeTuples`, `deleteTuples`,
- * `read`, `check`, `listObjects`).
+ * Returns the methods the codebase actually calls (`writeTuples`, `deleteTuples`,
+ * `read`, `check`, `listObjects`, `streamedListObjects`).
+ *
+ * `streamedListObjects` defaults to an empty async generator. Use
+ * {@link mockStreamedListObjects} to populate per-call results.
  *
  * @returns A mocked FGA client surface
  */
@@ -33,6 +50,7 @@ export function createMockFgaClient(): MockFgaClient {
     read: vi.fn().mockResolvedValue({ tuples: [], continuation_token: '' }),
     check: vi.fn().mockResolvedValue({ allowed: false }),
     listObjects: vi.fn().mockResolvedValue({ objects: [] }),
+    streamedListObjects: vi.fn().mockImplementation(makeEmptyStreamedListObjects()),
   };
 }
 
@@ -65,4 +83,49 @@ export function mockReadImplementation(
   impl: (body: { object?: string } | undefined) => Promise<ReadResponse>,
 ): void {
   client.read.mockImplementation(impl);
+}
+
+/**
+ * Configure `streamedListObjects` on a mock FGA client to yield the given
+ * object IDs as `StreamedListObjectsResponse` chunks.
+ *
+ * The configured implementation persists across calls; use
+ * `client.streamedListObjects.mockImplementationOnce(...)` for one-shot variants.
+ *
+ * @param client - The mock FGA client
+ * @param objects - Fully-qualified FGA object strings to yield (one per chunk),
+ *                  e.g., `['administration:abc', 'administration:def']`
+ *
+ * @example
+ * ```typescript
+ * mockStreamedListObjects(mockClient, ['administration:abc', 'administration:def']);
+ * const result = await service.listAccessibleObjects('user-123', 'can_read', 'administration');
+ * // result === ['administration:abc', 'administration:def']
+ * ```
+ */
+export function mockStreamedListObjects(client: MockFgaClient, objects: string[]): void {
+  client.streamedListObjects.mockImplementation(async function* (): AsyncGenerator<StreamedListObjectsResponse> {
+    for (const object of objects) {
+      yield { object };
+    }
+  });
+}
+
+/**
+ * Configure `streamedListObjects` to throw an error during iteration.
+ *
+ * Useful for testing error wrapping in `AuthorizationService.listAccessibleObjects`
+ * and `listAccessibleObjectsStreamed`.
+ *
+ * @param client - The mock FGA client
+ * @param error - The error to throw when the generator is iterated
+ */
+export function mockStreamedListObjectsError(client: MockFgaClient, error: Error): void {
+  // Awaiting a rejected promise throws at runtime, but the compiler can't prove
+  // that — so the trailing `yield` is reachable from TypeScript's perspective and
+  // we don't need any rule suppressions. The yield never executes in practice.
+  client.streamedListObjects.mockImplementation(async function* (): AsyncGenerator<StreamedListObjectsResponse> {
+    await Promise.reject(error);
+    yield { object: '' };
+  });
 }

--- a/apps/backend/src/test-support/services/authorization.service.ts
+++ b/apps/backend/src/test-support/services/authorization.service.ts
@@ -14,6 +14,9 @@ export function createMockAuthorizationService(): MockedObject<ReturnType<typeof
     hasPermission: vi.fn().mockResolvedValue(false),
     requirePermission: vi.fn().mockResolvedValue(undefined),
     listAccessibleObjects: vi.fn().mockResolvedValue([]),
+    listAccessibleObjectsStreamed: vi.fn().mockImplementation(async function* () {
+      // default empty generator
+    }),
     hasAnyPermission: vi.fn().mockResolvedValue(false),
   } as MockedObject<ReturnType<typeof AuthorizationService>>;
 }


### PR DESCRIPTION
## Summary

This PR switches `AuthorizationService.listAccessibleObjects` from the FGA SDK's `listObjects` (capped at `OPENFGA_LIST_OBJECTS_MAX_RESULTS`, default 1000) to `streamedListObjects`, eliminating silent truncation before the `class` domain starts hitting that ceiling at scale. It also lands the temp-table-join toolkit that `class`-scoped queries will need, so the follow-up migration is a small, focused change instead of repeating the setup code.

The existing low-cardinality consumers (`SchoolService.list`, `DistrictService.list`, the four `AdministrationService` callsites) keep their current shape — `listAccessibleObjects` still returns `Promise<string[]>`, just with the stream consumed internally. No consumer behavior changes in this PR.

## Why class, not user

The FGA model defines `type user` with **no relations** (`packages/authz/authorization-model.fga` — `user` is a principal-only type). User visibility is always derived from parent-entity permissions: `GET /districts/:districtId/users`, `GET /schools/:schoolId/users`, `GET /classes/:classId/users`, etc. each verify `can_list_users` on the parent entity and then query the junction tables directly. There are zero `listAccessibleObjects(..., FgaType.USER)` calls in the codebase, and there's no design path that would introduce one. The `user` domain doesn't need this work.

The `class` domain is the real motivation. `AdministrationService` already calls `listAccessibleObjects(userId, CAN_READ, FgaType.CLASS)` at `apps/backend/src/services/administration/administration.service.ts:1014` (the tree endpoint's parallel resolution of accessible districts / schools / classes / groups). A district admin's class set is `Σ schools × classes_per_school`, easily into the thousands at a large district (e.g., NYCPS), which will silently truncate at 1000 today. Pre-landing the streamed-list + temp-table toolkit means the `class`-scoped reporting and listing endpoints can opt in cleanly when they migrate.

## What changed

### Streaming surface on `AuthorizationService`

`listAccessibleObjects(userId, relation, type)` now consumes `client.streamedListObjects(...)` and collects the chunks into a `string[]`. The call site is otherwise identical, but the result is no longer subject to the 1000-result server-side cap.

A new `listAccessibleObjectsStreamed(userId, relation, type)` is exposed as an `AsyncGenerator<StreamedListObjectsResponse>` for high-cardinality consumers that want to feed the IDs straight into a temp-table join without materializing the full list. Errors thrown during iteration are wrapped in `ApiError` with `EXTERNAL_SERVICE_FAILED`, matching the existing error contract. Consumers don't need to add `try/catch` around their `for await` loops.

### `withFgaFilterIds` repository utility

`apps/backend/src/repositories/utils/fga-filter-ids.utils.ts` adds:

- `withFgaFilterIds(db, ids, callback)` — opens a Drizzle transaction, creates `TEMP TABLE fga_filter_ids (id uuid PRIMARY KEY) ON COMMIT DROP`, bulk-inserts UUIDs in chunks of 5,000 via parameterized multi-row `INSERT`, then invokes the callback inside the same transaction so the temp table is in scope for `INNER JOIN`.
- `collectStreamedFgaObjects(generator)` — utility for the common "collect into array" case when iterating `listAccessibleObjectsStreamed` directly.

The temp-table strategy avoids the bind-parameter cost and planner regressions that `WHERE id IN (...)` hits at thousands of ids. The JSDoc on `withFgaFilterIds` documents the cardinality threshold (≤500 → `inArray`, otherwise temp-table) so the `class` migration can pick deliberately on a per-query basis.

### Test-support updates

- `MockFgaClient` gains `streamedListObjects`, plus two helpers — `mockStreamedListObjects(client, ids)` configures the generator to yield the given IDs; `mockStreamedListObjectsError(client, error)` makes the generator reject on first iteration.
- `createMockAuthorizationService()` exposes `listAccessibleObjectsStreamed` so service tests can mock both surfaces.

## Out of scope

This PR is the substrate for the class-scoped migration, not the migration itself. `BaseRepository.getByIds` and the existing low-cardinality consumers continue to use `inArray`. When the `class`-scoped reporting / listing endpoints adopt FGA-driven filtering, they should iterate `listAccessibleObjectsStreamed` and feed it into `withFgaFilterIds` rather than collecting to an array. That's the call site where the 1000-cap matters and where `WHERE id IN (...)` would degrade.

The `user` domain is intentionally untouched. There are no `listAccessibleObjects(..., FgaType.USER)` calls in the codebase, and the FGA model has no `type user` relations. User visibility is always derived from parent-entity permissions, so this work is moot for users.

## Tests

This is auth-critical work, so coverage is important. Both happy and failure paths for every new branch are exercised, plus integration tests that verify Postgres semantics.

**Unit tests (`authorization.service.test.ts`)**: `listAccessibleObjects`: collects from stream, empty case, doesn't fall back to the deprecated `listObjects`, wraps mid-iteration errors, wraps synchronous SDK setup errors, logs context on failure. `listAccessibleObjectsStreamed`: yields, passes `current_time`, yields nothing on empty, wraps mid-iteration errors, wraps synchronous SDK setup errors, logs context on failure.

**Unit tests (`fga-filter-ids.utils.test.ts`)**: `withFgaFilterIds`: opens transaction + creates temp table, skips inserts on empty ids, chunks at the 5,000-id boundary, parameterized boundary cases (4,999 / 5,000 / 5,001 / 10,000 / 10,001 ids), returns the callback result, propagates callback errors so the transaction rolls back, propagates `CREATE TEMP TABLE` failures without invoking the callback. `collectStreamedFgaObjects`: collects, handles empty, propagates errors.

**Integration tests (`fga-filter-ids.utils.integration.test.ts`)**: verify behavior the unit harness can't, against real Postgres:
- Materializes ids into the temp table and reads them back inside the same transaction.
- `ON COMMIT DROP` — temp table is gone after a successful transaction.
- Same drop after a rolled-back transaction (callback throws).
- Concurrent transactions are isolated — each sees only its own rows.
- `INNER JOIN fga_filter_ids` works as the canonical consumer pattern.
- Empty ids array — temp table exists with zero rows.

**Open gap deferred to the class-migration follow-up:** there's no integration test that exercises `listAccessibleObjects(..., FgaType.CLASS)` end-to-end through the tree endpoint with a non-super-admin caller. Today's tree-endpoint integration tests use `tiers.superAdmin`, which short-circuits the FGA path entirely (see `administration.service.ts:995`). The route-level test that exercises the streamed FGA filtering is the right shape only once a real consumer has migrated; landing it in this substrate-only PR would mean adding then removing the assertion in the migration PR. It belongs in the class-migration PR alongside the consumer change.

Resolves [1753](https://github.com/yeatmanlab/roar-project-management/issues/1753)

## Types of changes

What types of changes does this pull request introduce?

<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (non-breaking change that does not add functionality but makes code cleaner or more efficient)
- [ ] Documentation Update
- [ ] Tests (new or updated tests)
- [ ] Style (changes to code styling)
- [x] CI (continuous integration changes)
- [ ] Repository Maintenance
- [ ] Other (please describe below)

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask.  We're here
to help! This is simply a reminder of what we are going to look for before
merging your code.
-->

- [x] I have read the [guidelines for contributing](https://github.com/yeatmanlab/roar-dashboard/blob/main/.github/CONTRIBUTING.md).
- [x] The changes in this PR are as small as they can be. They represent one and only one fix or enhancement.
- [x] Linting checks pass with my changes.
- [x] Any existing unit tests pass with my changes.
- [x] Any existing end-to-end tests pass with my changes.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] If this PR fixes an existing issue, I have added a unit or end-to-end test that will detect if this issue reoccurs.
- [x] I have added JSDoc comments as appropriate.
- [ ] I have added the necessary documentation to the [roar-docs repository](https://github.com/yeatmanlab/roar-docs).
- [x] I have shared this PR on the roar-pr-reviews channel (if I have access)
- [x] I have linked relevant issues (if any)