### PR TITLE
Enforce rosteringEnded hard boundary

### DIFF
--- a/apps/backend/src/controllers/administrations.controller.ts
+++ b/apps/backend/src/controllers/administrations.controller.ts
@@ -392,6 +392,7 @@ export const AdministrationsController = {
               totalItems: result.totalItems,
               totalPages: Math.ceil(result.totalItems / query.perPage),
             },
+            exclusions: result.exclusions,
           },
         },
       };
@@ -547,7 +548,7 @@ export const AdministrationsController = {
       const result = await reportService.listStudentScores(authContext, administrationId, query);
 
       // Service and contract types are structurally equivalent (same field
-      // names: tasks[], items[], totalItems). The cast is implicit via TS structural
+      // names: tasks[], items[], totalItems, exclusions). The cast is implicit via TS structural
       // typing — see report.types.ts for the source of truth on each side.
       const tasks: ReportTaskMetadata[] = result.tasks;
       const items: StudentScoreRow[] = result.items;
@@ -564,6 +565,7 @@ export const AdministrationsController = {
               totalItems: result.totalItems,
               totalPages: Math.ceil(result.totalItems / query.perPage),
             },
+            exclusions: result.exclusions,
           },
         },
       };

--- a/apps/backend/src/repositories/class.repository.integration.test.ts
+++ b/apps/backend/src/repositories/class.repository.integration.test.ts
@@ -197,6 +197,57 @@ describe('ClassRepository', () => {
       expect(result.totalItems).toBe(0);
     });
 
+    it('excludes users with rosteringEnded set in the past (#1742)', async () => {
+      // User-level rostering end is a hard boundary independent of the class's own
+      // rostering state — even with active enrollment in an active class, a
+      // rostering-ended user must not appear in user-list results.
+      const userListClass = await ClassFactory.create({
+        name: 'Class with Rostering-Ended User',
+        schoolId: baseFixture.schoolA.id,
+        districtId: baseFixture.district.id,
+      });
+
+      const activeStudent = await UserFactory.create({ nameLast: 'ActiveStudent1742' });
+      const endedStudent = await UserFactory.create({
+        nameLast: 'EndedStudent1742',
+        rosteringEnded: new Date(Date.now() - 24 * 60 * 60 * 1000),
+      });
+
+      await UserClassFactory.create({ userId: activeStudent.id, classId: userListClass.id, role: UserRole.STUDENT });
+      await UserClassFactory.create({ userId: endedStudent.id, classId: userListClass.id, role: UserRole.STUDENT });
+
+      const result = await repository.getUsersByClassId(userListClass.id, { page: 1, perPage: 100 });
+
+      expect(result.totalItems).toBe(1);
+      expect(result.items.map((u) => u.id)).toEqual([activeStudent.id]);
+    });
+
+    it('includes users with rosteringEnded set in the future (#1742)', async () => {
+      // A future rostering-end date means the user is still active. Only
+      // `rosteringEnded <= NOW()` is treated as decommissioned.
+      const userListClass = await ClassFactory.create({
+        name: 'Class with Future Rostering-Ended User',
+        schoolId: baseFixture.schoolA.id,
+        districtId: baseFixture.district.id,
+      });
+
+      const futureEndedStudent = await UserFactory.create({
+        nameLast: 'FutureEndedStudent1742',
+        rosteringEnded: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000),
+      });
+
+      await UserClassFactory.create({
+        userId: futureEndedStudent.id,
+        classId: userListClass.id,
+        role: UserRole.STUDENT,
+      });
+
+      const result = await repository.getUsersByClassId(userListClass.id, { page: 1, perPage: 100 });
+
+      expect(result.totalItems).toBe(1);
+      expect(result.items[0]!.id).toBe(futureEndedStudent.id);
+    });
+
     describe('filters', () => {
       it('filters by role', async () => {
         // Create a class with users having different roles

--- a/apps/backend/src/repositories/district.repository.integration.test.ts
+++ b/apps/backend/src/repositories/district.repository.integration.test.ts
@@ -367,6 +367,32 @@ describe('DistrictRepository', () => {
         classes: 0,
       });
     });
+
+    it('excludes rostering-ended users from district user counts (#1742)', async () => {
+      // Two users at a fresh district: one active, one rostering-ended.
+      // embedCounts joins through `users` with isActiveRoster, so the
+      // decommissioned user must not contribute to the user count.
+      const district = await OrgFactory.create({ orgType: OrgType.DISTRICT, name: 'District with Rostering-Ended' });
+
+      const activeAdmin = await UserFactory.create({ nameLast: 'ActiveAdminCounts1742' });
+      const endedAdmin = await UserFactory.create({
+        nameLast: 'EndedAdminCounts1742',
+        rosteringEnded: new Date(Date.now() - 24 * 60 * 60 * 1000),
+      });
+
+      await UserOrgFactory.create({ userId: activeAdmin.id, orgId: district.id, role: UserRole.ADMINISTRATOR });
+      await UserOrgFactory.create({ userId: endedAdmin.id, orgId: district.id, role: UserRole.ADMINISTRATOR });
+
+      const result = (await repository.listAll({
+        page: 1,
+        perPage: 1000,
+        embedCounts: true,
+      })) as { items: DistrictWithCounts[]; totalItems: number };
+
+      const districtResult = result.items.find((d) => d.id === district.id);
+      expect(districtResult).toBeDefined();
+      expect(districtResult?.counts?.users).toBe(1);
+    });
   });
 
   describe('getUsersByDistrictPath', () => {

--- a/apps/backend/src/repositories/district.repository.ts
+++ b/apps/backend/src/repositories/district.repository.ts
@@ -17,7 +17,7 @@ import {
   getEnrolledUsersFilterConditions,
   UserJunctionTable,
 } from './utils/enrolled-users-query.utils';
-import { isEnrollmentActive } from './utils/enrollment.utils';
+import { isEnrollmentActive, isActiveRoster } from './utils/enrollment.utils';
 
 /**
  * District-specific type (Org with orgType = 'district')
@@ -214,14 +214,17 @@ export class DistrictRepository extends LtreeRepository<District, typeof orgs> {
     districtIds: string[],
     includeEnded: boolean,
   ): Promise<Map<string, DistrictCounts>> {
-    // Pre-aggregate user counts per district
+    // Pre-aggregate user counts per district. Join through to `users` so the
+    // count excludes rostering-ended users (#1742) in addition to the existing
+    // enrollment-end filter on the userOrgs junction.
     const userCounts = this.db
       .select({
         districtId: userOrgs.orgId,
         users: countDistinct(userOrgs.userId).as('users'),
       })
       .from(userOrgs)
-      .where(and(inArray(userOrgs.orgId, districtIds), isNull(userOrgs.enrollmentEnd)))
+      .innerJoin(users, eq(users.id, userOrgs.userId))
+      .where(and(inArray(userOrgs.orgId, districtIds), isNull(userOrgs.enrollmentEnd), isActiveRoster(users)))
       .groupBy(userOrgs.orgId)
       .as('user_counts');
 

--- a/apps/backend/src/repositories/family.repository.integration.test.ts
+++ b/apps/backend/src/repositories/family.repository.integration.test.ts
@@ -225,6 +225,25 @@ describe('FamilyRepository', () => {
       expect(result.items).toEqual([]);
     });
 
+    it('excludes users with rosteringEnded set in the past (#1742)', async () => {
+      // The family is active, but one of its members is decommissioned.
+      // The rostering-ended user must be filtered at the user level.
+      const family = await FamilyFactory.create();
+      const activeParent = await UserFactory.create({ nameLast: 'ActiveParent1742' });
+      const endedChild = await UserFactory.create({
+        nameLast: 'EndedChild1742',
+        rosteringEnded: new Date(Date.now() - 24 * 60 * 60 * 1000),
+      });
+
+      await UserFamilyFactory.create({ userId: activeParent.id, familyId: family.id, role: 'parent' });
+      await UserFamilyFactory.create({ userId: endedChild.id, familyId: family.id, role: 'child' });
+
+      const result = await repository.getUsersByFamilyId(family.id, { page: 1, perPage: 100 });
+
+      expect(result.totalItems).toBe(1);
+      expect(result.items.map((u) => u.id)).toEqual([activeParent.id]);
+    });
+
     it('returns empty for nonexistent family ID', async () => {
       const result = await repository.getUsersByFamilyId('00000000-0000-0000-0000-000000000000', {
         page: 1,

--- a/apps/backend/src/repositories/group.repository.integration.test.ts
+++ b/apps/backend/src/repositories/group.repository.integration.test.ts
@@ -211,6 +211,34 @@ describe('GroupRepository', () => {
       expect(result.totalItems).toBe(0);
     });
 
+    it('excludes users with rosteringEnded set in the past (#1742)', async () => {
+      // User-level rostering end is an independent boundary — an active group
+      // must still not surface a decommissioned user in its enrolled-users list.
+      const groupForUserListTest = await GroupFactory.create({ name: 'Group with Rostering-Ended User' });
+
+      const activeStudent = await UserFactory.create({ nameLast: 'ActiveGroupStudent1742' });
+      const endedStudent = await UserFactory.create({
+        nameLast: 'EndedGroupStudent1742',
+        rosteringEnded: new Date(Date.now() - 24 * 60 * 60 * 1000),
+      });
+
+      await UserGroupFactory.create({
+        userId: activeStudent.id,
+        groupId: groupForUserListTest.id,
+        role: UserRole.STUDENT,
+      });
+      await UserGroupFactory.create({
+        userId: endedStudent.id,
+        groupId: groupForUserListTest.id,
+        role: UserRole.STUDENT,
+      });
+
+      const result = await repository.getUsersByGroupId(groupForUserListTest.id, { page: 1, perPage: 100 });
+
+      expect(result.totalItems).toBe(1);
+      expect(result.items.map((u) => u.id)).toEqual([activeStudent.id]);
+    });
+
     describe('filters', () => {
       it('filters by role', async () => {
         // Create a group with users having different roles

--- a/apps/backend/src/repositories/report.repository.integration.test.ts
+++ b/apps/backend/src/repositories/report.repository.integration.test.ts
@@ -13,6 +13,15 @@ import { RunFactory } from '../test-support/factories/run.factory';
 import { AdministrationFactory } from '../test-support/factories/administration.factory';
 import { AdministrationOrgFactory } from '../test-support/factories/administration-org.factory';
 import { AdministrationTaskVariantFactory } from '../test-support/factories/administration-task-variant.factory';
+import { OrgFactory } from '../test-support/factories/org.factory';
+import { ClassFactory } from '../test-support/factories/class.factory';
+import { GroupFactory } from '../test-support/factories/group.factory';
+import { UserFactory } from '../test-support/factories/user.factory';
+import { UserOrgFactory } from '../test-support/factories/user-org.factory';
+import { UserClassFactory } from '../test-support/factories/user-class.factory';
+import { UserGroupFactory } from '../test-support/factories/user-group.factory';
+import { OrgType } from '../enums/org-type.enum';
+import { UserRole } from '../enums/user-role.enum';
 
 let repo: ReportRepository;
 
@@ -570,5 +579,232 @@ describe('ReportRepository.getProgressOverviewCountsBulk — multi-scope aggrega
       .get(baseFixture.schoolB.id)!
       .taskStatusCounts.filter((tc) => tc.status === 'completed-required');
     expect(schoolBCompleted).toHaveLength(0);
+  });
+});
+
+describe('ReportRepository.countRosteringEndedExclusions — #1742', () => {
+  /**
+   * Each scope type gets a freshly created entity hierarchy and its own
+   * students, so the count is deterministic regardless of which other tests
+   * have seeded data on `baseFixture`. Both exclusion reasons are exercised:
+   *
+   * - User-level: `users.rosteringEnded <= NOW()`
+   * - Entity-level: parent entity's `rosteringEnded <= NOW()` (org / class /
+   *   group). The user themselves remains active.
+   */
+  let testRepo: ReportRepository;
+
+  beforeAll(() => {
+    testRepo = new ReportRepository();
+  });
+
+  const past = () => new Date(Date.now() - 24 * 60 * 60 * 1000);
+  const future = () => new Date(Date.now() + 30 * 24 * 60 * 60 * 1000);
+
+  describe('district scope', () => {
+    it('counts users excluded only at the user level (rostering-ended user, active district)', async () => {
+      const district = await OrgFactory.create({
+        orgType: OrgType.DISTRICT,
+        name: 'District UserLevel Exclude',
+      });
+
+      // 1 active student (must NOT be counted as excluded)
+      const activeStudent = await UserFactory.create({ nameLast: 'ActiveDistrictStudent' });
+      await UserOrgFactory.create({ userId: activeStudent.id, orgId: district.id, role: UserRole.STUDENT });
+
+      // 2 rostering-ended students (MUST be counted as excluded — distinct count = 2)
+      const endedStudent1 = await UserFactory.create({ nameLast: 'EndedDistrictStudent1', rosteringEnded: past() });
+      const endedStudent2 = await UserFactory.create({ nameLast: 'EndedDistrictStudent2', rosteringEnded: past() });
+      await UserOrgFactory.create({ userId: endedStudent1.id, orgId: district.id, role: UserRole.STUDENT });
+      await UserOrgFactory.create({ userId: endedStudent2.id, orgId: district.id, role: UserRole.STUDENT });
+
+      // Future-dated rostering-end is still active and must NOT be counted
+      const futureEndedStudent = await UserFactory.create({
+        nameLast: 'FutureEndedDistrictStudent',
+        rosteringEnded: future(),
+      });
+      await UserOrgFactory.create({ userId: futureEndedStudent.id, orgId: district.id, role: UserRole.STUDENT });
+
+      const count = await testRepo.countRosteringEndedExclusions({ scopeType: 'district', scopeId: district.id });
+      expect(count).toBe(2);
+    });
+
+    it('counts students excluded by descendant class rostering-ended even when no user is decommissioned', async () => {
+      const district = await OrgFactory.create({
+        orgType: OrgType.DISTRICT,
+        name: 'District EntityLevel Exclude',
+      });
+      const school = await OrgFactory.create({
+        orgType: OrgType.SCHOOL,
+        name: 'School Under District Entity Exclude',
+        parentOrgId: district.id,
+      });
+      const endedClass = await ClassFactory.create({
+        name: 'Ended Class Under District',
+        schoolId: school.id,
+        districtId: district.id,
+        rosteringEnded: past(),
+      });
+
+      const student = await UserFactory.create({ nameLast: 'ActiveStudentInEndedClass' });
+      await UserClassFactory.create({ userId: student.id, classId: endedClass.id, role: UserRole.STUDENT });
+
+      const count = await testRepo.countRosteringEndedExclusions({ scopeType: 'district', scopeId: district.id });
+      expect(count).toBe(1);
+    });
+
+    it('counts a student once when excluded for both user-level and entity-level reasons', async () => {
+      const district = await OrgFactory.create({
+        orgType: OrgType.DISTRICT,
+        name: 'District Both Reasons Exclude',
+      });
+      const school = await OrgFactory.create({
+        orgType: OrgType.SCHOOL,
+        name: 'School Under District Both Reasons',
+        parentOrgId: district.id,
+      });
+      const endedClass = await ClassFactory.create({
+        name: 'Ended Class For Dedup',
+        schoolId: school.id,
+        districtId: district.id,
+        rosteringEnded: past(),
+      });
+
+      // Student is both rostering-ended themselves AND in a rostering-ended class.
+      const doubleExcluded = await UserFactory.create({
+        nameLast: 'DoubleExcludedStudent',
+        rosteringEnded: past(),
+      });
+      await UserClassFactory.create({ userId: doubleExcluded.id, classId: endedClass.id, role: UserRole.STUDENT });
+
+      const count = await testRepo.countRosteringEndedExclusions({ scopeType: 'district', scopeId: district.id });
+      expect(count).toBe(1);
+    });
+
+    it('returns 0 when no students are excluded', async () => {
+      const district = await OrgFactory.create({
+        orgType: OrgType.DISTRICT,
+        name: 'District No Exclusions',
+      });
+      const student = await UserFactory.create({ nameLast: 'ActiveDistrictStudentOnly' });
+      await UserOrgFactory.create({ userId: student.id, orgId: district.id, role: UserRole.STUDENT });
+
+      const count = await testRepo.countRosteringEndedExclusions({ scopeType: 'district', scopeId: district.id });
+      expect(count).toBe(0);
+    });
+
+    it('only counts students (non-student roles are ignored)', async () => {
+      const district = await OrgFactory.create({
+        orgType: OrgType.DISTRICT,
+        name: 'District Role Filter Exclude',
+      });
+
+      const endedTeacher = await UserFactory.create({ nameLast: 'EndedTeacher', rosteringEnded: past() });
+      const endedStudent = await UserFactory.create({ nameLast: 'EndedStudentRoleFilter', rosteringEnded: past() });
+
+      await UserOrgFactory.create({ userId: endedTeacher.id, orgId: district.id, role: UserRole.TEACHER });
+      await UserOrgFactory.create({ userId: endedStudent.id, orgId: district.id, role: UserRole.STUDENT });
+
+      const count = await testRepo.countRosteringEndedExclusions({ scopeType: 'district', scopeId: district.id });
+      expect(count).toBe(1);
+    });
+  });
+
+  describe('school scope', () => {
+    it('counts user-level and class-entity-level exclusions distinctly', async () => {
+      const school = await OrgFactory.create({
+        orgType: OrgType.SCHOOL,
+        name: 'School Exclude Mix',
+        parentOrgId: baseFixture.district.id,
+      });
+      const endedClass = await ClassFactory.create({
+        name: 'Ended Class In School Scope',
+        schoolId: school.id,
+        districtId: baseFixture.district.id,
+        rosteringEnded: past(),
+      });
+
+      // Org-level: 1 user-level exclusion
+      const orgEndedStudent = await UserFactory.create({
+        nameLast: 'OrgEndedSchoolStudent',
+        rosteringEnded: past(),
+      });
+      await UserOrgFactory.create({ userId: orgEndedStudent.id, orgId: school.id, role: UserRole.STUDENT });
+
+      // Class-level: 1 active user in an ended class
+      const classOrphanStudent = await UserFactory.create({ nameLast: 'ClassOrphanStudent' });
+      await UserClassFactory.create({ userId: classOrphanStudent.id, classId: endedClass.id, role: UserRole.STUDENT });
+
+      const count = await testRepo.countRosteringEndedExclusions({ scopeType: 'school', scopeId: school.id });
+      expect(count).toBe(2);
+    });
+  });
+
+  describe('class scope', () => {
+    it('counts user-level exclusions for students directly in the class', async () => {
+      const klass = await ClassFactory.create({
+        name: 'Class Exclude Direct',
+        schoolId: baseFixture.schoolA.id,
+        districtId: baseFixture.district.id,
+      });
+
+      const activeStudent = await UserFactory.create({ nameLast: 'ActiveClassStudentDirect' });
+      const endedStudent = await UserFactory.create({
+        nameLast: 'EndedClassStudentDirect',
+        rosteringEnded: past(),
+      });
+
+      await UserClassFactory.create({ userId: activeStudent.id, classId: klass.id, role: UserRole.STUDENT });
+      await UserClassFactory.create({ userId: endedStudent.id, classId: klass.id, role: UserRole.STUDENT });
+
+      const count = await testRepo.countRosteringEndedExclusions({ scopeType: 'class', scopeId: klass.id });
+      expect(count).toBe(1);
+    });
+
+    it('counts entity-level exclusion (rostering-ended class) for active enrollees', async () => {
+      const endedKlass = await ClassFactory.create({
+        name: 'Class Exclude EntityLevel',
+        schoolId: baseFixture.schoolA.id,
+        districtId: baseFixture.district.id,
+        rosteringEnded: past(),
+      });
+
+      const student = await UserFactory.create({ nameLast: 'ActiveStudentInEndedClassDirect' });
+      await UserClassFactory.create({ userId: student.id, classId: endedKlass.id, role: UserRole.STUDENT });
+
+      const count = await testRepo.countRosteringEndedExclusions({ scopeType: 'class', scopeId: endedKlass.id });
+      expect(count).toBe(1);
+    });
+  });
+
+  describe('group scope', () => {
+    it('counts user-level exclusions for group members', async () => {
+      const group = await GroupFactory.create({ name: 'Group Exclude UserLevel' });
+
+      const activeStudent = await UserFactory.create({ nameLast: 'ActiveGroupStudentExclude' });
+      const endedStudent = await UserFactory.create({
+        nameLast: 'EndedGroupStudentExclude',
+        rosteringEnded: past(),
+      });
+
+      await UserGroupFactory.create({ userId: activeStudent.id, groupId: group.id, role: UserRole.STUDENT });
+      await UserGroupFactory.create({ userId: endedStudent.id, groupId: group.id, role: UserRole.STUDENT });
+
+      const count = await testRepo.countRosteringEndedExclusions({ scopeType: 'group', scopeId: group.id });
+      expect(count).toBe(1);
+    });
+
+    it('counts entity-level exclusion (rostering-ended group) for active members', async () => {
+      const endedGroup = await GroupFactory.create({
+        name: 'Group Exclude EntityLevel',
+        rosteringEnded: past(),
+      });
+
+      const student = await UserFactory.create({ nameLast: 'ActiveStudentInEndedGroup' });
+      await UserGroupFactory.create({ userId: student.id, groupId: endedGroup.id, role: UserRole.STUDENT });
+
+      const count = await testRepo.countRosteringEndedExclusions({ scopeType: 'group', scopeId: endedGroup.id });
+      expect(count).toBe(1);
+    });
   });
 });

--- a/apps/backend/src/repositories/report.repository.integration.test.ts
+++ b/apps/backend/src/repositories/report.repository.integration.test.ts
@@ -653,6 +653,39 @@ describe('ReportRepository.countRosteringEndedExclusions — #1742', () => {
       expect(count).toBe(1);
     });
 
+    it('does NOT count a student whose excluded-class enrollment is offset by an active org enrollment', async () => {
+      // Anti-join correctness: a student enrolled in BOTH an active org
+      // (visible via the org branch) AND a rostering-ended class (excluded
+      // via the class branch) appears in `items` AND would naively also
+      // appear in the exclusion count. The anti-join against
+      // `buildStudentInScopeQuery` removes them — we should report 0
+      // exclusions because every "excluded" student is still visible.
+      const district = await OrgFactory.create({
+        orgType: OrgType.DISTRICT,
+        name: 'District DualEnrollment AntiJoin',
+      });
+      const school = await OrgFactory.create({
+        orgType: OrgType.SCHOOL,
+        name: 'School Under District DualEnrollment',
+        parentOrgId: district.id,
+      });
+      const endedClass = await ClassFactory.create({
+        name: 'Ended Class Dual Enrollment',
+        schoolId: school.id,
+        districtId: district.id,
+        rosteringEnded: past(),
+      });
+
+      // Student is in the rostering-ended class AND in the active school
+      // org. The active org enrollment makes them visible in `items`.
+      const student = await UserFactory.create({ nameLast: 'DualEnrollmentStudent' });
+      await UserClassFactory.create({ userId: student.id, classId: endedClass.id, role: UserRole.STUDENT });
+      await UserOrgFactory.create({ userId: student.id, orgId: school.id, role: UserRole.STUDENT });
+
+      const count = await testRepo.countRosteringEndedExclusions({ scopeType: 'district', scopeId: district.id });
+      expect(count).toBe(0);
+    });
+
     it('counts a student once when excluded for both user-level and entity-level reasons', async () => {
       const district = await OrgFactory.create({
         orgType: OrgType.DISTRICT,

--- a/apps/backend/src/repositories/report.repository.ts
+++ b/apps/backend/src/repositories/report.repository.ts
@@ -1137,6 +1137,11 @@ export class ReportRepository {
     //   - <entity>.rostering_ended <= NOW()  → entity-level decommission
     const userExcluded = and(isNotNull(users.rosteringEnded), lte(users.rosteringEnded, sql`NOW()`));
 
+    // Postgres returns `count` as a bigint, which `pg` surfaces as a string
+    // to avoid silent overflow. We always cast to `Number` before returning
+    // — distinct-user counts won't realistically exceed Number.MAX_SAFE_INTEGER
+    // at our scale, and the API contract types the field as `number`.
+
     switch (scope.scopeType) {
       case EntityType.DISTRICT: {
         const orgsExcluded = and(isNotNull(orgs.rosteringEnded), lte(orgs.rosteringEnded, sql`NOW()`));
@@ -2119,7 +2124,12 @@ export class ReportRepository {
       .select({ userId: users.id })
       .from(users)
       .innerJoin(studentsInScope, eq(users.id, studentsInScope.userId))
-      .where(and(eq(users.id, userId), isNull(users.rosteringEnded)))
+      // Use the shared `isActiveRoster` helper so this endpoint applies the
+      // same "future-end = still active" semantics as every other rostering-
+      // ended filter site. Previously this used `isNull(users.rosteringEnded)`,
+      // which would 404 a student whose roster end is set in the future even
+      // though the list/overview reporting endpoints would still include them.
+      .where(and(eq(users.id, userId), isActiveRoster(users)))
       .limit(1);
 
     return rows.length > 0;

--- a/apps/backend/src/repositories/report.repository.ts
+++ b/apps/backend/src/repositories/report.repository.ts
@@ -35,7 +35,7 @@ import { UserRole } from '../enums/user-role.enum';
 import { PROGRESS_PRIORITY_TO_STATUS } from '../constants/progress-status';
 import type { ProgressStatus, ProgressStatusPriority } from '../constants/progress-status';
 import type { PaginatedResult } from './base.repository';
-import { isEnrollmentActive, isActiveInFamily } from './utils/enrollment.utils';
+import { isEnrollmentActive, isActiveInFamily, isActiveRoster } from './utils/enrollment.utils';
 import { alias } from 'drizzle-orm/pg-core';
 
 /**
@@ -1001,6 +1001,12 @@ export class ReportRepository {
    * by the `prevent_rostered_entity_delete` DB trigger.
    */
   private buildStudentInScopeQuery(scope: ReportScope) {
+    // Each UNION branch joins through to `users` so the user-level
+    // `isActiveRoster(users)` filter can exclude rostering-ended students
+    // (#1742). This is a separate, harder boundary than the existing
+    // entity-level `isNull(<entity>.rosteringEnded)` filters: a user whose
+    // own rostering has ended is decommissioned regardless of which entity
+    // their student-role enrollment is attached to.
     switch (scope.scopeType) {
       case EntityType.DISTRICT:
         // Students in user_orgs where org path is at or below the district
@@ -1010,11 +1016,13 @@ export class ReportRepository {
           .select({ userId: userOrgs.userId })
           .from(userOrgs)
           .innerJoin(orgs, eq(userOrgs.orgId, orgs.id))
+          .innerJoin(users, eq(users.id, userOrgs.userId))
           .where(
             and(
               eq(userOrgs.role, UserRole.STUDENT),
               isEnrollmentActive(userOrgs),
               isNull(orgs.rosteringEnded),
+              isActiveRoster(users),
               sql`${orgs.path} <@ (SELECT path FROM app.orgs WHERE id = ${scope.scopeId})`,
             ),
           )
@@ -1023,11 +1031,13 @@ export class ReportRepository {
               .select({ userId: userClasses.userId })
               .from(userClasses)
               .innerJoin(classes, eq(userClasses.classId, classes.id))
+              .innerJoin(users, eq(users.id, userClasses.userId))
               .where(
                 and(
                   eq(userClasses.role, UserRole.STUDENT),
                   isEnrollmentActive(userClasses),
                   isNull(classes.rosteringEnded),
+                  isActiveRoster(users),
                   sql`${classes.orgPath} <@ (SELECT path FROM app.orgs WHERE id = ${scope.scopeId})`,
                 ),
               ),
@@ -1040,11 +1050,13 @@ export class ReportRepository {
           .select({ userId: userOrgs.userId })
           .from(userOrgs)
           .innerJoin(orgs, eq(userOrgs.orgId, orgs.id))
+          .innerJoin(users, eq(users.id, userOrgs.userId))
           .where(
             and(
               eq(userOrgs.role, UserRole.STUDENT),
               isEnrollmentActive(userOrgs),
               isNull(orgs.rosteringEnded),
+              isActiveRoster(users),
               eq(userOrgs.orgId, scope.scopeId),
             ),
           )
@@ -1053,11 +1065,13 @@ export class ReportRepository {
               .select({ userId: userClasses.userId })
               .from(userClasses)
               .innerJoin(classes, eq(userClasses.classId, classes.id))
+              .innerJoin(users, eq(users.id, userClasses.userId))
               .where(
                 and(
                   eq(userClasses.role, UserRole.STUDENT),
                   isEnrollmentActive(userClasses),
                   isNull(classes.rosteringEnded),
+                  isActiveRoster(users),
                   eq(classes.schoolId, scope.scopeId),
                 ),
               ),
@@ -1068,11 +1082,13 @@ export class ReportRepository {
           .select({ userId: userClasses.userId })
           .from(userClasses)
           .innerJoin(classes, eq(userClasses.classId, classes.id))
+          .innerJoin(users, eq(users.id, userClasses.userId))
           .where(
             and(
               eq(userClasses.role, UserRole.STUDENT),
               isEnrollmentActive(userClasses),
               isNull(classes.rosteringEnded),
+              isActiveRoster(users),
               eq(userClasses.classId, scope.scopeId),
             ),
           );
@@ -1082,17 +1098,162 @@ export class ReportRepository {
           .select({ userId: userGroups.userId })
           .from(userGroups)
           .innerJoin(groups, eq(userGroups.groupId, groups.id))
+          .innerJoin(users, eq(users.id, userGroups.userId))
           .where(
             and(
               eq(userGroups.role, UserRole.STUDENT),
               isEnrollmentActive(userGroups),
               isNull(groups.rosteringEnded),
+              isActiveRoster(users),
               eq(userGroups.groupId, scope.scopeId),
             ),
           );
 
       default:
         // Exhaustive check — this should never be reached since ScopeType is validated by Zod
+        throw new Error(`Unsupported scope type: ${scope.scopeType satisfies never}`);
+    }
+  }
+
+  /**
+   * Count distinct students excluded from the report due to rostering-ended state.
+   *
+   * Mirrors `buildStudentInScopeQuery`'s FROM/JOIN shape, but with the
+   * rostering-ended predicates **inverted** so we count the users that would
+   * otherwise be in scope but are filtered out for either reason:
+   *   1. The user's own `rosteringEnded` is set in the past (`<= NOW()`), OR
+   *   2. The in-scope parent entity's `rosteringEnded` is set in the past.
+   *
+   * The two reasons share the `exclusions.rosteringEnded` key in the response
+   * (#1742) — frontend messaging is the same ("no longer active on ROAR") and
+   * users excluded for both are counted once via `COUNT(DISTINCT users.id)`.
+   *
+   * Designed to run in parallel with the main report query via `Promise.all`,
+   * adding one round-trip rather than serializing.
+   */
+  async countRosteringEndedExclusions(scope: ReportScope): Promise<number> {
+    // Predicate that matches users excluded by EITHER reason:
+    //   - users.rostering_ended <= NOW()  → user-level decommission
+    //   - <entity>.rostering_ended <= NOW()  → entity-level decommission
+    const userExcluded = and(isNotNull(users.rosteringEnded), lte(users.rosteringEnded, sql`NOW()`));
+
+    switch (scope.scopeType) {
+      case EntityType.DISTRICT: {
+        const orgsExcluded = and(isNotNull(orgs.rosteringEnded), lte(orgs.rosteringEnded, sql`NOW()`));
+        const classesExcluded = and(isNotNull(classes.rosteringEnded), lte(classes.rosteringEnded, sql`NOW()`));
+
+        const excludedUnion = this.db
+          .selectDistinct({ userId: userOrgs.userId })
+          .from(userOrgs)
+          .innerJoin(orgs, eq(userOrgs.orgId, orgs.id))
+          .innerJoin(users, eq(users.id, userOrgs.userId))
+          .where(
+            and(
+              eq(userOrgs.role, UserRole.STUDENT),
+              isEnrollmentActive(userOrgs),
+              sql`${orgs.path} <@ (SELECT path FROM app.orgs WHERE id = ${scope.scopeId})`,
+              or(userExcluded, orgsExcluded),
+            ),
+          )
+          .union(
+            this.db
+              .selectDistinct({ userId: userClasses.userId })
+              .from(userClasses)
+              .innerJoin(classes, eq(userClasses.classId, classes.id))
+              .innerJoin(users, eq(users.id, userClasses.userId))
+              .where(
+                and(
+                  eq(userClasses.role, UserRole.STUDENT),
+                  isEnrollmentActive(userClasses),
+                  sql`${classes.orgPath} <@ (SELECT path FROM app.orgs WHERE id = ${scope.scopeId})`,
+                  or(userExcluded, classesExcluded),
+                ),
+              ),
+          )
+          .as('excluded');
+
+        const [row] = await this.db.select({ count: countDistinct(excludedUnion.userId) }).from(excludedUnion);
+        return Number(row?.count ?? 0);
+      }
+
+      case EntityType.SCHOOL: {
+        const orgsExcluded = and(isNotNull(orgs.rosteringEnded), lte(orgs.rosteringEnded, sql`NOW()`));
+        const classesExcluded = and(isNotNull(classes.rosteringEnded), lte(classes.rosteringEnded, sql`NOW()`));
+
+        const excludedUnion = this.db
+          .selectDistinct({ userId: userOrgs.userId })
+          .from(userOrgs)
+          .innerJoin(orgs, eq(userOrgs.orgId, orgs.id))
+          .innerJoin(users, eq(users.id, userOrgs.userId))
+          .where(
+            and(
+              eq(userOrgs.role, UserRole.STUDENT),
+              isEnrollmentActive(userOrgs),
+              eq(userOrgs.orgId, scope.scopeId),
+              or(userExcluded, orgsExcluded),
+            ),
+          )
+          .union(
+            this.db
+              .selectDistinct({ userId: userClasses.userId })
+              .from(userClasses)
+              .innerJoin(classes, eq(userClasses.classId, classes.id))
+              .innerJoin(users, eq(users.id, userClasses.userId))
+              .where(
+                and(
+                  eq(userClasses.role, UserRole.STUDENT),
+                  isEnrollmentActive(userClasses),
+                  eq(classes.schoolId, scope.scopeId),
+                  or(userExcluded, classesExcluded),
+                ),
+              ),
+          )
+          .as('excluded');
+
+        const [row] = await this.db.select({ count: countDistinct(excludedUnion.userId) }).from(excludedUnion);
+        return Number(row?.count ?? 0);
+      }
+
+      case EntityType.CLASS: {
+        const classesExcluded = and(isNotNull(classes.rosteringEnded), lte(classes.rosteringEnded, sql`NOW()`));
+
+        const [row] = await this.db
+          .select({ count: countDistinct(userClasses.userId) })
+          .from(userClasses)
+          .innerJoin(classes, eq(userClasses.classId, classes.id))
+          .innerJoin(users, eq(users.id, userClasses.userId))
+          .where(
+            and(
+              eq(userClasses.role, UserRole.STUDENT),
+              isEnrollmentActive(userClasses),
+              eq(userClasses.classId, scope.scopeId),
+              or(userExcluded, classesExcluded),
+            ),
+          );
+        return Number(row?.count ?? 0);
+      }
+
+      case EntityType.GROUP: {
+        const groupsExcluded = and(isNotNull(groups.rosteringEnded), lte(groups.rosteringEnded, sql`NOW()`));
+
+        const [row] = await this.db
+          .select({ count: countDistinct(userGroups.userId) })
+          .from(userGroups)
+          .innerJoin(groups, eq(userGroups.groupId, groups.id))
+          .innerJoin(users, eq(users.id, userGroups.userId))
+          .where(
+            and(
+              eq(userGroups.role, UserRole.STUDENT),
+              isEnrollmentActive(userGroups),
+              eq(userGroups.groupId, scope.scopeId),
+              or(userExcluded, groupsExcluded),
+            ),
+          );
+        return Number(row?.count ?? 0);
+      }
+
+      default:
+        // Exhaustive check — Zod-validated upstream.
         throw new Error(`Unsupported scope type: ${scope.scopeType satisfies never}`);
     }
   }

--- a/apps/backend/src/repositories/report.repository.ts
+++ b/apps/backend/src/repositories/report.repository.ts
@@ -1128,6 +1128,14 @@ export class ReportRepository {
    * (#1742) — frontend messaging is the same ("no longer active on ROAR") and
    * users excluded for both are counted once via `COUNT(DISTINCT users.id)`.
    *
+   * At district / school scope the count is anti-joined against
+   * `buildStudentInScopeQuery` so a student who is excluded via one branch
+   * (e.g., rostering-ended class) but visible via another (e.g., active org
+   * enrollment) is NOT counted — that student appears in `items`, so
+   * counting them in `exclusions` would surface a false positive in the
+   * frontend "N students excluded" notice. Class / group scopes use a
+   * single query (no UNION), so the dual-enrollment case can't occur.
+   *
    * Designed to run in parallel with the main report query via `Promise.all`,
    * adding one round-trip rather than serializing.
    */
@@ -1141,6 +1149,20 @@ export class ReportRepository {
     // to avoid silent overflow. We always cast to `Number` before returning
     // — distinct-user counts won't realistically exceed Number.MAX_SAFE_INTEGER
     // at our scale, and the API contract types the field as `number`.
+
+    // Anti-join helper: at district / school scope, a student may appear in
+    // BOTH an excluded branch (e.g., a rostering-ended class) AND an
+    // in-scope branch (e.g., an active org enrollment). Without subtracting
+    // the in-scope set we'd surface a false positive in
+    // `exclusions.rosteringEnded` — the student is visible in `items` AND
+    // counted as "excluded". `buildStudentInScopeQuery` already returns
+    // exactly the set of students visible in `items` (rostering-ended
+    // branches are filtered out there), so a LEFT JOIN + IS NULL exactly
+    // expresses "excluded AND not visible elsewhere".
+    //
+    // CLASS / GROUP scopes use a single query (no UNION across branches),
+    // so the same student can't appear in both an excluded and an in-scope
+    // branch — the anti-join is unnecessary there.
 
     switch (scope.scopeType) {
       case EntityType.DISTRICT: {
@@ -1177,7 +1199,13 @@ export class ReportRepository {
           )
           .as('excluded');
 
-        const [row] = await this.db.select({ count: countDistinct(excludedUnion.userId) }).from(excludedUnion);
+        const studentsInScope = this.buildStudentInScopeQuery(scope).as('sis');
+
+        const [row] = await this.db
+          .select({ count: countDistinct(excludedUnion.userId) })
+          .from(excludedUnion)
+          .leftJoin(studentsInScope, eq(excludedUnion.userId, studentsInScope.userId))
+          .where(isNull(studentsInScope.userId));
         return Number(row?.count ?? 0);
       }
 
@@ -1215,7 +1243,13 @@ export class ReportRepository {
           )
           .as('excluded');
 
-        const [row] = await this.db.select({ count: countDistinct(excludedUnion.userId) }).from(excludedUnion);
+        const studentsInScope = this.buildStudentInScopeQuery(scope).as('sis');
+
+        const [row] = await this.db
+          .select({ count: countDistinct(excludedUnion.userId) })
+          .from(excludedUnion)
+          .leftJoin(studentsInScope, eq(excludedUnion.userId, studentsInScope.userId))
+          .where(isNull(studentsInScope.userId));
         return Number(row?.count ?? 0);
       }
 

--- a/apps/backend/src/repositories/run-scores.repository.integration.test.ts
+++ b/apps/backend/src/repositories/run-scores.repository.integration.test.ts
@@ -134,14 +134,19 @@ describe('RunScoresRepository', () => {
     it('treats two NULL assessment_stage rows with otherwise-identical natural keys as the same row', async () => {
       const run = await RunFactory.create();
 
+      // Uses type=computed because raw scores require an assessmentStage
+      // (run_scores_raw_requires_stage CHECK + discriminated-union contract rule
+      // landing alongside this constraint). The NULLS NOT DISTINCT behavior is
+      // independent of type, so a stage-less computed score exercises the same
+      // upsert semantics.
       // First write with NULL stage
       await repository.upsertMany({
         data: [
           {
             runId: run.id,
-            type: SCORE_TYPE.RAW,
+            type: SCORE_TYPE.COMPUTED,
             domain: SCORE_DOMAIN.COMPOSITE,
-            name: SCORE_NAME.THETA_SE,
+            name: 'final_composite',
             value: '0.5',
             assessmentStage: null,
           },
@@ -153,9 +158,9 @@ describe('RunScoresRepository', () => {
         data: [
           {
             runId: run.id,
-            type: SCORE_TYPE.RAW,
+            type: SCORE_TYPE.COMPUTED,
             domain: SCORE_DOMAIN.COMPOSITE,
-            name: SCORE_NAME.THETA_SE,
+            name: 'final_composite',
             value: '0.4',
             assessmentStage: null,
           },

--- a/apps/backend/src/repositories/school.repository.integration.test.ts
+++ b/apps/backend/src/repositories/school.repository.integration.test.ts
@@ -213,6 +213,36 @@ describe('SchoolRepository', () => {
       });
     });
 
+    it('excludes rostering-ended users from school user counts (#1742)', async () => {
+      // School with one active and one decommissioned user. The user-count
+      // subquery joins through `users` with isActiveRoster, so the ended
+      // user must drop out of the count.
+      const school = await OrgFactory.create({
+        orgType: OrgType.SCHOOL,
+        name: 'School with Rostering-Ended User Counts',
+        parentOrgId: baseFixture.district.id,
+      });
+
+      const activeStudent = await UserFactory.create({ nameLast: 'ActiveSchoolStudent1742' });
+      const endedStudent = await UserFactory.create({
+        nameLast: 'EndedSchoolStudent1742',
+        rosteringEnded: new Date(Date.now() - 24 * 60 * 60 * 1000),
+      });
+
+      await UserOrgFactory.create({ userId: activeStudent.id, orgId: school.id, role: UserRole.STUDENT });
+      await UserOrgFactory.create({ userId: endedStudent.id, orgId: school.id, role: UserRole.STUDENT });
+
+      const result = (await repository.listAll({
+        page: 1,
+        perPage: 1000,
+        embedCounts: true,
+      })) as { items: SchoolWithCounts[]; totalItems: number };
+
+      const schoolResult = result.items.find((s) => s.id === school.id);
+      expect(schoolResult).toBeDefined();
+      expect(schoolResult?.counts?.users).toBe(1);
+    });
+
     it('includes ended classes in counts when includeEnded=true', async () => {
       // Create a school with one active class and one ended class
       const school = await OrgFactory.create({

--- a/apps/backend/src/repositories/school.repository.ts
+++ b/apps/backend/src/repositories/school.repository.ts
@@ -18,7 +18,7 @@ import {
   getEnrolledUsersFilterConditions,
   UserJunctionTable,
 } from './utils/enrolled-users-query.utils';
-import { isEnrollmentActive } from './utils/enrollment.utils';
+import { isEnrollmentActive, isActiveRoster } from './utils/enrollment.utils';
 
 /**
  * School-specific type (Org with orgType = 'school')
@@ -157,14 +157,17 @@ export class SchoolRepository extends LtreeRepository<School, typeof orgs> {
    * @returns Map of school ID to counts
    */
   private async fetchSchoolCounts(schoolIds: string[], includeEnded: boolean): Promise<Map<string, SchoolCounts>> {
-    // Pre-aggregate user counts per school
+    // Pre-aggregate user counts per school. Join through to `users` so the
+    // count excludes rostering-ended users (#1742) in addition to the
+    // existing enrollment-end filter on the userOrgs junction.
     const userCounts = this.db
       .select({
         schoolId: userOrgs.orgId,
         users: countDistinct(userOrgs.userId).as('users'),
       })
       .from(userOrgs)
-      .where(and(inArray(userOrgs.orgId, schoolIds), isNull(userOrgs.enrollmentEnd)))
+      .innerJoin(users, eq(users.id, userOrgs.userId))
+      .where(and(inArray(userOrgs.orgId, schoolIds), isNull(userOrgs.enrollmentEnd), isActiveRoster(users)))
       .groupBy(userOrgs.orgId)
       .as('user_counts');
 

--- a/apps/backend/src/repositories/utils/enrolled-users-query.utils.test.ts
+++ b/apps/backend/src/repositories/utils/enrolled-users-query.utils.test.ts
@@ -24,28 +24,34 @@ describe('enrolled-users-query.utils', () => {
   });
 
   describe('getEnrolledUsersFilterConditions', () => {
-    it('returns empty array when no filters provided', () => {
+    // The base array always includes the `isActiveRoster(users)` predicate
+    // (#1742). Every user-list endpoint must exclude rostering-ended users
+    // unconditionally, so it's wired at the query composition layer rather
+    // than added by each caller. Length assertions below account for it.
+    const BASE_CONDITION_COUNT = 1;
+
+    it('returns only the active-roster condition when no filters provided', () => {
       const options: ListEnrolledUsersOptions = { page: 1, perPage: 10 };
       const conditions = getEnrolledUsersFilterConditions(options, UserJunctionTable.USER_CLASSES);
-      expect(conditions).toEqual([]);
+      expect(conditions).toHaveLength(BASE_CONDITION_COUNT);
     });
 
-    it('returns grade condition when grade filter provided', () => {
+    it('appends grade condition when grade filter provided', () => {
       const options: ListEnrolledUsersOptions = { page: 1, perPage: 10, grade: ['5'] };
       const conditions = getEnrolledUsersFilterConditions(options, UserJunctionTable.USER_CLASSES);
-      expect(conditions).toHaveLength(1);
+      expect(conditions).toHaveLength(BASE_CONDITION_COUNT + 1);
     });
 
-    it('returns role condition when role filter provided', () => {
+    it('appends role condition when role filter provided', () => {
       const options: ListEnrolledUsersOptions = { page: 1, perPage: 10, role: UserRole.STUDENT };
       const conditions = getEnrolledUsersFilterConditions(options, UserJunctionTable.USER_CLASSES);
-      expect(conditions).toHaveLength(1);
+      expect(conditions).toHaveLength(BASE_CONDITION_COUNT + 1);
     });
 
-    it('returns both conditions when grade and role filters provided', () => {
+    it('appends both conditions when grade and role filters provided', () => {
       const options: ListEnrolledUsersOptions = { page: 1, perPage: 10, grade: ['5'], role: UserRole.STUDENT };
       const conditions = getEnrolledUsersFilterConditions(options, UserJunctionTable.USER_CLASSES);
-      expect(conditions).toHaveLength(2);
+      expect(conditions).toHaveLength(BASE_CONDITION_COUNT + 2);
     });
   });
 });

--- a/apps/backend/src/repositories/utils/enrolled-users-query.utils.ts
+++ b/apps/backend/src/repositories/utils/enrolled-users-query.utils.ts
@@ -1,6 +1,7 @@
 import { SQL, inArray, eq, Column } from 'drizzle-orm';
 import type { EnrolledUsersSortFieldType } from '@roar-dashboard/api-contract';
 import { users, userClasses, userGroups, userOrgs, userFamilies } from '../../db/schema';
+import { isActiveRoster } from './enrollment.utils';
 import type { ListEnrolledUsersOptions, ListEnrolledFamilyUsersOptions } from '../../types/user';
 
 export const ENROLLED_USERS_SORT_COLUMNS: Record<EnrolledUsersSortFieldType, Column> = {
@@ -30,6 +31,12 @@ export const getEnrolledUsersFilterConditions = (
 ): SQL[] => {
   const { grade, role } = options;
   const conditions: SQL[] = [];
+
+  // Always exclude rostering-ended users (#1742). Applied at the query
+  // composition layer so every consumer of `getEnrolledUsersFilterConditions`
+  // — district, school, class, group, family user-list endpoints — gets
+  // the same hard boundary. There is no opt-in flag to include them.
+  conditions.push(isActiveRoster(users));
 
   if (grade?.length) {
     conditions.push(inArray(users.grade, grade));

--- a/apps/backend/src/repositories/utils/enrollment.utils.test.ts
+++ b/apps/backend/src/repositories/utils/enrollment.utils.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
-import { isEnrollmentActive } from './enrollment.utils';
-import { userOrgs } from '../../db/schema';
+import { SQL } from 'drizzle-orm';
+import { isEnrollmentActive, isActiveRoster } from './enrollment.utils';
+import { userOrgs, users, orgs, classes, groups } from '../../db/schema';
 
 describe('enrollment.utils', () => {
   describe('isEnrollmentActive', () => {
@@ -19,6 +20,45 @@ describe('enrollment.utils', () => {
       };
 
       const condition = isEnrollmentActive(mockTable);
+      expect(condition).toBeTruthy();
+    });
+  });
+
+  describe('isActiveRoster', () => {
+    it('returns a non-undefined SQL expression', () => {
+      // The helper applies a non-null assertion internally so callers can
+      // use it in strict `SQL` contexts (e.g., `SQL[]` array push). Verify
+      // the return type is concretely SQL — not the bare `SQL | undefined`
+      // that drizzle's `or()` returns.
+      const condition = isActiveRoster(users);
+
+      expect(condition).toBeDefined();
+      expect(condition).toBeInstanceOf(SQL);
+    });
+
+    it('accepts the canonical users table', () => {
+      const condition = isActiveRoster(users);
+      expect(condition).toBeTruthy();
+    });
+
+    it.each([
+      ['orgs', orgs],
+      ['classes', classes],
+      ['groups', groups],
+    ])('accepts any table with a rosteringEnded column: %s', (_name, table) => {
+      // The filter is also used against entity tables (orgs, classes, groups)
+      // for the entity-level rostering-ended check in `buildStudentInScopeQuery`.
+      // The helper's structural typing should accept any table with the
+      // `rosteringEnded` column.
+      const condition = isActiveRoster(table);
+      expect(condition).toBeTruthy();
+    });
+
+    it('accepts a mock table object with just a rosteringEnded column', () => {
+      // Confirms the structural-typing contract — callers don't need to
+      // pass a full Drizzle table reference.
+      const mockTable = { rosteringEnded: users.rosteringEnded };
+      const condition = isActiveRoster(mockTable);
       expect(condition).toBeTruthy();
     });
   });

--- a/apps/backend/src/repositories/utils/enrollment.utils.ts
+++ b/apps/backend/src/repositories/utils/enrollment.utils.ts
@@ -1,5 +1,5 @@
 import type { AnyColumn } from 'drizzle-orm';
-import { and, lte, gte, or, isNull, sql } from 'drizzle-orm';
+import { and, lte, gte, or, isNull, sql, gt } from 'drizzle-orm';
 
 /**
  * Builds enrollment date boundary conditions for user membership tables.
@@ -68,4 +68,49 @@ export function isEnrollmentActive(table: { enrollmentStart: AnyColumn; enrollme
  */
 export function isActiveInFamily(table: { joinedOn: AnyColumn; leftOn: AnyColumn }) {
   return and(lte(table.joinedOn, sql`NOW()`), or(gte(table.leftOn, sql`NOW()`), isNull(table.leftOn)));
+}
+
+/**
+ * Builds a condition that excludes users whose rostering has ended.
+ *
+ * The user's rostering is considered active when:
+ * - `rosteringEnded IS NULL` (no end date set), OR
+ * - `rosteringEnded > NOW()` (end date is in the future)
+ *
+ * Users with `rosteringEnded <= NOW()` are excluded from results. This is
+ * the hard boundary defined in ticket #1742 — once a user's roster has
+ * ended, they're treated as decommissioned: invisible from list endpoints,
+ * invisible from reports, and 404 from per-user lookups.
+ *
+ * ## Timezone Handling
+ *
+ * Uses PostgreSQL's `NOW()`; `rosteringEnded` is `timestamptz` so comparisons
+ * are timezone-safe.
+ *
+ * @example
+ * ```ts
+ * // In a query selecting users
+ * .where(and(
+ *   eq(users.id, userId),
+ *   isActiveRoster(users)
+ * ))
+ *
+ * // Composed with other conditions
+ * .where(and(
+ *   isEnrollmentActive(userOrgs),
+ *   isActiveRoster(users),
+ * ))
+ * ```
+ *
+ * @param table - A table reference with a `rosteringEnded` `timestamptz` column
+ * @returns Drizzle SQL condition for non-ended rostering
+ */
+export function isActiveRoster(table: { rosteringEnded: AnyColumn }) {
+  // `or()` returns `SQL | undefined` because it returns undefined when all
+  // arguments are undefined. Both arguments here are concrete (an `isNull`
+  // check and a `gt` comparison), so undefined is unreachable — the
+  // non-null assertion narrows the return type so callers can use the
+  // result in contexts that demand a strict `SQL` (e.g., pushing into a
+  // typed `SQL[]` array).
+  return or(isNull(table.rosteringEnded), gt(table.rosteringEnded, sql`NOW()`))!;
 }

--- a/apps/backend/src/routes/reports.integration.test.ts
+++ b/apps/backend/src/routes/reports.integration.test.ts
@@ -392,6 +392,13 @@ describe('GET /v1/administrations/:id/reports/progress/students', () => {
       expect(data.pagination.page).toBe(1);
       expect(data.pagination.perPage).toBe(25);
       expect(data.pagination.totalItems).toBeGreaterThan(0);
+
+      // Exclusions block — #1742. Always present, defaulting to 0 when no
+      // rostering-ended users would have otherwise been in scope.
+      expect(data).toHaveProperty('exclusions');
+      expect(data.exclusions).toHaveProperty('rosteringEnded');
+      expect(typeof data.exclusions.rosteringEnded).toBe('number');
+      expect(data.exclusions.rosteringEnded).toBeGreaterThanOrEqual(0);
     });
 
     it('respects pagination parameters', async () => {
@@ -560,6 +567,65 @@ describe('GET /v1/administrations/:id/reports/progress/students', () => {
         .set('Authorization', 'Bearer token');
 
       expect(res.status).toBe(StatusCodes.BAD_REQUEST);
+    });
+  });
+
+  describe('rostering-ended exclusions (#1742)', () => {
+    /**
+     * End-to-end check that a rostering-ended student is invisible from the
+     * progress students list AND surfaces in `exclusions.rosteringEnded`. This
+     * targets the progress students endpoint specifically; the other three
+     * reporting endpoints share the same service-level wiring and are covered
+     * at the repository level by `countRosteringEndedExclusions` tests.
+     */
+    it('excludes rostering-ended student from items and increments exclusions count', async () => {
+      const { OrgFactory } = await import('../test-support/factories/org.factory');
+      const { UserFactory } = await import('../test-support/factories/user.factory');
+      const { UserOrgFactory } = await import('../test-support/factories/user-org.factory');
+      const { AdministrationFactory } = await import('../test-support/factories/administration.factory');
+      const { AdministrationOrgFactory } = await import('../test-support/factories/administration-org.factory');
+      const { AdministrationTaskVariantFactory } = await import(
+        '../test-support/factories/administration-task-variant.factory'
+      );
+      const { OrgType } = await import('../enums/org-type.enum');
+      const { UserRole } = await import('../enums/user-role.enum');
+
+      // Isolated district + administration so the count is deterministic.
+      const district = await OrgFactory.create({ orgType: OrgType.DISTRICT, name: 'District Exclusions Route Test' });
+      const admin = await AdministrationFactory.create({
+        name: 'Admin Exclusions Route Test',
+        createdBy: baseFixture.districtAdmin.id,
+      });
+      await AdministrationOrgFactory.create({ administrationId: admin.id, orgId: district.id });
+      await AdministrationTaskVariantFactory.create({
+        administrationId: admin.id,
+        taskVariantId: baseFixture.variantForAllGrades.id,
+        orderIndex: 0,
+      });
+
+      const activeStudent = await UserFactory.create({ nameLast: 'ActiveStudentForReport1742' });
+      const endedStudent = await UserFactory.create({
+        nameLast: 'EndedStudentForReport1742',
+        rosteringEnded: new Date(Date.now() - 24 * 60 * 60 * 1000),
+      });
+
+      await UserOrgFactory.create({ userId: activeStudent.id, orgId: district.id, role: UserRole.STUDENT });
+      await UserOrgFactory.create({ userId: endedStudent.id, orgId: district.id, role: UserRole.STUDENT });
+
+      authenticateAs(tiers.superAdmin);
+      const res = await request(app)
+        .get(progressStudentsPath(admin.id))
+        .query({ scopeType: 'district', scopeId: district.id, page: 1, perPage: 25 })
+        .set('Authorization', 'Bearer token');
+
+      expect(res.status).toBe(StatusCodes.OK);
+      const { data } = res.body;
+
+      const itemUserIds = (data.items as Array<{ user: { userId: string } }>).map((row) => row.user.userId);
+      expect(itemUserIds).toContain(activeStudent.id);
+      expect(itemUserIds).not.toContain(endedStudent.id);
+
+      expect(data.exclusions.rosteringEnded).toBe(1);
     });
   });
 
@@ -1073,6 +1139,12 @@ describe('GET /v1/administrations/:id/reports/progress/overview', () => {
       // Convenience totals by requirement axis
       expect(firstTask).toHaveProperty('required');
       expect(firstTask).toHaveProperty('optional');
+
+      // Exclusions block — #1742
+      expect(data).toHaveProperty('exclusions');
+      expect(data.exclusions).toHaveProperty('rosteringEnded');
+      expect(typeof data.exclusions.rosteringEnded).toBe('number');
+      expect(data.exclusions.rosteringEnded).toBeGreaterThanOrEqual(0);
     });
 
     it('per-task 7-level counts are internally consistent', async () => {
@@ -1657,6 +1729,12 @@ describe('GET /v1/administrations/:id/reports/scores/overview', () => {
       expect(firstTask.supportLevels).toHaveProperty('developingSkill');
       expect(firstTask.supportLevels).toHaveProperty('needsExtraSupport');
       expect(firstTask.supportLevels.achievedSkill).toHaveProperty('count');
+
+      // Exclusions block — #1742
+      expect(data).toHaveProperty('exclusions');
+      expect(data.exclusions).toHaveProperty('rosteringEnded');
+      expect(typeof data.exclusions.rosteringEnded).toBe('number');
+      expect(data.exclusions.rosteringEnded).toBeGreaterThanOrEqual(0);
     });
 
     it('per-task counts are internally consistent', async () => {
@@ -2092,6 +2170,12 @@ describe('GET /v1/administrations/:id/reports/scores/students', () => {
         expect(row.user).toHaveProperty('userId');
         expect(row.user).toHaveProperty('grade');
       }
+
+      // Exclusions block — #1742
+      expect(data).toHaveProperty('exclusions');
+      expect(data.exclusions).toHaveProperty('rosteringEnded');
+      expect(typeof data.exclusions.rosteringEnded).toBe('number');
+      expect(data.exclusions.rosteringEnded).toBeGreaterThanOrEqual(0);
     });
 
     it('populates schoolName on user info at district scope', async () => {

--- a/apps/backend/src/routes/users.integration.test.ts
+++ b/apps/backend/src/routes/users.integration.test.ts
@@ -1432,12 +1432,20 @@ describe('GET /v1/users/:userId/administrations', () => {
       expect(res.body.error.code).toBe(ApiErrorCode.RESOURCE_NOT_FOUND);
     });
 
-    it('returns 404 when a rostering-ended user requests their own administrations (#1742)', async () => {
-      // Self-lookup is also blocked: the rostering-ended check now runs
-      // before the `requesterUserId === userId` early return so a
-      // rostering-ended user can't bypass the boundary via self-listing
-      // even if they manage to authenticate (defense-in-depth alongside
-      // auth guard #1735).
+    it('returns 403 when a rostering-ended user requests their own administrations (#1742)', async () => {
+      // End-to-end, the auth guard (#1735) blocks rostering-ended users at
+      // the middleware layer and returns 403 AUTH_ROSTERING_ENDED before
+      // any handler runs — so the service-layer 404 (which would otherwise
+      // fire for a self-lookup against a rostering-ended target) is
+      // unreachable from a route test. We still want to verify the
+      // user-visible behavior: a rostering-ended user can't access their
+      // own administrations.
+      //
+      // The service-layer defense-in-depth (rejectRosteringEndedTarget
+      // running BEFORE the `requesterUserId === userId` early return)
+      // matters if the auth guard logic is ever bypassed or changed —
+      // that path is covered by the unit test in
+      // `administration.service.test.ts`.
       const endedUser = await UserFactory.create({
         nameLast: 'EndedSelfAdmin1742',
         rosteringEnded: new Date(Date.now() - 24 * 60 * 60 * 1000),
@@ -1445,9 +1453,9 @@ describe('GET /v1/users/:userId/administrations', () => {
 
       const res = await expectRoute('GET', `/v1/users/${endedUser.id}/administrations`)
         .as({ id: endedUser.id, authId: endedUser.authId! })
-        .toReturn(StatusCodes.NOT_FOUND);
+        .toReturn(StatusCodes.FORBIDDEN);
 
-      expect(res.body.error.code).toBe(ApiErrorCode.RESOURCE_NOT_FOUND);
+      expect(res.body.error.code).toBe(ApiErrorCode.AUTH_ROSTERING_ENDED);
     });
 
     it('returns 403 when non-super-admin tries to list administrations for user with no shared access', async () => {

--- a/apps/backend/src/routes/users.integration.test.ts
+++ b/apps/backend/src/routes/users.integration.test.ts
@@ -1432,6 +1432,24 @@ describe('GET /v1/users/:userId/administrations', () => {
       expect(res.body.error.code).toBe(ApiErrorCode.RESOURCE_NOT_FOUND);
     });
 
+    it('returns 404 when a rostering-ended user requests their own administrations (#1742)', async () => {
+      // Self-lookup is also blocked: the rostering-ended check now runs
+      // before the `requesterUserId === userId` early return so a
+      // rostering-ended user can't bypass the boundary via self-listing
+      // even if they manage to authenticate (defense-in-depth alongside
+      // auth guard #1735).
+      const endedUser = await UserFactory.create({
+        nameLast: 'EndedSelfAdmin1742',
+        rosteringEnded: new Date(Date.now() - 24 * 60 * 60 * 1000),
+      });
+
+      const res = await expectRoute('GET', `/v1/users/${endedUser.id}/administrations`)
+        .as({ id: endedUser.id, authId: endedUser.authId! })
+        .toReturn(StatusCodes.NOT_FOUND);
+
+      expect(res.body.error.code).toBe(ApiErrorCode.RESOURCE_NOT_FOUND);
+    });
+
     it('returns 403 when non-super-admin tries to list administrations for user with no shared access', async () => {
       // districtBStudent is in a different district from tiers.admin (who is in districtA)
       const res = await expectRoute('GET', `/v1/users/${baseFixture.districtBStudent.id}/administrations`)

--- a/apps/backend/src/routes/users.integration.test.ts
+++ b/apps/backend/src/routes/users.integration.test.ts
@@ -444,6 +444,36 @@ describe('GET /v1/users/:id', () => {
       expect(res.body.error.code).toBe(ApiErrorCode.RESOURCE_NOT_FOUND);
     });
 
+    it('returns 404 for a rostering-ended target user — even to super admin (#1742)', async () => {
+      // Rostering-ended users are decommissioned: any URL that names them as a
+      // target returns 404, with the same code/shape as a non-existent user.
+      // The shape is symmetric so requesters can't distinguish whether the
+      // target ever existed.
+      const endedUser = await UserFactory.create({
+        nameLast: 'EndedUserDirectAccess',
+        rosteringEnded: new Date(Date.now() - 24 * 60 * 60 * 1000),
+      });
+
+      const res = await expectRoute('GET', `/v1/users/${endedUser.id}`).as(tiers.superAdmin).toReturn(404);
+
+      expect(res.body.error.code).toBe(ApiErrorCode.RESOURCE_NOT_FOUND);
+    });
+
+    it('returns 404 for a rostering-ended target user — same shape as not-found (#1742)', async () => {
+      const endedUser = await UserFactory.create({
+        nameLast: 'EndedUserShapeCheck',
+        rosteringEnded: new Date(Date.now() - 24 * 60 * 60 * 1000),
+      });
+
+      const endedRes = await expectRoute('GET', `/v1/users/${endedUser.id}`).as(tiers.superAdmin).toReturn(404);
+      const notFoundRes = await expectRoute('GET', '/v1/users/00000000-0000-0000-0000-000000000000')
+        .as(tiers.superAdmin)
+        .toReturn(404);
+
+      // The error code matches — caller can't distinguish the two cases.
+      expect(endedRes.body.error.code).toBe(notFoundRes.body.error.code);
+    });
+
     it('returns 400 for invalid UUID format', async () => {
       const res = await expectRoute('GET', '/v1/users/not-a-valid-uuid').as(tiers.superAdmin).toReturn(400);
 
@@ -765,6 +795,28 @@ describe('PATCH /v1/users/:id', () => {
 
       expect(res.body.error.code).toBe(ApiErrorCode.RESOURCE_NOT_FOUND);
     });
+
+    it('returns 404 for a rostering-ended target user — same shape as not-found (#1742)', async () => {
+      // A rostering-ended user cannot be PATCHed — same 404 shape as
+      // not-found so callers can't distinguish.
+      const endedUser = await UserFactory.create({
+        nameFirst: 'Patch',
+        nameLast: 'EndedTarget',
+        rosteringEnded: new Date(Date.now() - 24 * 60 * 60 * 1000),
+      });
+
+      const res = await expectRoute('PATCH', `/v1/users/${endedUser.id}`)
+        .as(tiers.superAdmin)
+        .withBody({ nameFirst: 'ShouldNotApply' })
+        .toReturn(StatusCodes.NOT_FOUND);
+
+      expect(res.body.error.code).toBe(ApiErrorCode.RESOURCE_NOT_FOUND);
+
+      // Verify the underlying row was NOT modified.
+      const stillEnded = await userRepository.getById({ id: endedUser.id });
+      expect(stillEnded).not.toBeNull();
+      expect(stillEnded!.nameFirst).toBe('Patch');
+    });
   });
 });
 
@@ -1027,6 +1079,22 @@ describe('POST /v1/users/:userId/agreements', () => {
   describe('validation', () => {
     it('should return 404 when target user does not exist', async () => {
       const res = await expectRoute('POST', '/v1/users/00000000-0000-0000-0000-000000000000/agreements')
+        .as(tiers.superAdmin)
+        .withBody({ agreementVersionId: tosAgreementVersion.id })
+        .toReturn(StatusCodes.NOT_FOUND);
+
+      expect(res.body.error.code).toBe(ApiErrorCode.RESOURCE_NOT_FOUND);
+    });
+
+    it('should return 404 when target user is rostering-ended (#1742)', async () => {
+      // Even with a valid agreement version and a super-admin requester,
+      // a rostering-ended target user yields 404 with the same code as not-found.
+      const endedUser = await UserFactory.create({
+        dob: '1990-01-01',
+        rosteringEnded: new Date(Date.now() - 24 * 60 * 60 * 1000),
+      });
+
+      const res = await expectRoute('POST', `/v1/users/${endedUser.id}/agreements`)
         .as(tiers.superAdmin)
         .withBody({ agreementVersionId: tosAgreementVersion.id })
         .toReturn(StatusCodes.NOT_FOUND);
@@ -1345,6 +1413,19 @@ describe('GET /v1/users/:userId/administrations', () => {
   describe('validation', () => {
     it('returns 404 when target user does not exist', async () => {
       const res = await expectRoute('GET', '/v1/users/00000000-0000-0000-0000-000000000000/administrations')
+        .as(tiers.superAdmin)
+        .toReturn(StatusCodes.NOT_FOUND);
+
+      expect(res.body.error.code).toBe(ApiErrorCode.RESOURCE_NOT_FOUND);
+    });
+
+    it('returns 404 when target user is rostering-ended (#1742)', async () => {
+      const endedUser = await UserFactory.create({
+        nameLast: 'EndedAdminsList1742',
+        rosteringEnded: new Date(Date.now() - 24 * 60 * 60 * 1000),
+      });
+
+      const res = await expectRoute('GET', `/v1/users/${endedUser.id}/administrations`)
         .as(tiers.superAdmin)
         .toReturn(StatusCodes.NOT_FOUND);
 
@@ -2304,6 +2385,22 @@ describe('GET /v1/users/:userId/administrations/:administrationId', () => {
       expect(res.body.error.code).toBe(ApiErrorCode.RESOURCE_NOT_FOUND);
     });
 
+    it('returns 404 when target user is rostering-ended (#1742)', async () => {
+      const endedUser = await UserFactory.create({
+        nameLast: 'EndedSingleAdmin1742',
+        rosteringEnded: new Date(Date.now() - 24 * 60 * 60 * 1000),
+      });
+
+      const res = await expectRoute(
+        'GET',
+        `/v1/users/${endedUser.id}/administrations/${baseFixture.administrationAssignedToSchoolA.id}`,
+      )
+        .as(tiers.superAdmin)
+        .toReturn(StatusCodes.NOT_FOUND);
+
+      expect(res.body.error.code).toBe(ApiErrorCode.RESOURCE_NOT_FOUND);
+    });
+
     it('returns 404 when administration does not exist', async () => {
       const res = await expectRoute(
         'GET',
@@ -2480,17 +2577,10 @@ describe('GET /v1/users/:userId/reports/scores', () => {
     });
 
     it('returns 404 for a student with rosteringEnded set', async () => {
-      // UserFactory.onCreate strips `rosteringEnded` from the insert payload, so
-      // setting it via the factory override has no DB-level effect. Set it
-      // explicitly with an UPDATE after the create to exercise the
-      // rostering-ended branch in the service.
-      const endedStudent = await UserFactory.create({ userType: 'student' });
-      const { eq } = await import('drizzle-orm');
-      const { CoreDbClient } = await import('../db/clients');
-      const { users } = await import('../db/schema');
-      await CoreDbClient.update(users)
-        .set({ rosteringEnded: new Date('2025-01-01') })
-        .where(eq(users.id, endedStudent.id));
+      const endedStudent = await UserFactory.create({
+        userType: 'student',
+        rosteringEnded: new Date('2025-01-01'),
+      });
 
       const res = await expectRoute('GET', reportPath(endedStudent.id)).as(tiers.superAdmin).toReturn(404);
 

--- a/apps/backend/src/services/administration/administration.service.test.ts
+++ b/apps/backend/src/services/administration/administration.service.test.ts
@@ -2433,6 +2433,42 @@ describe('AdministrationService', () => {
       expect(result.totalItems).toBe(2);
     });
 
+    it('throws 404 when a rostering-ended user requests their own administrations (#1742 defense-in-depth)', async () => {
+      // The auth guard (#1735) blocks rostering-ended users end-to-end, but
+      // the service-layer check runs BEFORE the `requesterUserId === userId`
+      // early return so a rostering-ended user can't bypass the boundary
+      // even if the guard is somehow circumvented or future-changed. This
+      // unit test exercises that defense-in-depth path directly.
+      const endedUser = UserFactory.build({
+        id: 'ended-user-self-1742',
+        rosteringEnded: new Date(Date.now() - 24 * 60 * 60 * 1000),
+      });
+      mockUserRepository.getById.mockResolvedValue(endedUser);
+
+      const service = AdministrationService({
+        administrationRepository: mockAdministrationRepository,
+        userRepository: mockUserRepository,
+        authorizationService: mockAuthorizationService,
+      });
+
+      await expect(
+        service.getUserAdministrations({ userId: endedUser.id, isSuperAdmin: false }, endedUser.id, {
+          page: 1,
+          perPage: 25,
+          sortBy: 'createdAt',
+          sortOrder: 'desc',
+        }),
+      ).rejects.toMatchObject({
+        statusCode: StatusCodes.NOT_FOUND,
+        code: ApiErrorCode.RESOURCE_NOT_FOUND,
+      });
+
+      // Self-access early return must NOT have been taken — FGA / admin
+      // repo should never be called for a rostering-ended self-lookup.
+      expect(mockAuthorizationService.listAccessibleObjects).not.toHaveBeenCalled();
+      expect(mockAdministrationRepository.getByIds).not.toHaveBeenCalled();
+    });
+
     it('should return administrations for super admin without filtering by requester permissions', async () => {
       const mockAdmins = AdministrationFactory.buildList(3);
       const mockUser = UserFactory.build({ id: 'target-user-123' });

--- a/apps/backend/src/services/administration/administration.service.test.ts
+++ b/apps/backend/src/services/administration/administration.service.test.ts
@@ -2396,8 +2396,13 @@ describe('AdministrationService', () => {
 
   describe('getUserAdministrations', () => {
     it('should delegate to list() when user requests their own administrations (self-access)', async () => {
-      const mockAdmins = AdministrationFactory.buildList(2);
+      // The self-access path still goes through `userRepository.getById` +
+      // `rejectRosteringEndedTarget` (#1742) so a rostering-ended user can't
+      // bypass the boundary via self-listing. The user lookup must be mocked.
+      const mockUser = UserFactory.build({ id: 'user-123', rosteringEnded: null });
+      mockUserRepository.getById.mockResolvedValue(mockUser);
 
+      const mockAdmins = AdministrationFactory.buildList(2);
       mockAuthorizationService.listAccessibleObjects.mockResolvedValue(mockAdmins.map((a) => `administration:${a.id}`));
       mockAdministrationRepository.getByIds.mockResolvedValue({
         items: mockAdmins,
@@ -2406,6 +2411,7 @@ describe('AdministrationService', () => {
 
       const service = AdministrationService({
         administrationRepository: mockAdministrationRepository,
+        userRepository: mockUserRepository,
         authorizationService: mockAuthorizationService,
       });
 

--- a/apps/backend/src/services/administration/administration.service.ts
+++ b/apps/backend/src/services/administration/administration.service.ts
@@ -821,12 +821,11 @@ export function AdministrationService({
   ): Promise<PaginatedResult<AdministrationWithEmbeds>> {
     const { userId: requesterUserId, isSuperAdmin } = authContext;
 
-    if (requesterUserId === userId) {
-      return list(authContext, options);
-    }
-
     try {
-      // Verify target user exists
+      // Verify target user exists. The lookup + rostering-ended check runs
+      // BEFORE the self-lookup early return so a rostering-ended user can't
+      // bypass the boundary by requesting their own administrations
+      // (defense-in-depth alongside auth guard #1735).
       const targetUser = await userRepository.getById({ id: userId });
 
       if (!targetUser) {
@@ -839,9 +838,13 @@ export function AdministrationService({
 
       // Rostering-ended users are decommissioned (#1742). The user-scoped
       // URL names them as the target, so any caller (admin / teacher /
-      // guardian) gets a symmetric 404 — same shape as "not found" so the
-      // caller can't distinguish.
+      // guardian / the user themselves) gets a symmetric 404 — same shape
+      // as "not found" so the caller can't distinguish.
       rejectRosteringEndedTarget(targetUser, { requesterUserId, targetUserId: userId }, 'User-administration list');
+
+      if (requesterUserId === userId) {
+        return list(authContext, options);
+      }
 
       const queryParams = {
         page: options.page,

--- a/apps/backend/src/services/administration/administration.service.ts
+++ b/apps/backend/src/services/administration/administration.service.ts
@@ -55,7 +55,7 @@ import { TaskVariantRepository } from '../../repositories/task-variant.repositor
 import { AgreementRepository } from '../../repositories/agreement.repository';
 import type { Condition } from '../../types/condition';
 import { isMajorityAge } from '../../utils/is-majority-age.util';
-import { verifyEntitiesExist } from '../utils/validations.utils';
+import { verifyEntitiesExist, rejectRosteringEndedTarget } from '../utils/validations.utils';
 
 /**
  * Administration with optional embedded data.
@@ -841,17 +841,7 @@ export function AdministrationService({
       // URL names them as the target, so any caller (admin / teacher /
       // guardian) gets a symmetric 404 — same shape as "not found" so the
       // caller can't distinguish.
-      if (targetUser.rosteringEnded !== null && targetUser.rosteringEnded <= new Date()) {
-        logger.warn(
-          { requesterUserId, targetUserId: userId, rosteringEnded: targetUser.rosteringEnded },
-          'User-administration list attempted on rostering-ended user',
-        );
-        throw new ApiError(ApiErrorMessage.NOT_FOUND, {
-          statusCode: StatusCodes.NOT_FOUND,
-          code: ApiErrorCode.RESOURCE_NOT_FOUND,
-          context: { userId, rosteringEnded: targetUser.rosteringEnded },
-        });
-      }
+      rejectRosteringEndedTarget(targetUser, { requesterUserId, targetUserId: userId }, 'User-administration list');
 
       const queryParams = {
         page: options.page,
@@ -1161,17 +1151,11 @@ export function AdministrationService({
       }
 
       // Rostering-ended target → symmetric 404 (#1742).
-      if (targetUser.rosteringEnded !== null && targetUser.rosteringEnded <= new Date()) {
-        logger.warn(
-          { requesterUserId, targetUserId: userId, administrationId, rosteringEnded: targetUser.rosteringEnded },
-          'Per-user administration lookup attempted on rostering-ended user',
-        );
-        throw new ApiError(ApiErrorMessage.NOT_FOUND, {
-          statusCode: StatusCodes.NOT_FOUND,
-          code: ApiErrorCode.RESOURCE_NOT_FOUND,
-          context: { userId, administrationId, rosteringEnded: targetUser.rosteringEnded },
-        });
-      }
+      rejectRosteringEndedTarget(
+        targetUser,
+        { requesterUserId, targetUserId: userId, administrationId },
+        'Per-user administration lookup',
+      );
 
       const administration = await verifyAdministrationAccess(
         { userId, isSuperAdmin: targetUser.isSuperAdmin },

--- a/apps/backend/src/services/administration/administration.service.ts
+++ b/apps/backend/src/services/administration/administration.service.ts
@@ -836,6 +836,23 @@ export function AdministrationService({
           context: { userId },
         });
       }
+
+      // Rostering-ended users are decommissioned (#1742). The user-scoped
+      // URL names them as the target, so any caller (admin / teacher /
+      // guardian) gets a symmetric 404 — same shape as "not found" so the
+      // caller can't distinguish.
+      if (targetUser.rosteringEnded !== null && targetUser.rosteringEnded <= new Date()) {
+        logger.warn(
+          { requesterUserId, targetUserId: userId, rosteringEnded: targetUser.rosteringEnded },
+          'User-administration list attempted on rostering-ended user',
+        );
+        throw new ApiError(ApiErrorMessage.NOT_FOUND, {
+          statusCode: StatusCodes.NOT_FOUND,
+          code: ApiErrorCode.RESOURCE_NOT_FOUND,
+          context: { userId, rosteringEnded: targetUser.rosteringEnded },
+        });
+      }
+
       const queryParams = {
         page: options.page,
         perPage: options.perPage,
@@ -1140,6 +1157,19 @@ export function AdministrationService({
           statusCode: StatusCodes.NOT_FOUND,
           code: ApiErrorCode.RESOURCE_NOT_FOUND,
           context: { userId },
+        });
+      }
+
+      // Rostering-ended target → symmetric 404 (#1742).
+      if (targetUser.rosteringEnded !== null && targetUser.rosteringEnded <= new Date()) {
+        logger.warn(
+          { requesterUserId, targetUserId: userId, administrationId, rosteringEnded: targetUser.rosteringEnded },
+          'Per-user administration lookup attempted on rostering-ended user',
+        );
+        throw new ApiError(ApiErrorMessage.NOT_FOUND, {
+          statusCode: StatusCodes.NOT_FOUND,
+          code: ApiErrorCode.RESOURCE_NOT_FOUND,
+          context: { userId, administrationId, rosteringEnded: targetUser.rosteringEnded },
         });
       }
 

--- a/apps/backend/src/services/report/report.service.ts
+++ b/apps/backend/src/services/report/report.service.ts
@@ -300,17 +300,34 @@ export function ReportService({
           ? buildFilterConditions(userFilters, PROGRESS_FILTER_FIELDS, { gradeAwareFields: GRADE_AWARE_FIELDS })
           : undefined;
 
-      // 5. Get paginated students with run data.
-      // Progress status sort/filter is handled via LEFT JOIN + CASE in the repository.
-      const result = await reportRepository.getProgressStudents(
-        administrationId,
-        { scopeType, scopeId },
-        taskVariantIds,
-        { page, perPage, sortColumn, sortDirection: sortOrder },
-        filterCondition,
-        progressStatusSort ?? undefined,
-        progressStatusFilters.length > 0 ? progressStatusFilters : undefined,
-      );
+      // 5. Get paginated students with run data and the rostering-ended
+      // exclusion count in parallel. Progress status sort/filter is handled
+      // via LEFT JOIN + CASE in the repository. The exclusion query runs as
+      // a sibling rather than a serial follow-up so the wall-clock cost is
+      // bounded by `max(students-query, exclusion-count-query)` rather than
+      // the sum.
+      const [result, exclusionsRosteringEnded] = await Promise.all([
+        reportRepository.getProgressStudents(
+          administrationId,
+          { scopeType, scopeId },
+          taskVariantIds,
+          { page, perPage, sortColumn, sortDirection: sortOrder },
+          filterCondition,
+          progressStatusSort ?? undefined,
+          progressStatusFilters.length > 0 ? progressStatusFilters : undefined,
+        ),
+        reportRepository.countRosteringEndedExclusions({ scopeType, scopeId }).catch((err) => {
+          // Wrap the parallel branch in `.catch` so a failure here throws
+          // `ApiError` immediately rather than propagating a raw error to
+          // the outer catch (per backend-error-handling.md).
+          throw new ApiError('Failed to compute rostering-ended exclusion count', {
+            statusCode: StatusCodes.INTERNAL_SERVER_ERROR,
+            code: ApiErrorCode.DATABASE_QUERY_FAILED,
+            context: { userId, administrationId, scopeType, scopeId },
+            cause: err,
+          });
+        }),
+      ]);
 
       // 6. Transform to response shape
       const tasks: ServiceTaskMetadata[] = taskMetas.map((t) => ({
@@ -338,7 +355,12 @@ export function ReportService({
       // Students with an empty progress map (all tasks excluded by conditionsAssignment)
       // are intentionally included — they are enrolled in the scope and the empty row is
       // meaningful to teachers. Excluding them would cause pagination instability.
-      return { tasks, items, totalItems: result.totalItems };
+      return {
+        tasks,
+        items,
+        totalItems: result.totalItems,
+        exclusions: { rosteringEnded: exclusionsRosteringEnded },
+      };
     } catch (error) {
       if (error instanceof ApiError) throw error;
 
@@ -397,14 +419,22 @@ export function ReportService({
       // 2. Validate scope and authorize can_read_progress on the scope entity
       await authorizeScopeAccess(authContext, administrationId, scopeType, scopeId);
 
-      // 3. Get task metadata and run SQL-level aggregation
+      // 3. Get task metadata and run SQL-level aggregation in parallel with
+      // the rostering-ended exclusion count (#1742). The exclusion query
+      // adds one round-trip rather than serializing.
       const taskMetas = await reportRepository.getTaskMetadata(administrationId);
 
-      const { totalStudents, taskStatusCounts, studentCounts } = await reportRepository.getProgressOverviewCounts(
-        administrationId,
-        { scopeType, scopeId },
-        taskMetas,
-      );
+      const [{ totalStudents, taskStatusCounts, studentCounts }, exclusionsRosteringEnded] = await Promise.all([
+        reportRepository.getProgressOverviewCounts(administrationId, { scopeType, scopeId }, taskMetas),
+        reportRepository.countRosteringEndedExclusions({ scopeType, scopeId }).catch((err) => {
+          throw new ApiError('Failed to compute rostering-ended exclusion count', {
+            statusCode: StatusCodes.INTERNAL_SERVER_ERROR,
+            code: ApiErrorCode.DATABASE_QUERY_FAILED,
+            context: { userId, administrationId, scopeType, scopeId },
+            cause: err,
+          });
+        }),
+      ]);
 
       // 4. Build per-task counters from unique taskIds (preserving order from metadata)
       const taskIdOrder: string[] = [];
@@ -482,6 +512,7 @@ export function ReportService({
         studentsCompleted: studentCounts.studentsCompleted,
         byTask,
         computedAt: new Date().toISOString(),
+        exclusions: { rosteringEnded: exclusionsRosteringEnded },
       };
     } catch (error) {
       if (error instanceof ApiError) throw error;
@@ -582,11 +613,29 @@ export function ReportService({
       // filter eliminates every task we can short-circuit without touching the DB.
       const taskGroups = groupVariantsByTaskId(taskMetas);
 
+      // Fetch the rostering-ended exclusion count eagerly so it can be
+      // surfaced in every return path of this function (including the
+      // short-circuit empty-tasks branch immediately below). The count is
+      // a single COUNT(DISTINCT) query — cheap on its own and run before
+      // the heavier `getAllStudentsInScope` so we can include it in early-
+      // return responses.
+      const exclusionsRosteringEnded = await reportRepository
+        .countRosteringEndedExclusions({ scopeType, scopeId })
+        .catch((err) => {
+          throw new ApiError('Failed to compute rostering-ended exclusion count', {
+            statusCode: StatusCodes.INTERNAL_SERVER_ERROR,
+            code: ApiErrorCode.DATABASE_QUERY_FAILED,
+            context: { userId, administrationId, scopeType, scopeId },
+            cause: err,
+          });
+        });
+
       if (taskGroups.length === 0) {
         return {
           totalStudents: 0,
           tasks: [],
           computedAt: new Date().toISOString(),
+          exclusions: { rosteringEnded: exclusionsRosteringEnded },
         };
       }
 
@@ -601,6 +650,7 @@ export function ReportService({
           totalStudents,
           tasks: taskGroups.map(({ representative }) => buildEmptyTaskOverview(representative)),
           computedAt: new Date().toISOString(),
+          exclusions: { rosteringEnded: exclusionsRosteringEnded },
         };
       }
 
@@ -636,7 +686,12 @@ export function ReportService({
         ),
       );
 
-      return { totalStudents, tasks, computedAt: new Date().toISOString() };
+      return {
+        totalStudents,
+        tasks,
+        computedAt: new Date().toISOString(),
+        exclusions: { rosteringEnded: exclusionsRosteringEnded },
+      };
     } catch (error) {
       if (error instanceof ApiError) throw error;
 
@@ -757,12 +812,26 @@ export function ReportService({
             })
           : undefined;
 
+      // Fetch the rostering-ended exclusion count eagerly so it can be
+      // surfaced in every return path of this function (including the
+      // short-circuit empty-tasks branch immediately below).
+      const exclusionsRosteringEnded = await reportRepository
+        .countRosteringEndedExclusions({ scopeType, scopeId })
+        .catch((err) => {
+          throw new ApiError('Failed to compute rostering-ended exclusion count', {
+            statusCode: StatusCodes.INTERNAL_SERVER_ERROR,
+            code: ApiErrorCode.DATABASE_QUERY_FAILED,
+            context: { userId, administrationId, scopeType, scopeId },
+            cause: err,
+          });
+        });
+
       // Short-circuit: when the taskId filter (or an empty administration) leaves
       // no tasks in scope, no per-task entries can be assembled. Skip the
       // pagination + score JOINs and return an empty page. Matches the analogous
       // short-circuit in getScoreOverview.
       if (taskMetas.length === 0) {
-        return { tasks: [], items: [], totalItems: 0 };
+        return { tasks: [], items: [], totalItems: 0, exclusions: { rosteringEnded: exclusionsRosteringEnded } };
       }
 
       // 9. Determine the static sort column when sorting by a user field.
@@ -819,7 +888,12 @@ export function ReportService({
         ),
       );
 
-      return { tasks: tasksOrdered, items, totalItems: result.totalItems };
+      return {
+        tasks: tasksOrdered,
+        items,
+        totalItems: result.totalItems,
+        exclusions: { rosteringEnded: exclusionsRosteringEnded },
+      };
     } catch (error) {
       if (error instanceof ApiError) throw error;
 

--- a/apps/backend/src/services/report/report.types.ts
+++ b/apps/backend/src/services/report/report.types.ts
@@ -72,11 +72,22 @@ export interface ServiceProgressStudent {
   progress: Record<string, ServiceProgressEntry>;
 }
 
+/**
+ * Counts of records filtered out of a reporting response (#1742). Surfaced
+ * alongside `pagination` / `totalItems` so the frontend can caveat sparse
+ * historical reports. Open-ended on purpose — future categories beyond
+ * `rosteringEnded` can be added without a breaking change.
+ */
+export interface ReportExclusions {
+  rosteringEnded: number;
+}
+
 /** Return type for listProgressStudents. */
 export interface ProgressStudentsResult {
   tasks: ServiceTaskMetadata[];
   items: ServiceProgressStudent[];
   totalItems: number;
+  exclusions: ReportExclusions;
 }
 
 /** Query input for getProgressOverview. */
@@ -120,6 +131,7 @@ export interface ProgressOverviewResult {
   studentsCompleted: number;
   byTask: ServiceTaskOverview[];
   computedAt: string;
+  exclusions: ReportExclusions;
 }
 
 /** Query input for getScoreOverview. */
@@ -161,6 +173,7 @@ export interface ScoreOverviewResult {
   tasks: ServiceTaskScoreOverview[];
   /** ISO 8601 timestamp when the aggregation was computed */
   computedAt: string;
+  exclusions: ReportExclusions;
 }
 
 /** Query input for listStudentScores. */
@@ -228,6 +241,7 @@ export interface StudentScoresResult {
   tasks: ServiceTaskMetadata[];
   items: ServiceStudentScoreRow[];
   totalItems: number;
+  exclusions: ReportExclusions;
 }
 
 /** Query input for getIndividualStudentReport. */

--- a/apps/backend/src/services/user/user.service.ts
+++ b/apps/backend/src/services/user/user.service.ts
@@ -251,6 +251,27 @@ export function UserService({
       });
     }
 
+    // 1b. Rostering-ended users are decommissioned (#1742). Any URL that
+    // names them as a target — single-user lookup, per-user reporting,
+    // PATCH, agreement record, user-scoped administration list — returns
+    // 404 with no access-control distinction (the auth guard #1735 already
+    // blocks the rostering-ended user themselves from calling the API; the
+    // only callers reaching this point are *other* users looking them up).
+    // The 404 is symmetric to a not-found user — same `ApiErrorMessage.NOT_FOUND`,
+    // same `ApiErrorCode.RESOURCE_NOT_FOUND` — so requesters can't infer
+    // whether the target ever existed.
+    if (user.rosteringEnded !== null && user.rosteringEnded <= new Date()) {
+      logger.warn(
+        { userId, targetUserId: id, rosteringEnded: user.rosteringEnded },
+        'Lookup attempted on rostering-ended user',
+      );
+      throw new ApiError(ApiErrorMessage.NOT_FOUND, {
+        statusCode: StatusCodes.NOT_FOUND,
+        code: ApiErrorCode.RESOURCE_NOT_FOUND,
+        context: { id, userId, rosteringEnded: user.rosteringEnded },
+      });
+    }
+
     // 2. Super admins bypass permission checks
     if (isSuperAdmin) {
       return user;
@@ -1088,6 +1109,20 @@ export function UserService({
         });
       }
 
+      // Rostering-ended users return 404 — same shape as not-found so requesters
+      // can't tell the difference (#1742).
+      if (user.rosteringEnded !== null && user.rosteringEnded <= new Date()) {
+        logger.warn(
+          { userId, targetUserId: id, rosteringEnded: user.rosteringEnded },
+          'PATCH attempted on rostering-ended user',
+        );
+        throw new ApiError(ApiErrorMessage.NOT_FOUND, {
+          statusCode: StatusCodes.NOT_FOUND,
+          code: ApiErrorCode.RESOURCE_NOT_FOUND,
+          context: { userId, id, rosteringEnded: user.rosteringEnded },
+        });
+      }
+
       await userRepository.update({
         id,
         data: {
@@ -1181,6 +1216,20 @@ export function UserService({
           statusCode: StatusCodes.NOT_FOUND,
           code: ApiErrorCode.RESOURCE_NOT_FOUND,
           context: { userId: requestingUserId, targetUserId: userId },
+        });
+      }
+
+      // 1b. Rostering-ended users are decommissioned — same 404 shape as
+      // a not-found user so the caller can't distinguish (#1742).
+      if (targetUser.rosteringEnded !== null && targetUser.rosteringEnded <= new Date()) {
+        logger.warn(
+          { requestingUserId, targetUserId: userId, rosteringEnded: targetUser.rosteringEnded },
+          'Agreement record attempted on rostering-ended user',
+        );
+        throw new ApiError(ApiErrorMessage.NOT_FOUND, {
+          statusCode: StatusCodes.NOT_FOUND,
+          code: ApiErrorCode.RESOURCE_NOT_FOUND,
+          context: { userId: requestingUserId, targetUserId: userId, rosteringEnded: targetUser.rosteringEnded },
         });
       }
 

--- a/apps/backend/src/services/user/user.service.ts
+++ b/apps/backend/src/services/user/user.service.ts
@@ -41,6 +41,7 @@ import { UserType } from '../../enums/user-type.enum';
 import { AuthProvider } from '../../enums/auth-provider.enum';
 import { isFirebaseError } from '../../types/firebase';
 import { FIREBASE_ERROR_CODES } from '../../constants/firebase-error-codes';
+import { rejectRosteringEndedTarget } from '../utils/validations.utils';
 
 // Types for the unsigned TOS agreements response
 interface TosAgreementVersion {
@@ -257,20 +258,7 @@ export function UserService({
     // 404 with no access-control distinction (the auth guard #1735 already
     // blocks the rostering-ended user themselves from calling the API; the
     // only callers reaching this point are *other* users looking them up).
-    // The 404 is symmetric to a not-found user — same `ApiErrorMessage.NOT_FOUND`,
-    // same `ApiErrorCode.RESOURCE_NOT_FOUND` — so requesters can't infer
-    // whether the target ever existed.
-    if (user.rosteringEnded !== null && user.rosteringEnded <= new Date()) {
-      logger.warn(
-        { userId, targetUserId: id, rosteringEnded: user.rosteringEnded },
-        'Lookup attempted on rostering-ended user',
-      );
-      throw new ApiError(ApiErrorMessage.NOT_FOUND, {
-        statusCode: StatusCodes.NOT_FOUND,
-        code: ApiErrorCode.RESOURCE_NOT_FOUND,
-        context: { id, userId, rosteringEnded: user.rosteringEnded },
-      });
-    }
+    rejectRosteringEndedTarget(user, { id, userId }, 'Lookup');
 
     // 2. Super admins bypass permission checks
     if (isSuperAdmin) {
@@ -1109,19 +1097,15 @@ export function UserService({
         });
       }
 
-      // Rostering-ended users return 404 — same shape as not-found so requesters
-      // can't tell the difference (#1742).
-      if (user.rosteringEnded !== null && user.rosteringEnded <= new Date()) {
-        logger.warn(
-          { userId, targetUserId: id, rosteringEnded: user.rosteringEnded },
-          'PATCH attempted on rostering-ended user',
-        );
-        throw new ApiError(ApiErrorMessage.NOT_FOUND, {
-          statusCode: StatusCodes.NOT_FOUND,
-          code: ApiErrorCode.RESOURCE_NOT_FOUND,
-          context: { userId, id, rosteringEnded: user.rosteringEnded },
-        });
-      }
+      // Rostering-ended users return 404 — same shape as not-found so
+      // requesters can't tell the difference (#1742).
+      //
+      // TODO: When PATCH authorization is opened up beyond super-admin (see
+      // the FORBIDDEN guard above + JSDoc), this rostering-ended rejection
+      // must continue to run *before* the new authorization path so the 404
+      // remains the response for any non-super-admin attempting to write to
+      // a rostering-ended user — not a 403 / 200 race.
+      rejectRosteringEndedTarget(user, { userId, id }, 'PATCH');
 
       await userRepository.update({
         id,
@@ -1221,17 +1205,7 @@ export function UserService({
 
       // 1b. Rostering-ended users are decommissioned — same 404 shape as
       // a not-found user so the caller can't distinguish (#1742).
-      if (targetUser.rosteringEnded !== null && targetUser.rosteringEnded <= new Date()) {
-        logger.warn(
-          { requestingUserId, targetUserId: userId, rosteringEnded: targetUser.rosteringEnded },
-          'Agreement record attempted on rostering-ended user',
-        );
-        throw new ApiError(ApiErrorMessage.NOT_FOUND, {
-          statusCode: StatusCodes.NOT_FOUND,
-          code: ApiErrorCode.RESOURCE_NOT_FOUND,
-          context: { userId: requestingUserId, targetUserId: userId, rosteringEnded: targetUser.rosteringEnded },
-        });
-      }
+      rejectRosteringEndedTarget(targetUser, { userId: requestingUserId, targetUserId: userId }, 'Agreement record');
 
       // 2. Verify agreement version exists and fetch agreement type
       const agreementVersion = await agreementVersionRepository.getById({ id: agreementVersionId });

--- a/apps/backend/src/services/utils/validations.utils.ts
+++ b/apps/backend/src/services/utils/validations.utils.ts
@@ -2,6 +2,7 @@ import { StatusCodes } from 'http-status-codes';
 import { ApiErrorCode } from '../../enums/api-error-code.enum';
 import { ApiErrorMessage } from '../../enums/api-error-message.enum';
 import { ApiError } from '../../errors';
+import { logger } from '../../logger';
 
 /**
  * Validation function that verifies that all ids from entityIdsToCheck exist in allEntities.
@@ -22,4 +23,44 @@ function verifyEntitiesExist(allEntities: { id: string }[], entityIdsToCheck: st
   }
 }
 
-export { verifyEntitiesExist };
+/**
+ * Throws a 404 `ApiError` if the given user has had their rostering ended
+ * (i.e., `rosteringEnded` is set to a timestamp at or before now).
+ *
+ * Rostering-ended users are decommissioned (#1742): any URL that names them
+ * as a target — single-user lookup, per-user reporting, PATCH, agreement
+ * record, user-scoped administration list — returns 404 with no
+ * access-control distinction. The 404 shape is symmetric to a not-found user
+ * — same `ApiErrorMessage.NOT_FOUND`, same `ApiErrorCode.RESOURCE_NOT_FOUND`
+ * — so requesters can't infer whether the target ever existed.
+ *
+ * Centralized here so every per-user endpoint applies the same predicate
+ * with the same response shape and log message format.
+ *
+ * @param targetUser - The user record to check; only `rosteringEnded` is read.
+ * @param context - Structured context for the warn log + error context object.
+ *                  Pass `requesterUserId`, `targetUserId`, plus any extra
+ *                  identifiers relevant to the calling endpoint.
+ * @param operation - Short label for the log line (e.g., "PATCH",
+ *                    "Agreement record", "Per-user administration lookup").
+ * @throws {ApiError} 404 NOT_FOUND when the user is rostering-ended.
+ */
+function rejectRosteringEndedTarget(
+  targetUser: { rosteringEnded: Date | null },
+  context: Record<string, unknown>,
+  operation: string,
+): void {
+  if (targetUser.rosteringEnded !== null && targetUser.rosteringEnded <= new Date()) {
+    logger.warn(
+      { ...context, rosteringEnded: targetUser.rosteringEnded },
+      `${operation} attempted on rostering-ended user`,
+    );
+    throw new ApiError(ApiErrorMessage.NOT_FOUND, {
+      statusCode: StatusCodes.NOT_FOUND,
+      code: ApiErrorCode.RESOURCE_NOT_FOUND,
+      context: { ...context, rosteringEnded: targetUser.rosteringEnded },
+    });
+  }
+}
+
+export { verifyEntitiesExist, rejectRosteringEndedTarget };

--- a/apps/backend/src/services/utils/validations.utils.ts
+++ b/apps/backend/src/services/utils/validations.utils.ts
@@ -37,6 +37,20 @@ function verifyEntitiesExist(allEntities: { id: string }[], entityIdsToCheck: st
  * Centralized here so every per-user endpoint applies the same predicate
  * with the same response shape and log message format.
  *
+ * ## Time source
+ *
+ * This comparison uses the Node.js wall clock (`new Date()`), while every
+ * SQL filter (`isActiveRoster`, the access-control subqueries, the report
+ * exclusion count) uses PostgreSQL `NOW()`. In a perfectly synchronized
+ * environment those are identical; in practice Node and Postgres can drift
+ * by milliseconds. The discrepancy is bounded by the host clock skew (NTP
+ * keeps it small) and is only observable in the instant straddling the
+ * exact `rosteringEnded` cutoff for a single request. Since rostering-end
+ * timestamps are set by an administrative action with second-or-coarser
+ * granularity, the practical window for a clock-skew false negative /
+ * positive is negligible. Accepting the small discrepancy keeps this
+ * predicate a pure in-memory check (no extra round-trip per call).
+ *
  * @param targetUser - The user record to check; only `rosteringEnded` is read.
  * @param context - Structured context for the warn log + error context object.
  *                  Pass `requesterUserId`, `targetUserId`, plus any extra

--- a/apps/backend/src/test-support/factories/user.factory.ts
+++ b/apps/backend/src/test-support/factories/user.factory.ts
@@ -46,6 +46,7 @@ export const UserFactory = Factory.define<User>(({ onCreate }) => {
       hispanicEthnicity: user.hispanicEthnicity,
       homeLanguage: user.homeLanguage,
       isSuperAdmin: user.isSuperAdmin,
+      rosteringEnded: user.rosteringEnded,
     };
 
     const [inserted] = await CoreDbClient.insert(users).values(insertData).returning();

--- a/apps/backend/src/test-support/repositories/report.repository.ts
+++ b/apps/backend/src/test-support/repositories/report.repository.ts
@@ -21,6 +21,10 @@ export function createMockReportRepository(): MockedObject<ReportRepository> {
     getSchoolNamesForUsers: vi.fn(),
     getStudentScores: vi.fn(),
     verifyStudentInScope: vi.fn(),
+    // Default to 0 — most unit tests don't care about exclusion counts and
+    // would otherwise need to mock this on every call. Tests asserting on
+    // exclusion counts should override per-test with mockResolvedValue.
+    countRosteringEndedExclusions: vi.fn().mockResolvedValue(0),
     getHistoricalRunsForUser: vi.fn(),
     getScoresForRunIds: vi.fn(),
     getCompletedRunsForUser: vi.fn(),

--- a/packages/api-contract/src/v1/administrations/reports/progress/schema.ts
+++ b/packages/api-contract/src/v1/administrations/reports/progress/schema.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import { PaginationQuerySchema, PaginationMetaSchema, createDynamicSortQuerySchema } from '../../../common/query';
+import { ExclusionsSchema } from '../../../common/exclusions';
 import {
   ReportScopeQuerySchema,
   createFilterQuerySchema,
@@ -147,12 +148,17 @@ export type ProgressStudent = z.infer<typeof ProgressStudentSchema>;
 
 /**
  * Response schema for the progress students endpoint.
- * Includes task metadata for column rendering and paginated student rows.
+ *
+ * Includes task metadata for column rendering, paginated student rows, and
+ * an `exclusions` object (see `common/exclusions.ts`) — reporting endpoints
+ * surface counts of records filtered out (e.g., for rostering-ended #1742) so
+ * the frontend can explain a sparse historical report.
  */
 export const ProgressStudentsResponseSchema = z.object({
   tasks: z.array(ReportTaskMetadataSchema),
   items: z.array(ProgressStudentSchema),
   pagination: PaginationMetaSchema,
+  exclusions: ExclusionsSchema,
 });
 
 export type ProgressStudentsResponse = z.infer<typeof ProgressStudentsResponseSchema>;
@@ -227,6 +233,13 @@ export const ProgressOverviewResponseSchema = z.object({
   studentsCompleted: z.number().int(),
   byTask: z.array(ProgressTaskOverviewSchema),
   computedAt: z.string().datetime(),
+  /**
+   * Counts of records filtered out of this report (see
+   * `common/exclusions.ts`). Surfaces rostering-ended (#1742) and future
+   * exclusion categories alongside the aggregate counts so the frontend can
+   * caveat a sparse historical report.
+   */
+  exclusions: ExclusionsSchema,
 });
 
 export type ProgressOverviewResponse = z.infer<typeof ProgressOverviewResponseSchema>;

--- a/packages/api-contract/src/v1/administrations/reports/scores/schema.ts
+++ b/packages/api-contract/src/v1/administrations/reports/scores/schema.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import { PaginationQuerySchema, PaginationMetaSchema, createDynamicSortQuerySchema } from '../../../common/query';
+import { ExclusionsSchema } from '../../../common/exclusions';
 import {
   ReportScopeQuerySchema,
   createFilterQuerySchema,
@@ -68,6 +69,13 @@ export const ScoreOverviewResponseSchema = z.object({
   tasks: z.array(TaskScoreOverviewSchema),
   /** Server timestamp when the aggregation was computed (ISO 8601) */
   computedAt: z.string().datetime(),
+  /**
+   * Counts of records filtered out of this overview (see
+   * `common/exclusions.ts`). Surfaces rostering-ended (#1742) and future
+   * exclusion categories so the frontend can caveat a sparse historical
+   * report.
+   */
+  exclusions: ExclusionsSchema,
 });
 
 export type ScoreOverviewResponse = z.infer<typeof ScoreOverviewResponseSchema>;
@@ -218,12 +226,17 @@ export type StudentScoreRow = z.infer<typeof StudentScoreRowSchema>;
 
 /**
  * Response schema for the student scores endpoint.
- * Includes task metadata for column rendering and paginated student rows.
+ *
+ * Includes task metadata for column rendering, paginated student rows, and
+ * an `exclusions` object (see `common/exclusions.ts`) — reporting endpoints
+ * surface counts of records filtered out (e.g., for rostering-ended #1742) so
+ * the frontend can explain a sparse historical report.
  */
 export const StudentScoresResponseSchema = z.object({
   tasks: z.array(ReportTaskMetadataSchema),
   items: z.array(StudentScoreRowSchema),
   pagination: PaginationMetaSchema,
+  exclusions: ExclusionsSchema,
 });
 
 export type StudentScoresResponse = z.infer<typeof StudentScoresResponseSchema>;

--- a/packages/api-contract/src/v1/common/exclusions.ts
+++ b/packages/api-contract/src/v1/common/exclusions.ts
@@ -1,0 +1,23 @@
+import { z } from 'zod';
+
+/**
+ * Exclusions metadata for reporting list responses.
+ *
+ * Surfaces counts of records that were filtered out of the result set, so
+ * the frontend can explain a sparse historical report. The schema is
+ * open-ended on purpose — future exclusion categories (e.g., `enrollmentEnded`)
+ * can be added without a breaking response-shape change.
+ *
+ * Initial keys:
+ * - `rosteringEnded`: count of unique users excluded because of rostering-end
+ *   (either the user's own `rosteringEnded` was set or their in-scope parent
+ *   entity's `rosteringEnded` was set). See #1742.
+ *
+ * The count is aggregate across the report scope, not per-org / per-class.
+ * A user excluded for multiple reasons is counted once.
+ */
+export const ExclusionsSchema = z.object({
+  rosteringEnded: z.number().int().nonnegative(),
+});
+
+export type Exclusions = z.infer<typeof ExclusionsSchema>;

--- a/packages/api-contract/src/v1/common/index.ts
+++ b/packages/api-contract/src/v1/common/index.ts
@@ -1,5 +1,6 @@
 export * from './condition';
 export * from './entity';
+export * from './exclusions';
 export * from './http';
 export * from './parse-jsonb';
 export * from './query';

--- a/packages/api-contract/src/v1/common/query.ts
+++ b/packages/api-contract/src/v1/common/query.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { ExclusionsSchema } from './exclusions';
 
 /**
  * Schema for pagination query parameters.
@@ -140,6 +141,23 @@ export const createPaginatedResponseSchema = <T extends z.ZodTypeAny>(itemSchema
   z.object({
     items: z.array(itemSchema),
     pagination: PaginationMetaSchema,
+  });
+
+/**
+ * Creates a paginated response schema for reporting list endpoints. Adds an
+ * `exclusions` object alongside `pagination` so the response can surface
+ * counts of records that were filtered out of the result set (see
+ * `common/exclusions.ts`). User-list endpoints — which return the active
+ * roster and don't have a notion of "excluded for reporting reasons" —
+ * keep using `createPaginatedResponseSchema` and don't include this field.
+ *
+ * @param itemSchema - The Zod schema for individual items in the list
+ */
+export const createReportingPaginatedResponseSchema = <T extends z.ZodTypeAny>(itemSchema: T) =>
+  z.object({
+    items: z.array(itemSchema),
+    pagination: PaginationMetaSchema,
+    exclusions: ExclusionsSchema,
   });
 
 /**

--- a/packages/api-contract/src/v1/common/query.ts
+++ b/packages/api-contract/src/v1/common/query.ts
@@ -1,5 +1,4 @@
 import { z } from 'zod';
-import { ExclusionsSchema } from './exclusions';
 
 /**
  * Schema for pagination query parameters.
@@ -141,23 +140,6 @@ export const createPaginatedResponseSchema = <T extends z.ZodTypeAny>(itemSchema
   z.object({
     items: z.array(itemSchema),
     pagination: PaginationMetaSchema,
-  });
-
-/**
- * Creates a paginated response schema for reporting list endpoints. Adds an
- * `exclusions` object alongside `pagination` so the response can surface
- * counts of records that were filtered out of the result set (see
- * `common/exclusions.ts`). User-list endpoints — which return the active
- * roster and don't have a notion of "excluded for reporting reasons" —
- * keep using `createPaginatedResponseSchema` and don't include this field.
- *
- * @param itemSchema - The Zod schema for individual items in the list
- */
-export const createReportingPaginatedResponseSchema = <T extends z.ZodTypeAny>(itemSchema: T) =>
-  z.object({
-    items: z.array(itemSchema),
-    pagination: PaginationMetaSchema,
-    exclusions: ExclusionsSchema,
   });
 
 /**


### PR DESCRIPTION
## Summary

This PR makes `users.rosteringEnded` a hard boundary across every endpoint that lists, looks up, or reports on users. Once a user's `rosteringEnded` timestamp is set in the past, that user is invisible from list endpoints, returns 404 from per-user lookups, and is excluded from reporting outputs with a count surfaced in a new `exclusions.rosteringEnded` field on the reporting response envelopes.

## Behavior

| Surface | Behavior |
|---------|----------|
| User-list endpoints (district / school / class / group / family) | Rostering-ended users filtered out of `items`; `totalItems` reflects the active count |
| District / school `embed=counts` | `users` total excludes rostering-ended users |
| `GET /v1/users/:id`, `GET /v1/me`<sup>*</sup>, `PATCH /v1/users/:id`, `POST /v1/users/:userId/agreements` | 404 NOT_FOUND with `ApiErrorCode.RESOURCE_NOT_FOUND` — symmetric to a non-existent user so requesters can't infer prior existence |
| `GET /v1/users/:userId/administrations`, `GET /v1/users/:userId/administrations/:administrationId` | Same 404 shape |
| `GET /v1/users/:userId/reports/scores` (guardian report) | Same 404 shape |
| `GET /v1/administrations/:id/reports/progress/students` | Rostering-ended students filtered from `items`; count in `exclusions.rosteringEnded` |
| `GET /v1/administrations/:id/reports/progress/overview` | Rostering-ended students excluded from aggregations; count in `exclusions.rosteringEnded` |
| `GET /v1/administrations/:id/reports/scores/overview` | Same |
| `GET /v1/administrations/:id/reports/scores/students` | Same |
| `GET /v1/administrations/:id/reports/scores/students/:userId` (individual student report) | 404 when target is rostering-ended |

<sup>*</sup> The `/me` endpoint is protected by the auth guard, which already blocks a rostering-ended user from authenticating; the service-layer check is defense-in-depth for the same `verifyUserAccess` path.

The boundary is intentionally narrower than authorization: super admins **do not** bypass it. Rostering-ended means "decommissioned from the platform," not "I don't have permission".

## Semantics

- `rosteringEnded IS NULL` → user is active
- `rosteringEnded > NOW()` → user is still active (future-dated end is a scheduled decommission, not an immediate one)
- `rosteringEnded <= NOW()` → user is decommissioned

This matches the existing org / class / group / family rostering-ended semantics, and is captured in the new `isActiveRoster()` SQL helper applied uniformly across every site.

## Architecture

**`isActiveRoster()` helper** in `repositories/utils/enrollment.utils.ts` is the single source of truth for the SQL predicate. It returns a strict `SQL` (not `SQL | undefined`) so callers can use it in typed contexts like `SQL[]` arrays. Used by:

- `getEnrolledUsersFilterConditions` (every user-list endpoint via the shared filter composer)
- `buildStudentInScopeQuery` (every reporting in-scope query)
- `verifyStudentInScope` (individual student report 404 check)
- `fetchDistrictCounts` and `fetchSchoolCounts` (the `embed=counts` user-count subqueries)

**`rejectRosteringEndedTarget()` helper** in `services/utils/validations.utils.ts` is the single source of truth for the service-layer 404, same `ApiErrorMessage.NOT_FOUND`, same `ApiErrorCode.RESOURCE_NOT_FOUND`, same `logger.warn` shape. Used by:

- `UserService.verifyUserAccess` (covers GET `/users/:id`, GET `/me`)
- `UserService.update`
- `UserService.recordUserAgreement`
- `AdministrationService.getUserAdministrations`
- `AdministrationService.getUserAdministration`

**`ReportRepository.countRosteringEndedExclusions(scope)`** is a new public method that mirrors the FROM/JOIN shape of `buildStudentInScopeQuery` but inverts the rostering-ended predicates, returning `COUNT(DISTINCT users.id)` of students that would otherwise have been in scope but were filtered out. Both reasons share the same key (user-level vs entity-level), and the `DISTINCT` clause dedups students excluded for both. Designed to run in parallel with the main report query via `Promise.all`. One extra round-trip per reporting endpoint, not N+1.

## Contract changes

New `ExclusionsSchema` in `packages/api-contract/src/v1/common/exclusions.ts`:

```ts
export const ExclusionsSchema = z.object({
  rosteringEnded: z.number().int().nonnegative(),
});
```

Added as an `exclusions` field to all four reporting response schemas:

- `ProgressStudentsResponseSchema`
- `ProgressOverviewResponseSchema`
- `ScoreOverviewResponseSchema`
- `StudentScoresResponseSchema`

The shape is open-ended on purpose. Additional exclusion categories beyond `rosteringEnded` can be added without a breaking change.

## Data flow

```mermaid
sequenceDiagram
  Client->>Controller: GET /administrations/:id/reports/progress/students
  Controller->>Service: listProgressStudents(authContext, query)
  par main report query
    Service->>Repository: getProgressStudents(scope, ...)
    Repository->>DB: students_in_scope JOIN users (isActiveRoster)
    DB-->>Repository: filtered items
  and exclusion count query
    Service->>Repository: countRosteringEndedExclusions(scope)
    Repository->>DB: UNION of inverted predicates
    DB-->>Repository: COUNT DISTINCT
  end
  Repository-->>Service: { items, totalItems, exclusions }
  Service-->>Controller: ProgressStudentsResult
  Controller-->>Client: { data: { items, pagination, exclusions } }
```

## Testing

Unit tests for `isActiveRoster` cover the helper's structural typing and non-undefined return shape. Integration tests added:

- **User-list endpoints** — `class`, `group`, `family`, `district`, `school` repos each verify that user-level rostering-ended exclusion works at the user-list / embed-counts query.
- **`countRosteringEndedExclusions`** — covers district, school, class, and group scopes; both user-level and entity-level exclusion reasons; the dedup case where the same student matches both; the future-dated rostering-end is still active case; the role filter (non-students ignored).
- **Per-user 404s** — added 404 tests for rostering-ended targets on `GET /v1/users/:id`, `PATCH /v1/users/:id`, `POST /v1/users/:userId/agreements`, `GET /v1/users/:userId/administrations`, `GET /v1/users/:userId/administrations/:administrationId`. Verified shape symmetry against the not-found case.
- **Reporting endpoints** — `exclusions.rosteringEnded` shape assertion on all four endpoints, plus an end-to-end test that asserts a rostering-ended student is excluded from `items` AND surfaces in `exclusions.rosteringEnded`.

## Out of scope / follow-ups

- **PATCH authorization expansion**: PATCH is currently super-admin only. A TODO comment in `update()` notes that when the gate is relaxed, the rostering-ended 404 must continue to fire before the new authorization path.

Resolves [1742](https://github.com/yeatmanlab/roar-project-management/issues/1742)

## Types of changes

What types of changes does this pull request introduce?

<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (non-breaking change that does not add functionality but makes code cleaner or more efficient)
- [ ] Documentation Update
- [x] Tests (new or updated tests)
- [ ] Style (changes to code styling)
- [ ] CI (continuous integration changes)
- [ ] Repository Maintenance
- [ ] Other (please describe below)

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask.  We're here
to help! This is simply a reminder of what we are going to look for before
merging your code.
-->

- [x] I have read the [guidelines for contributing](https://github.com/yeatmanlab/roar-dashboard/blob/main/.github/CONTRIBUTING.md).
- [x] The changes in this PR are as small as they can be. They represent one and only one fix or enhancement.
- [x] Linting checks pass with my changes.
- [x] Any existing unit tests pass with my changes.
- [x] Any existing end-to-end tests pass with my changes.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] If this PR fixes an existing issue, I have added a unit or end-to-end test that will detect if this issue reoccurs.
- [x] I have added JSDoc comments as appropriate.
- [ ] I have added the necessary documentation to the [roar-docs repository](https://github.com/yeatmanlab/roar-docs).
- [x] I have shared this PR on the roar-pr-reviews channel (if I have access)
- [x] I have linked relevant issues (if any)