### PR TITLE
Fix crc-32 runtime crash in production bundle

### DIFF
--- a/apps/backend/src/utils/assessment-pid.util.ts
+++ b/apps/backend/src/utils/assessment-pid.util.ts
@@ -1,10 +1,11 @@
-import { createRequire } from 'node:module';
+// crc-32 is CJS-only. Use a default import so Rollup's commonjs() plugin can
+// statically resolve and bundle it into the production output. Named ESM imports
+// (import { str }) also work at build time, but a default import is more robust
+// across bundler CJS interop modes. In the distroless Docker image there are no
+// node_modules, so the module MUST be bundled — createRequire() won't work.
+import crc32Module from 'crc-32';
 
-// crc-32 is CJS-only; named ESM imports fail at runtime when the module is externalized.
-// createRequire loads it as CJS and avoids TypeScript organize-imports rewriting the call.
-const { str: crc32 } = createRequire(import.meta.url)('crc-32') as {
-  str: (data: string, seed?: number) => number;
-};
+const crc32 = crc32Module.str;
 
 /**
  * Generate a CRC32 hex checksum of a string.


### PR DESCRIPTION
## Summary

This PR fixes the `Cannot find module 'crc-32'` crash that occurs at startup in production Cloud Run deployments.

The previous code used `createRequire(import.meta.url)('crc-32')` to load the CJS-only `crc-32` package. This pattern is opaque to Rollup's static analysis and hence Rollup doesn't recognise it as an import, so the `require('crc-32')` call passes through unchanged into the production bundle. In the distroless Docker image (no `node_modules`), this crashes at startup.

The fix switches to a standard default ESM import (`import crc32Module from 'crc-32'`), which Rollup's `commonjs()` + `nodeResolve()` plugins can statically resolve and bundle into the output.

### Why the previous approaches failed

| Approach | Dev | Production | Problem |
|----------|-----|------------|---------|
| `import { str } from 'crc-32'` (original) | Fails | Works | Node's ESM runtime can't resolve named exports from CJS without `exports` field |
| `createRequire(...)('crc-32')` (monorepo migration) | Works | Fails | Rollup can't statically analyze `createRequire` — leaves runtime `require()` in bundle |
| `import crc32Module from 'crc-32'` (this PR) | Works | Works | Default import is resolved by `commonjs()` plugin at build time in both modes |

### Why the `onLog` safeguard didn't catch it

The `UNRESOLVED_IMPORT` error handler in `rollup.config.mjs` only fires when Rollup *attempts* to resolve a module and fails. Since Rollup never recognizes the `createRequire` call as an import, no resolution is attempted and no warning is emitted.
