### PR TITLE
Fix auth emulator for non-super-admins

### DIFF
--- a/apps/dashboard/src/composables/mutations/useSignOutMutation.js
+++ b/apps/dashboard/src/composables/mutations/useSignOutMutation.js
@@ -4,6 +4,7 @@ import * as Sentry from '@sentry/vue';
 import { useAuthStore } from '@/store/auth';
 import { SIGN_OUT_MUTATION_KEY } from '@/constants/mutationKeys';
 import { APP_ROUTES } from '@/constants/routes';
+import { IS_FIREBASE_EMULATOR_ENABLED } from '@/constants/firebase';
 
 /**
  * Sign-Out mutation.
@@ -37,6 +38,19 @@ const useSignOutMutation = () => {
       // Clear the query client to remove all cached data — this also drops
       // any cached `/me` payload.
       queryClient.clear();
+
+      // Local emulator: re-initializing Firekit client-side re-runs
+      // connectAuthEmulator on the already-used Auth instance, which Firebase only
+      // permits before the instance is used — the second call leaves auth broken
+      // until a manual page refresh. That is the cause of the local "hang when
+      // logging out and back in as a different user". A full reload to the sign-in
+      // page gives the next sign-in a clean Firebase/Firekit init, exactly like the
+      // manual refresh that currently works around it. Gated on the emulator flag,
+      // so deployed builds keep the client-side re-init + SPA redirect below.
+      if (IS_FIREBASE_EMULATOR_ENABLED) {
+        window.location.assign(APP_ROUTES.SIGN_IN);
+        return;
+      }
 
       // Re-initialize Firekit. This is necessary to ensure that Firekit is properly reset after
       // sign-out in order to allow a new user to sign in.

--- a/apps/dashboard/src/composables/mutations/useSignOutMutation.js
+++ b/apps/dashboard/src/composables/mutations/useSignOutMutation.js
@@ -45,10 +45,11 @@ const useSignOutMutation = () => {
       // until a manual page refresh. That is the cause of the local "hang when
       // logging out and back in as a different user". A full reload to the sign-in
       // page gives the next sign-in a clean Firebase/Firekit init, exactly like the
-      // manual refresh that currently works around it. Gated on the emulator flag,
-      // so deployed builds keep the client-side re-init + SPA redirect below.
+      // manual refresh that currently works around it; `replace` (not `assign`) keeps
+      // the signed-out page out of history so Back can't return to it. Gated on the
+      // emulator flag, so deployed builds keep the client-side re-init + SPA redirect below.
       if (IS_FIREBASE_EMULATOR_ENABLED) {
-        window.location.assign(APP_ROUTES.SIGN_IN);
+        window.location.replace(APP_ROUTES.SIGN_IN);
         return;
       }
 

--- a/apps/dashboard/src/helpers/resolveUserClaims.js
+++ b/apps/dashboard/src/helpers/resolveUserClaims.js
@@ -1,34 +1,68 @@
+import { UserRoles } from '@bdelab/roar-firekit';
 import { fetchDocById } from '@/helpers/query/utils';
 import { getRoarApiClient } from '@/clients/roar-api';
 import { IS_FIREBASE_EMULATOR_ENABLED } from '@/constants/firebase';
+
+/**
+ * Backend `/me` `userType` values that should land on the admin dashboard.
+ * `admin` covers administrators/principals; `educator` covers teachers
+ * (supervisory). `student` and `caregiver` are participants.
+ */
+const ADMIN_DASHBOARD_USER_TYPES = new Set(['admin', 'educator']);
+
+/**
+ * Derive the subset of legacy `userClaims` the dashboard gates on from a backend
+ * `/me` payload. Emulator-only helper: the Firestore claims document
+ * (`super_admin`, `role`, `minimalAdminOrgs`) isn't available against the local
+ * stack, so reconstruct what `useUserType` (routing) and the auth-store getters
+ * read, using `/me`'s `userType` + `isSuperAdmin`.
+ *
+ * - `super_admin`: from `/me` `isSuperAdmin` (the canonical, FGA-derived flag).
+ * - `role` / `admin`: set for admin- and educator-type users so `useUserType`
+ *   resolves to ADMIN and they route to `HomeAdministrator`. The backend still
+ *   scopes what they can see via FGA, so no admin-org list is needed here.
+ *   Students and caregivers get neither claim and route to `HomeParticipant`.
+ *
+ * @param {{ isSuperAdmin?: boolean, userType?: string } | undefined} meData - The `/me` `data` payload.
+ * @returns {{ super_admin: boolean, admin?: boolean, role?: string }} The derived claims.
+ */
+export function deriveEmulatorClaims(meData) {
+  const isSuperAdmin = Boolean(meData?.isSuperAdmin);
+  const isAdminDashboardUser = ADMIN_DASHBOARD_USER_TYPES.has(meData?.userType);
+
+  return {
+    super_admin: isSuperAdmin,
+    ...(isAdminDashboardUser ? { admin: true, role: UserRoles.ADMIN } : {}),
+  };
+}
 
 /**
  * Resolve the authenticated user's claims object: `{ claims: { super_admin, ... } }`.
  *
  * Production path: read the legacy `userClaims` document from Firestore.
  *
- * Local emulator path: the Firestore claims document is not available against
- * the local stack (only the Auth emulator runs), so derive the one claim the
- * dashboard currently gates super-admin access on — `super_admin` — from the
- * backend `/me` response instead. This branch is gated on
- * `VITE_FIREBASE_EMULATOR_ENABLED` and is a no-op in deployed builds, so the
- * production Firestore claims path is left untouched while the broader
- * off-Firestore claims migration is still pending.
+ * Local emulator path: the Firestore claims document is not available against the
+ * local stack (only the Auth emulator runs), so derive the claims the dashboard
+ * gates routing on — `super_admin` plus, for admins/teachers, `role`/`admin` — from
+ * the backend `/me` response via {@link deriveEmulatorClaims}. This branch is gated
+ * on `VITE_FIREBASE_EMULATOR_ENABLED` and is a no-op in deployed builds, so the
+ * production Firestore claims path is left untouched while the broader off-Firestore
+ * claims migration is still pending.
  *
  * @param {string} uid - The Firebase (admin) UID used to look up Firestore claims.
- *   Used by the production path only; the emulator path identifies the user via
- *   the `/me` Bearer token, so `uid` is ignored there.
+ *   Used by the production path only; the emulator path identifies the user via the
+ *   `/me` Bearer token, so `uid` is ignored there.
  * @returns {Promise<{ claims: object } | undefined>} The userClaims object.
  */
 export async function resolveUserClaims(uid) {
   if (IS_FIREBASE_EMULATOR_ENABLED) {
     try {
       const response = await getRoarApiClient().me.get();
-      const isSuperAdmin = response?.status === 200 ? Boolean(response.body?.data?.isSuperAdmin) : false;
-      return { claims: { super_admin: isSuperAdmin } };
+      const meData = response?.status === 200 ? response.body?.data : undefined;
+      return { claims: deriveEmulatorClaims(meData) };
     } catch (error) {
       // The only backend in the local stack is server-test; if it isn't running,
-      // `/me` throws a network error. Fail closed (no super-admin) with a clear
+      // `/me` throws a network error. Fail closed (no admin access) with a clear
       // hint rather than letting an unhandled rejection break the sign-in flow.
       console.error('[resolveUserClaims] emulator: failed to reach /me — is the local backend running?', error);
       return { claims: { super_admin: false } };

--- a/apps/dashboard/src/helpers/resolveUserClaims.test.js
+++ b/apps/dashboard/src/helpers/resolveUserClaims.test.js
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest';
+import { UserRoles } from '@bdelab/roar-firekit';
+import { deriveEmulatorClaims } from './resolveUserClaims';
+
+describe('deriveEmulatorClaims', () => {
+  it('maps a super admin to super_admin (with admin claims included)', () => {
+    expect(deriveEmulatorClaims({ isSuperAdmin: true, userType: 'admin' })).toEqual({
+      super_admin: true,
+      admin: true,
+      role: UserRoles.ADMIN,
+    });
+  });
+
+  it('maps an admin-type user to admin claims without super_admin', () => {
+    expect(deriveEmulatorClaims({ isSuperAdmin: false, userType: 'admin' })).toEqual({
+      super_admin: false,
+      admin: true,
+      role: UserRoles.ADMIN,
+    });
+  });
+
+  it('maps an educator (teacher) to admin claims so they reach the admin dashboard', () => {
+    expect(deriveEmulatorClaims({ isSuperAdmin: false, userType: 'educator' })).toEqual({
+      super_admin: false,
+      admin: true,
+      role: UserRoles.ADMIN,
+    });
+  });
+
+  it('maps a student to participant claims (no admin/role)', () => {
+    expect(deriveEmulatorClaims({ isSuperAdmin: false, userType: 'student' })).toEqual({ super_admin: false });
+  });
+
+  it('maps a caregiver to participant claims (no admin/role)', () => {
+    expect(deriveEmulatorClaims({ isSuperAdmin: false, userType: 'caregiver' })).toEqual({ super_admin: false });
+  });
+
+  it('fails closed when the /me payload is missing or empty', () => {
+    expect(deriveEmulatorClaims(undefined)).toEqual({ super_admin: false });
+    expect(deriveEmulatorClaims({})).toEqual({ super_admin: false });
+  });
+});

--- a/apps/dashboard/src/helpers/resolveUserClaims.test.js
+++ b/apps/dashboard/src/helpers/resolveUserClaims.test.js
@@ -35,6 +35,12 @@ describe('deriveEmulatorClaims', () => {
     expect(deriveEmulatorClaims({ isSuperAdmin: false, userType: 'caregiver' })).toEqual({ super_admin: false });
   });
 
+  it('keeps super_admin for a super admin whose userType is not an admin-dashboard type', () => {
+    // super_admin is checked first in useUserType, so SUPER_ADMIN routing wins even
+    // without the admin/role claims.
+    expect(deriveEmulatorClaims({ isSuperAdmin: true, userType: 'student' })).toEqual({ super_admin: true });
+  });
+
   it('fails closed when the /me payload is missing or empty', () => {
     expect(deriveEmulatorClaims(undefined)).toEqual({ super_admin: false });
     expect(deriveEmulatorClaims({})).toEqual({ super_admin: false });


### PR DESCRIPTION
## Summary

This PR fixes two bugs in the local Firebase Auth emulator dev flow (`npm run dev:local`): non-super-admins were routed to an empty participant page, and logging out then back in as a different user hung until a manual refresh. Both fixes are gated on `VITE_FIREBASE_EMULATOR_ENABLED` and leave the deployed production auth paths unchanged.

## Route non-super-admins to the admin dashboard

In emulator mode the Firestore `userClaims` document isn't available, so `resolveUserClaims` derives claims from the backend `/me` response. It previously derived only `super_admin`, so every non-super-admin fell through to PARTICIPANT in `useUserType` and rendered the (locally-empty) assignments page.

`resolveUserClaims` now derives admin routing claims from `/me` `userType` via a new `deriveEmulatorClaims` helper:

- `super_admin` ← `/me` `isSuperAdmin`
- `userType` `admin` / `educator` → `{ admin: true, role: UserRoles.ADMIN }` so `useUserType` resolves to ADMIN and they route to `HomeAdministrator`
- `student` / `caregiver` → no admin claims → `HomeParticipant`

The synthesized claims drive only client-side routing/UI; the backend still scopes all data via FGA, so they cannot widen access. The derivation fails closed when the `/me` payload is missing or unreachable. Covered by `resolveUserClaims.test.js`.

## Avoid the re-login hang on emulator sign-out

On sign-out the dashboard re-initializes Firekit client-side. In emulator mode roar-firekit calls `connectAuthEmulator` during `init()`, which Firebase only permits before the Auth instance is used; the second call leaves Auth broken until a full page reload (the reason a manual refresh recovers it).

In emulator mode, `useSignOutMutation` now performs a full reload to `/signin` (`window.location.assign`) after clearing client state, instead of the client-side re-init + SPA redirect. This gives the next sign-in a clean Firebase/Firekit init — exactly what the manual refresh does. The production path (re-init + `router.push`) is unchanged.

## Verification

- Independent auth-focused review: approved, no blockers. Production paths confirmed unchanged and emulator-gated; routing traced correct for all five user tiers against the `/me` `userType` enum (`['student','educator','caregiver','admin']`); list-query enablement confirmed independent of `minimalAdminOrgs`.
- `resolveUserClaims.test.js` covers the mapping (admin/educator/student/caregiver × super/non-super, plus fail-closed on empty/missing `/me`).
- Issue 2's reload fix is reasoned from the `connectAuthEmulator` call-once constraint and the "refresh fixes it" symptom — worth a quick runtime confirmation in the local stack (log out → log back in as a different user).

## Scope

Local-dev/emulator only; both paths gated on `VITE_FIREBASE_EMULATOR_ENABLED`.

Resolves [roar-project-management/issues/1921](https://github.com/yeatmanlab/roar-project-management/issues/1921)
