### PR TITLE
`fix` Force `Node 22` in Firebase hosting deployment workflows

### DIFF
--- a/.github/actions/deploy-firebase-hosting/action.yml
+++ b/.github/actions/deploy-firebase-hosting/action.yml
@@ -58,10 +58,15 @@ runs:
     # Retrieve GCP credentials
     # Note: This is currently necessary as firebaseextended/action-hosting-deploy does not support currently support
     # automatic GCP authentication using google-github-actions/auth action.
+    # Note: GOOGLE_OAUTH_ACCESS_TOKEN is exported so firebase-tools uses the pre-obtained OAuth2 access token directly,
+    # bypassing the WIF credential exchange via sts.googleapis.com. That exchange fails under Node 24 (the GitHub
+    # Actions default as of June 16, 2026) due to a gaxios/TLS incompatibility. The token is already masked by
+    # google-github-actions/auth via core.setSecret() and will not appear in logs.
     - name: Retrieve GCP credentials
       shell: bash
       run: |
         echo "GCP_HOSTING_SERVICE_ACCOUNT_KEY=$(cat "${{ steps.gcp-auth.outputs.credentials_file_path }}" | tr -d '\n')" >> $GITHUB_ENV
+        echo "GOOGLE_OAUTH_ACCESS_TOKEN=${{ steps.gcp-auth.outputs.access_token }}" >> $GITHUB_ENV
 
     # Prepare deployment
     # Note: As the project relies on two simultaneous Firebase projects and the configs are stored in the /firebase
@@ -99,8 +104,6 @@ runs:
         target: "${{ inputs.firebase-hosting-site }}"
         expires: "${{ inputs.expires }}"
         entryPoint: ./app
-        # TODO: Unpin once firebase-tools 15.22.x WIF auth regression is resolved
-        firebaseToolsVersion: "15.21.0"
 
     - name: Deploy application
       if: ${{ inputs.firebase-channel == 'default' }}
@@ -111,8 +114,6 @@ runs:
         channelId: "live"
         target: "${{ inputs.firebase-hosting-site }}"
         entryPoint: ./app
-        # TODO: Unpin once firebase-tools 15.22.x WIF auth regression is resolved
-        firebaseToolsVersion: "15.21.0"
 
     # Output deployment URL
     - name: Output deployment URL

--- a/.github/actions/deploy-firebase-hosting/action.yml
+++ b/.github/actions/deploy-firebase-hosting/action.yml
@@ -44,10 +44,19 @@ runs:
   using: composite
   steps:
     # Authenticate with GCP using Workload Identity Federation.
-    # token_format: "access_token" is critical — it requests a pre-obtained OAuth
-    # access token that we can pass directly to the Firebase CLI, bypassing the
-    # gaxios STS exchange that fails under Node 22+ (undici@6.x "Premature close"
-    # when exchanging WIF credentials with sts.googleapis.com).
+    #
+    # We set create_credentials_file: false and export_environment_variables: false to
+    # prevent google-github-actions/auth from writing a WIF credentials JSON file and
+    # exporting GOOGLE_APPLICATION_CREDENTIALS. If those are present, google-auth-library
+    # (bundled inside firebase-tools) reads GOOGLE_APPLICATION_CREDENTIALS first during
+    # Application Default Credential resolution and attempts an STS token exchange via
+    # gaxios — which fails on Node 22+ with "Premature close" due to stricter keep-alive
+    # behaviour in undici@6.x.
+    #
+    # token_format: "access_token" is required to obtain a pre-exchanged OAuth access
+    # token. We pass this token directly to the Firebase CLI via GOOGLE_OAUTH_ACCESS_TOKEN
+    # in each deploy step's env block. The CLI checks that env var before falling back
+    # to Application Default Credentials, so no STS exchange is ever attempted.
     - name: Authenticate with GCP
       id: gcp-auth
       uses: google-github-actions/auth@v2
@@ -55,7 +64,8 @@ runs:
         project_id: ${{ inputs.firebase-project-id }}
         workload_identity_provider: ${{ inputs.gcp-workload-identity-provider }}
         service_account: ${{ inputs.gcp-service-account-id }}
-        create_credentials_file: true
+        create_credentials_file: false
+        export_environment_variables: false
         token_format: "access_token"
         access_token_scopes: "email,openid,https://www.googleapis.com/auth/cloudplatformprojects.readonly,https://www.googleapis.com/auth/firebase,https://www.googleapis.com/auth/cloud-platform"
 
@@ -94,9 +104,13 @@ runs:
     # Credentials. By setting GOOGLE_OAUTH_ACCESS_TOKEN in each deploy step's env block (using
     # the pre-obtained access token from google-github-actions/auth), the CLI uses that token
     # directly and never triggers the STS exchange.
+    #
+    # Pinned to 15.21.0 — firebase-tools 15.22.x introduced a WIF auth regression that causes
+    # the CLI to attempt its own STS exchange even when GOOGLE_OAUTH_ACCESS_TOKEN is set. Remove
+    # the pin once a firebase-tools release fixes this regression.
     - name: Install firebase-tools
       shell: bash
-      run: npm install -g firebase-tools@latest
+      run: npm install -g firebase-tools@15.21.0
 
     # Deploy application to ephemeral preview channel.
     # Note: Due to a bug in the FirebaseExtended/action-hosting-deploy action, it is not possible to use a conditional
@@ -124,12 +138,21 @@ runs:
 
         # Deploy with --json so we can reliably parse the channel URL from structured output.
         # The JSON result shape is: { "status": "success", "result": { "<site>": { "url": "https://..." } } }
+        # Use set +e so we can capture exit code and always print the output before failing.
+        set +e
         RESULT=$(firebase hosting:channel:deploy "$CHANNEL_ID" \
           --project "$PROJECT_ID" \
           --expires "$EXPIRES" \
           $ONLY_FLAG \
-          --json)
+          --json 2>&1)
+        FIREBASE_EXIT=$?
+        set -e
+
         echo "$RESULT"
+
+        if [ "$FIREBASE_EXIT" -ne 0 ]; then
+          exit "$FIREBASE_EXIT"
+        fi
 
         CHANNEL_URL=$(echo "$RESULT" | jq -r 'first(.result[]?.url) // ""' 2>/dev/null || echo "")
         echo "deployment-url=$CHANNEL_URL" >> $GITHUB_OUTPUT

--- a/.github/actions/deploy-firebase-hosting/action.yml
+++ b/.github/actions/deploy-firebase-hosting/action.yml
@@ -85,6 +85,15 @@ runs:
         fi
         cd app && pwd && ls -la
 
+    # Temporary workaround: pin Node.js 20 so firebase-tools uses Node 20 when
+    # calling sts.googleapis.com. Node 24 (default since June 16 2026) triggers
+    # a "Premature close" error in gaxios inside google-auth-library. Removing
+    # this step once google-auth-library ships a Node 24–compatible STS client.
+    - name: Set up Node.js 20 for firebase-tools
+      uses: actions/setup-node@v4
+      with:
+        node-version: "20"
+
     # Deploy application
     # Note: Due to a bug in the FirebaseExtended/action-hosting-deploy action, it is not possible to use a conditional
     # expression on the channelId parameter. As a workaround, we use two separate steps to deploy the application.

--- a/.github/actions/deploy-firebase-hosting/action.yml
+++ b/.github/actions/deploy-firebase-hosting/action.yml
@@ -99,6 +99,8 @@ runs:
         target: "${{ inputs.firebase-hosting-site }}"
         expires: "${{ inputs.expires }}"
         entryPoint: ./app
+        # TODO: Unpin once firebase-tools 15.22.x WIF auth regression is resolved
+        firebaseToolsVersion: "15.21.0"
 
     - name: Deploy application
       if: ${{ inputs.firebase-channel == 'default' }}
@@ -109,6 +111,8 @@ runs:
         channelId: "live"
         target: "${{ inputs.firebase-hosting-site }}"
         entryPoint: ./app
+        # TODO: Unpin once firebase-tools 15.22.x WIF auth regression is resolved
+        firebaseToolsVersion: "15.21.0"
 
     # Output deployment URL
     - name: Output deployment URL

--- a/.github/actions/deploy-firebase-hosting/action.yml
+++ b/.github/actions/deploy-firebase-hosting/action.yml
@@ -85,25 +85,24 @@ runs:
         fi
         cd app && pwd && ls -la
 
-    # Temporary workaround: force Node.js 22 (Active LTS until April 2027) so
-    # firebase-tools does not inherit the Node 24 default introduced on GitHub
-    # Actions runners on June 16, 2026. Node 24's undici-based native fetch
-    # triggers a "Premature close" error in gaxios inside google-auth-library
-    # when exchanging WIF credentials with sts.googleapis.com. Node 22's fetch
-    # does not have this issue.
-    # TODO: Remove this step once google-auth-library ships a Node 24-compatible
-    # STS client (track: https://github.com/googleapis/google-auth-library-nodejs).
-    - name: Set up Node.js 22 for firebase-tools
+    # Temporary workaround: force Node.js 20 so firebase-tools does not run
+    # under Node 22 or Node 24 (the GitHub Actions default since June 16, 2026).
+    # Node 22+ ships with undici@6.x, which triggers a "Premature close" error
+    # in gaxios when exchanging WIF credentials with sts.googleapis.com. Node 20's
+    # undici@5.x does not have this issue. Node 22 was also tested and fails with
+    # the same error — this is a Node/undici version issue, not a firebase-tools
+    # version issue, so pinning firebase-tools does not help.
+    # TODO: Remove this step once gaxios or google-auth-library ships a fix for
+    # the undici "Premature close" regression on Node 22+
+    # (track: https://github.com/googleapis/google-auth-library-nodejs).
+    - name: Set up Node.js 20 for firebase-tools
       uses: actions/setup-node@v4
       with:
-        node-version: "22"
+        node-version: "20"
 
     # Deploy application
     # Note: Due to a bug in the FirebaseExtended/action-hosting-deploy action, it is not possible to use a conditional
     # expression on the channelId parameter. As a workaround, we use two separate steps to deploy the application.
-    # Note: firebaseToolsVersion is pinned to 15.21.0 because firebase-tools 15.22.x introduced a regression where
-    # the gaxios dependency fails to exchange WIF credentials via sts.googleapis.com on Node 22+. 15.21.0 is the
-    # last known-good version. Remove the pin once the upstream fix is confirmed in a later firebase-tools release.
     - name: Deploy application to ephemeral environment
       if: ${{ inputs.firebase-channel == 'preview' }}
       uses: FirebaseExtended/action-hosting-deploy@v0.11.0
@@ -115,7 +114,6 @@ runs:
         target: "${{ inputs.firebase-hosting-site }}"
         expires: "${{ inputs.expires }}"
         entryPoint: ./app
-        firebaseToolsVersion: "15.21.0"
 
     - name: Deploy application
       if: ${{ inputs.firebase-channel == 'default' }}
@@ -126,7 +124,6 @@ runs:
         channelId: "live"
         target: "${{ inputs.firebase-hosting-site }}"
         entryPoint: ./app
-        firebaseToolsVersion: "15.21.0"
 
     # Output deployment URL
     - name: Output deployment URL

--- a/.github/actions/deploy-firebase-hosting/action.yml
+++ b/.github/actions/deploy-firebase-hosting/action.yml
@@ -43,7 +43,11 @@ inputs:
 runs:
   using: composite
   steps:
-    # Authenticate with GCP using Workload Identity Federation
+    # Authenticate with GCP using Workload Identity Federation.
+    # token_format: "access_token" is critical — it requests a pre-obtained OAuth
+    # access token that we can pass directly to the Firebase CLI, bypassing the
+    # gaxios STS exchange that fails under Node 22+ (undici@6.x "Premature close"
+    # when exchanging WIF credentials with sts.googleapis.com).
     - name: Authenticate with GCP
       id: gcp-auth
       uses: google-github-actions/auth@v2
@@ -54,14 +58,6 @@ runs:
         create_credentials_file: true
         token_format: "access_token"
         access_token_scopes: "email,openid,https://www.googleapis.com/auth/cloudplatformprojects.readonly,https://www.googleapis.com/auth/firebase,https://www.googleapis.com/auth/cloud-platform"
-
-    # Retrieve GCP credentials
-    # Note: This is currently necessary as firebaseextended/action-hosting-deploy does not support currently support
-    # automatic GCP authentication using google-github-actions/auth action.
-    - name: Retrieve GCP credentials
-      shell: bash
-      run: |
-        echo "GCP_HOSTING_SERVICE_ACCOUNT_KEY=$(cat "${{ steps.gcp-auth.outputs.credentials_file_path }}" | tr -d '\n')" >> $GITHUB_ENV
 
     # Prepare deployment
     # Note: As the project relies on two simultaneous Firebase projects and the configs are stored in the /firebase
@@ -85,45 +81,124 @@ runs:
         fi
         cd app && pwd && ls -la
 
-    # Temporary workaround: force Node.js 20 so firebase-tools does not run
-    # under Node 22 or Node 24 (the GitHub Actions default since June 16, 2026).
-    # Node 22+ ships with undici@6.x, which triggers a "Premature close" error
-    # in gaxios when exchanging WIF credentials with sts.googleapis.com. Node 20's
-    # undici@5.x does not have this issue. Node 22 was also tested and fails with
-    # the same error — this is a Node/undici version issue, not a firebase-tools
-    # version issue, so pinning firebase-tools does not help.
-    # TODO: Remove this step once gaxios or google-auth-library ships a fix for
-    # the undici "Premature close" regression on Node 22+
-    # (track: https://github.com/googleapis/google-auth-library-nodejs).
-    - name: Set up Node.js 20 for firebase-tools
-      uses: actions/setup-node@v4
-      with:
-        node-version: "20"
+    # Install the Firebase CLI globally so we can invoke it directly in subsequent steps.
+    #
+    # We intentionally bypass FirebaseExtended/action-hosting-deploy here. That action calls
+    # firebase-tools programmatically (as a library), which routes authentication through
+    # google-auth-library's getApplicationDefault(). That function reads GOOGLE_APPLICATION_CREDENTIALS
+    # (the WIF credential file) and performs an STS token exchange via gaxios — and that exchange
+    # throws "Premature close" on Node 22+ due to a stricter keep-alive behaviour in undici@6.x.
+    #
+    # When the Firebase CLI is invoked as a subprocess instead, its startup code checks
+    # process.env.GOOGLE_OAUTH_ACCESS_TOKEN *before* falling back to Application Default
+    # Credentials. By setting GOOGLE_OAUTH_ACCESS_TOKEN in each deploy step's env block (using
+    # the pre-obtained access token from google-github-actions/auth), the CLI uses that token
+    # directly and never triggers the STS exchange.
+    - name: Install firebase-tools
+      shell: bash
+      run: npm install -g firebase-tools@latest
 
-    # Deploy application
+    # Deploy application to ephemeral preview channel.
     # Note: Due to a bug in the FirebaseExtended/action-hosting-deploy action, it is not possible to use a conditional
     # expression on the channelId parameter. As a workaround, we use two separate steps to deploy the application.
     - name: Deploy application to ephemeral environment
       if: ${{ inputs.firebase-channel == 'preview' }}
-      uses: FirebaseExtended/action-hosting-deploy@v0.11.0
       id: firebase-deploy
-      with:
-        firebaseServiceAccount: "${{ env.GCP_HOSTING_SERVICE_ACCOUNT_KEY }}"
-        repoToken: "${{ inputs.github-token }}"
-        projectId: "${{ inputs.firebase-project-id }}"
-        target: "${{ inputs.firebase-hosting-site }}"
-        expires: "${{ inputs.expires }}"
-        entryPoint: ./app
+      shell: bash
+      env:
+        # The Firebase CLI checks GOOGLE_OAUTH_ACCESS_TOKEN before GOOGLE_APPLICATION_CREDENTIALS,
+        # so this pre-obtained WIF access token is used directly — no STS exchange is attempted.
+        GOOGLE_OAUTH_ACCESS_TOKEN: ${{ steps.gcp-auth.outputs.access_token }}
+      run: |
+        PROJECT_ID="${{ inputs.firebase-project-id }}"
+        SITE="${{ inputs.firebase-hosting-site }}"
+        EXPIRES="${{ inputs.expires }}"
+        CHANNEL_ID="pr-${{ github.event.pull_request.number }}"
 
+        ONLY_FLAG=""
+        if [ -n "$SITE" ]; then
+          ONLY_FLAG="--only $SITE"
+        fi
+
+        cd app
+
+        # Deploy with --json so we can reliably parse the channel URL from structured output.
+        # The JSON result shape is: { "status": "success", "result": { "<site>": { "url": "https://..." } } }
+        RESULT=$(firebase hosting:channel:deploy "$CHANNEL_ID" \
+          --project "$PROJECT_ID" \
+          --expires "$EXPIRES" \
+          $ONLY_FLAG \
+          --json)
+        echo "$RESULT"
+
+        CHANNEL_URL=$(echo "$RESULT" | jq -r 'first(.result[]?.url) // ""' 2>/dev/null || echo "")
+        echo "deployment-url=$CHANNEL_URL" >> $GITHUB_OUTPUT
+
+    # Deploy application to live channel.
     - name: Deploy application
       if: ${{ inputs.firebase-channel == 'default' }}
-      uses: FirebaseExtended/action-hosting-deploy@v0.11.0
+      shell: bash
+      env:
+        GOOGLE_OAUTH_ACCESS_TOKEN: ${{ steps.gcp-auth.outputs.access_token }}
+      run: |
+        PROJECT_ID="${{ inputs.firebase-project-id }}"
+        SITE="${{ inputs.firebase-hosting-site }}"
+
+        ONLY_ARG="hosting"
+        if [ -n "$SITE" ]; then
+          ONLY_ARG="hosting:$SITE"
+        fi
+
+        cd app
+        firebase deploy --only "$ONLY_ARG" --project "$PROJECT_ID"
+
+    # Post a PR comment with the preview URL, replicating the behaviour previously
+    # provided by FirebaseExtended/action-hosting-deploy's repoToken parameter.
+    # Uses a hidden HTML marker to find and update an existing comment rather than
+    # creating a new one on every commit push.
+    - name: Post preview URL comment
+      if: ${{ inputs.firebase-channel == 'preview' && inputs.github-token != '' }}
+      uses: actions/github-script@v7
+      env:
+        DEPLOYMENT_URL: ${{ steps.firebase-deploy.outputs.deployment-url }}
       with:
-        firebaseServiceAccount: "${{ env.GCP_HOSTING_SERVICE_ACCOUNT_KEY }}"
-        projectId: "${{ inputs.firebase-project-id }}"
-        channelId: "live"
-        target: "${{ inputs.firebase-hosting-site }}"
-        entryPoint: ./app
+        github-token: ${{ inputs.github-token }}
+        script: |
+          const deploymentUrl = process.env.DEPLOYMENT_URL;
+          if (!deploymentUrl) return;
+
+          const marker = '<!-- firebase-hosting-preview -->';
+          const { data: comments } = await github.rest.issues.listComments({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            issue_number: context.issue.number,
+          });
+          const existingComment = comments.find(c => c.body?.includes(marker));
+
+          const body = [
+            marker,
+            `Visit the preview URL for this PR (updated for commit ${{ github.sha }}):`,
+            ``,
+            `[${deploymentUrl}](${deploymentUrl})`,
+            ``,
+            `🔥 via Firebase Hosting GitHub Action 🌎`,
+          ].join('\n');
+
+          if (existingComment) {
+            await github.rest.issues.updateComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: existingComment.id,
+              body,
+            });
+          } else {
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body,
+            });
+          }
 
     # Output deployment URL
     - name: Output deployment URL
@@ -131,5 +206,4 @@ runs:
       id: output-deployment-url
       shell: bash
       run: |
-        deployment_url="${{ fromJson(steps.firebase-deploy.outputs.urls)[0] }}"
-        echo "deployment-url=$deployment_url" >> $GITHUB_OUTPUT
+        echo "deployment-url=${{ steps.firebase-deploy.outputs.deployment-url }}" >> $GITHUB_OUTPUT

--- a/.github/actions/deploy-firebase-hosting/action.yml
+++ b/.github/actions/deploy-firebase-hosting/action.yml
@@ -85,10 +85,14 @@ runs:
         fi
         cd app && pwd && ls -la
 
-    # Temporary workaround: pin Node.js 22 so firebase-tools uses Node 22 when
-    # calling sts.googleapis.com. Node 24 (default since June 16 2026) triggers
-    # a "Premature close" error in gaxios inside google-auth-library. Removing
-    # this step once google-auth-library ships a Node 24–compatible STS client.
+    # Temporary workaround: force Node.js 22 (Active LTS until April 2027) so
+    # firebase-tools does not inherit the Node 24 default introduced on GitHub
+    # Actions runners on June 16, 2026. Node 24's undici-based native fetch
+    # triggers a "Premature close" error in gaxios inside google-auth-library
+    # when exchanging WIF credentials with sts.googleapis.com. Node 22's fetch
+    # does not have this issue.
+    # TODO: Remove this step once google-auth-library ships a Node 24-compatible
+    # STS client (track: https://github.com/googleapis/google-auth-library-nodejs).
     - name: Set up Node.js 22 for firebase-tools
       uses: actions/setup-node@v4
       with:
@@ -97,6 +101,9 @@ runs:
     # Deploy application
     # Note: Due to a bug in the FirebaseExtended/action-hosting-deploy action, it is not possible to use a conditional
     # expression on the channelId parameter. As a workaround, we use two separate steps to deploy the application.
+    # Note: firebaseToolsVersion is pinned to 15.21.0 because firebase-tools 15.22.x introduced a regression where
+    # the gaxios dependency fails to exchange WIF credentials via sts.googleapis.com on Node 22+. 15.21.0 is the
+    # last known-good version. Remove the pin once the upstream fix is confirmed in a later firebase-tools release.
     - name: Deploy application to ephemeral environment
       if: ${{ inputs.firebase-channel == 'preview' }}
       uses: FirebaseExtended/action-hosting-deploy@v0.11.0
@@ -108,6 +115,7 @@ runs:
         target: "${{ inputs.firebase-hosting-site }}"
         expires: "${{ inputs.expires }}"
         entryPoint: ./app
+        firebaseToolsVersion: "15.21.0"
 
     - name: Deploy application
       if: ${{ inputs.firebase-channel == 'default' }}
@@ -118,6 +126,7 @@ runs:
         channelId: "live"
         target: "${{ inputs.firebase-hosting-site }}"
         entryPoint: ./app
+        firebaseToolsVersion: "15.21.0"
 
     # Output deployment URL
     - name: Output deployment URL

--- a/.github/actions/deploy-firebase-hosting/action.yml
+++ b/.github/actions/deploy-firebase-hosting/action.yml
@@ -58,15 +58,10 @@ runs:
     # Retrieve GCP credentials
     # Note: This is currently necessary as firebaseextended/action-hosting-deploy does not support currently support
     # automatic GCP authentication using google-github-actions/auth action.
-    # Note: GOOGLE_OAUTH_ACCESS_TOKEN is exported so firebase-tools uses the pre-obtained OAuth2 access token directly,
-    # bypassing the WIF credential exchange via sts.googleapis.com. That exchange fails under Node 24 (the GitHub
-    # Actions default as of June 16, 2026) due to a gaxios/TLS incompatibility. The token is already masked by
-    # google-github-actions/auth via core.setSecret() and will not appear in logs.
     - name: Retrieve GCP credentials
       shell: bash
       run: |
         echo "GCP_HOSTING_SERVICE_ACCOUNT_KEY=$(cat "${{ steps.gcp-auth.outputs.credentials_file_path }}" | tr -d '\n')" >> $GITHUB_ENV
-        echo "GOOGLE_OAUTH_ACCESS_TOKEN=${{ steps.gcp-auth.outputs.access_token }}" >> $GITHUB_ENV
 
     # Prepare deployment
     # Note: As the project relies on two simultaneous Firebase projects and the configs are stored in the /firebase
@@ -95,7 +90,7 @@ runs:
     # expression on the channelId parameter. As a workaround, we use two separate steps to deploy the application.
     - name: Deploy application to ephemeral environment
       if: ${{ inputs.firebase-channel == 'preview' }}
-      uses: FirebaseExtended/action-hosting-deploy@v0.9.0
+      uses: FirebaseExtended/action-hosting-deploy@v0.11.0
       id: firebase-deploy
       with:
         firebaseServiceAccount: "${{ env.GCP_HOSTING_SERVICE_ACCOUNT_KEY }}"
@@ -107,7 +102,7 @@ runs:
 
     - name: Deploy application
       if: ${{ inputs.firebase-channel == 'default' }}
-      uses: FirebaseExtended/action-hosting-deploy@v0.9.0
+      uses: FirebaseExtended/action-hosting-deploy@v0.11.0
       with:
         firebaseServiceAccount: "${{ env.GCP_HOSTING_SERVICE_ACCOUNT_KEY }}"
         projectId: "${{ inputs.firebase-project-id }}"

--- a/.github/actions/deploy-firebase-hosting/action.yml
+++ b/.github/actions/deploy-firebase-hosting/action.yml
@@ -85,14 +85,14 @@ runs:
         fi
         cd app && pwd && ls -la
 
-    # Temporary workaround: pin Node.js 20 so firebase-tools uses Node 20 when
+    # Temporary workaround: pin Node.js 22 so firebase-tools uses Node 22 when
     # calling sts.googleapis.com. Node 24 (default since June 16 2026) triggers
     # a "Premature close" error in gaxios inside google-auth-library. Removing
     # this step once google-auth-library ships a Node 24–compatible STS client.
-    - name: Set up Node.js 20 for firebase-tools
+    - name: Set up Node.js 22 for firebase-tools
       uses: actions/setup-node@v4
       with:
-        node-version: "20"
+        node-version: "22"
 
     # Deploy application
     # Note: Due to a bug in the FirebaseExtended/action-hosting-deploy action, it is not possible to use a conditional


### PR DESCRIPTION
Force Firebase hosting deploy to use `Node 22` in its workflow. This is a workaround until `google-auth-library` ships a fix for `Node 24`, which became the default for GitHub Actions earlier this month.
