### PR TITLE
Fix Firebase Hosting deploy auth failure caused by Node 24.17.0 bug

### DIFF
--- a/.github/actions/deploy-firebase-hosting/action.yml
+++ b/.github/actions/deploy-firebase-hosting/action.yml
@@ -43,10 +43,18 @@ inputs:
 runs:
   using: composite
   steps:
+    # Ensure firebase-tools runs under the project's Node version instead of
+    # the runner's system default (which may lag behind and hit bugs like the
+    # keep-alive socket issue in Node 24.17.0 — nodejs/node#63989).
+    - name: Setup Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version-file: '.nvmrc'
+
     # Authenticate with GCP using Workload Identity Federation
     - name: Authenticate with GCP
       id: gcp-auth
-      uses: google-github-actions/auth@v2
+      uses: google-github-actions/auth@v3
       with:
         project_id: ${{ inputs.firebase-project-id }}
         workload_identity_provider: ${{ inputs.gcp-workload-identity-provider }}
@@ -90,7 +98,7 @@ runs:
     # expression on the channelId parameter. As a workaround, we use two separate steps to deploy the application.
     - name: Deploy application to ephemeral environment
       if: ${{ inputs.firebase-channel == 'preview' }}
-      uses: FirebaseExtended/action-hosting-deploy@v0.9.0
+      uses: FirebaseExtended/action-hosting-deploy@v0.11.0
       id: firebase-deploy
       with:
         firebaseServiceAccount: "${{ env.GCP_HOSTING_SERVICE_ACCOUNT_KEY }}"
@@ -102,7 +110,7 @@ runs:
 
     - name: Deploy application
       if: ${{ inputs.firebase-channel == 'default' }}
-      uses: FirebaseExtended/action-hosting-deploy@v0.9.0
+      uses: FirebaseExtended/action-hosting-deploy@v0.11.0
       with:
         firebaseServiceAccount: "${{ env.GCP_HOSTING_SERVICE_ACCOUNT_KEY }}"
         projectId: "${{ inputs.firebase-project-id }}"

--- a/.github/actions/deploy-firestore-config/action.yml
+++ b/.github/actions/deploy-firestore-config/action.yml
@@ -34,7 +34,7 @@ runs:
     # Admin Project
     # Authenticate with GCP using Workload Identity Federation
     - name: Authenticate with GCP
-      uses: google-github-actions/auth@v2
+      uses: google-github-actions/auth@v3
       with:
         project_id: ${{ inputs.firebase-project-id }}
         workload_identity_provider: ${{ inputs.gcp-workload-identity-provider }}

--- a/.nvmrc
+++ b/.nvmrc
@@ -1,1 +1,1 @@
-lts/krypton
+24.18.0


### PR DESCRIPTION
## Summary

This PR fixes the Firebase Hosting deploy authentication failure that broke all preview and production deploys.

### Root cause

Node 24.17.0 (the current GitHub Actions runner default) introduced a keep-alive socket bug ([nodejs/node#63989](https://github.com/nodejs/node/issues/63989)) that causes `ERR_STREAM_PREMATURE_CLOSE` errors during gzip-encoded, chunked HTTPS responses. This broke the STS token exchange that `firebase-tools` performs via `google-auth-library` when authenticating with Workload Identity Federation, producing the `"Failed to authenticate, have you run firebase login?"` error.

### Fix
To resolve the issue, this PR adds a `setup-node` step in the deploy-firebase-hosting action pinned to Node 24.18.0, which includes the upstream fix ([nodejs/node#64004](https://github.com/nodejs/node/pull/64004)). Additionally, this PR also bumps `google-github-actions/auth` from v2 to v3 and `FirebaseExtended/action-hosting-deploy` from v0.9.0 to v0.11.0



Resolves https://github.com/yeatmanlab/roar-project-management/issues/1969