### PR TITLE
`fix` Firebase.json formatting for multichoice and survey

### DIFF
--- a/apps/assessments/roar-multichoice/firebase.json
+++ b/apps/assessments/roar-multichoice/firebase.json
@@ -1,98 +1,48 @@
 {
-  "hosting": [
-    {
-      "public": "dist",
-      "target": "production",
-      "ignore": ["firebase.json", "**/.*", "**/node_modules/**"],
-      "rewrites": [
-        {
-          "source": "**",
-          "destination": "/index.html"
-        }
-      ],
-      "headers": [
-        {
-          "source": "**",
-          "headers": [
-            {
-              "key": "Report-To",
-              "value": "{\"group\":\"csp-endpoint\",\"max_age\":10886400,\"endpoints\":[{\"url\":\"https://o4505913837420544.ingest.us.sentry.io/api/4505915663712256/security/?sentry_key=e569875f465207e7bfdd9baaf170501a&sentry_environment=production\"}],\"include_subdomains\":true}"
-            },
-            {
-              "key": "Content-Security-Policy",
-              "value": "default-src 'self'; report-uri https://o4505913837420544.ingest.us.sentry.io/api/4505915663712256/security/?sentry_key=e569875f465207e7bfdd9baaf170501a&sentry_environment=production; report-to csp-endpoint"
-            },
-            {
-              "key": "Cross-Origin-Opener-Policy",
-              "value": "same-origin-allow-popups"
-            },
-            {
-              "key": "X-Content-Type-Options",
-              "value": "nosniff"
-            },
-            {
-              "key": "Strict-Transport-Security",
-              "value": "max-age=63072000; includeSubDomains; preload"
-            }
-          ]
-        },
-        {
-          "source": "**/*",
-          "headers": [
-            {
-              "key": "Feature-Policy",
-              "value": "autoplay=*"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "public": "dist",
-      "target": "staging",
-      "ignore": ["firebase.json", "**/.*", "**/node_modules/**"],
-      "rewrites": [
-        {
-          "source": "**",
-          "destination": "/index.html"
-        }
-      ],
-      "headers": [
-        {
-          "source": "**",
-          "headers": [
-            {
-              "key": "Report-To",
-              "value": "{\"group\":\"csp-endpoint\",\"max_age\":10886400,\"endpoints\":[{\"url\":\"https://o4505913837420544.ingest.us.sentry.io/api/4505915663712256/security/?sentry_key=e569875f465207e7bfdd9baaf170501a&sentry_environment=staging\"}],\"include_subdomains\":true}"
-            },
-            {
-              "key": "Content-Security-Policy",
-              "value": "default-src 'self'; report-uri https://o4505913837420544.ingest.us.sentry.io/api/4505915663712256/security/?sentry_key=e569875f465207e7bfdd9baaf170501a&sentry_environment=staging; report-to csp-endpoint"
-            },
-            {
-              "key": "Cross-Origin-Opener-Policy",
-              "value": "same-origin-allow-popups"
-            },
-            {
-              "key": "X-Content-Type-Options",
-              "value": "nosniff"
-            },
-            {
-              "key": "Strict-Transport-Security",
-              "value": "max-age=63072000; includeSubDomains; preload"
-            }
-          ]
-        },
-        {
-          "source": "**/*",
-          "headers": [
-            {
-              "key": "Feature-Policy",
-              "value": "autoplay=*"
-            }
-          ]
-        }
-      ]
-    }
-  ]
+  "hosting": {
+    "public": "dist",
+    "ignore": ["firebase.json", "**/.*", "**/node_modules/**"],
+    "rewrites": [
+      {
+        "source": "**",
+        "destination": "/index.html"
+      }
+    ],
+    "headers": [
+      {
+        "source": "**",
+        "headers": [
+          {
+            "key": "Report-To",
+            "value": "{\"group\":\"csp-endpoint\",\"max_age\":10886400,\"endpoints\":[{\"url\":\"https://o4505913837420544.ingest.us.sentry.io/api/4505915663712256/security/?sentry_key=e569875f465207e7bfdd9baaf170501a&sentry_environment=production\"}],\"include_subdomains\":true}"
+          },
+          {
+            "key": "Content-Security-Policy",
+            "value": "default-src 'self'; report-uri https://o4505913837420544.ingest.us.sentry.io/api/4505915663712256/security/?sentry_key=e569875f465207e7bfdd9baaf170501a&sentry_environment=production; report-to csp-endpoint"
+          },
+          {
+            "key": "Cross-Origin-Opener-Policy",
+            "value": "same-origin-allow-popups"
+          },
+          {
+            "key": "X-Content-Type-Options",
+            "value": "nosniff"
+          },
+          {
+            "key": "Strict-Transport-Security",
+            "value": "max-age=63072000; includeSubDomains; preload"
+          }
+        ]
+      },
+      {
+        "source": "**/*",
+        "headers": [
+          {
+            "key": "Feature-Policy",
+            "value": "autoplay=*"
+          }
+        ]
+      }
+    ]
+  }
 }

--- a/apps/assessments/roar-survey/firebase.json
+++ b/apps/assessments/roar-survey/firebase.json
@@ -1,44 +1,21 @@
 {
-  "hosting": [
-    {
-      "target": "production",
-      "public": "dist",
-      "ignore": ["firebase.json", "**/.*", "**/node_modules/**"],
-      "rewrites": [{ "source": "**", "destination": "/index.html" }],
-      "headers": [
-        {
-          "source": "**",
-          "headers": [
-            { "key": "Cross-Origin-Opener-Policy", "value": "same-origin-allow-popups" },
-            { "key": "X-Content-Type-Options", "value": "nosniff" },
-            {
-              "key": "Strict-Transport-Security",
-              "value": "max-age=63072000; includeSubDomains; preload"
-            }
-          ]
-        },
-        { "source": "**/*", "headers": [{ "key": "Feature-Policy", "value": "autoplay=*" }] }
-      ]
-    },
-    {
-      "target": "staging",
-      "public": "dist",
-      "ignore": ["firebase.json", "**/.*", "**/node_modules/**"],
-      "rewrites": [{ "source": "**", "destination": "/index.html" }],
-      "headers": [
-        {
-          "source": "**",
-          "headers": [
-            { "key": "Cross-Origin-Opener-Policy", "value": "same-origin-allow-popups" },
-            { "key": "X-Content-Type-Options", "value": "nosniff" },
-            {
-              "key": "Strict-Transport-Security",
-              "value": "max-age=63072000; includeSubDomains; preload"
-            }
-          ]
-        },
-        { "source": "**/*", "headers": [{ "key": "Feature-Policy", "value": "autoplay=*" }] }
-      ]
-    }
-  ]
+  "hosting": {
+    "public": "dist",
+    "ignore": ["firebase.json", "**/.*", "**/node_modules/**"],
+    "rewrites": [{ "source": "**", "destination": "/index.html" }],
+    "headers": [
+      {
+        "source": "**",
+        "headers": [
+          { "key": "Cross-Origin-Opener-Policy", "value": "same-origin-allow-popups" },
+          { "key": "X-Content-Type-Options", "value": "nosniff" },
+          {
+            "key": "Strict-Transport-Security",
+            "value": "max-age=63072000; includeSubDomains; preload"
+          }
+        ]
+      },
+      { "source": "**/*", "headers": [{ "key": "Feature-Policy", "value": "autoplay=*" }] }
+    ]
+  }
 }


### PR DESCRIPTION
Fix Firebase.json formatting for `roar-multichoice` and `roar-survey` which prevented these assessmets from being deployed to their (dummy) staging targets.

The top-level `hosting` key was erroneously set as an array, which caused parsing errors during deployment.
