### PR TITLE
Score report: wire distribution facets to the facets endpoint

### DIFF
--- a/apps/dashboard/src/components/reports/DistributionChartFacet.vue
+++ b/apps/dashboard/src/components/reports/DistributionChartFacet.vue
@@ -54,9 +54,13 @@ const props = defineProps({
       return { name: 'Grade', key: 'grade' };
     },
   },
-  runs: {
-    type: Array,
-    required: true,
+  facets: {
+    // Per-task facet aggregation from `getScoreFacets` (scoreBinsByGrade /
+    // scoreBinsBySchool). Each bin is `{ binStart, binEnd, count }`, already
+    // computed server-side. Null while the query is loading.
+    type: Object,
+    required: false,
+    default: null,
   },
   minGradeByRuns: {
     type: Number,
@@ -64,47 +68,11 @@ const props = defineProps({
   },
 });
 
-const makeRunsFromBins = ({ binsObj, facet, scoreKey }) => {
-  const rows = [];
-  if (!binsObj || typeof binsObj !== 'object') return rows;
-
-  for (const [binLabel, payload] of Object.entries(binsObj)) {
-    const [a, b] = String(binLabel).split('-').map(Number);
-    const value = Number.isFinite(a) && Number.isFinite(b) ? (a + b) / 2 : NaN;
-    if (!Number.isFinite(value)) continue;
-
-    if (facet === 'grade') {
-      const grades = payload?.grades ?? {};
-      for (const [gradeKey, countRaw] of Object.entries(grades)) {
-        const count = Number(countRaw) || 0;
-        for (let i = 0; i < count; i++) {
-          rows.push({
-            grade: String(gradeKey),
-            scores: { [scoreKey]: value },
-          });
-        }
-      }
-    } else {
-      const schools = payload?.schools ?? {};
-      for (const school of Object.values(schools)) {
-        const name = school?.name ?? 'Unknown school';
-        const count = Number(school?.count) || 0;
-        for (let i = 0; i < count; i++) {
-          rows.push({
-            user: { schoolName: name },
-            scores: { [scoreKey]: value },
-          });
-        }
-      }
-    }
-  }
-  return rows;
-};
+const { data: tasksDictionary, isLoading: isLoadingTasksDictionary } = useTasksDictionaryQuery();
 
 // Normalize facet mode to 'grade' | 'school'
 const facetKind = computed(() => (props.facetMode?.name === 'Grade' ? 'grade' : 'school'));
-
-const { data: tasksDictionary, isLoading: isLoadingTasksDictionary } = useTasksDictionaryQuery();
+const isGradeFacet = computed(() => props.facetMode.key === 'grade');
 
 const scoreMode = ref({ name: 'Raw Score', key: 'rawScore' });
 const scoreModes = [
@@ -112,72 +80,55 @@ const scoreModes = [
   { name: 'Percentile', key: 'stdPercentile' },
 ];
 
-const getBinSize = (scoreMode, taskId) => {
-  if (scoreMode === 'Percentile') {
-    return 10;
-  } else if (scoreMode === 'Raw Score') {
-    if (taskId === 'pa') return 5;
-    else if (taskId === 'sre') return 10;
-    else if (taskId === 'swr') return 50;
-  }
-  return 10;
-};
+// Leading-zero trim matches the prior client behavior (e.g. "01" → "1").
+const trimGrade = (grade) => String(grade ?? '').replace(/^0+(?=\D|\d)/, '');
+// Kindergarten / "0" sort as grade 0; everything else is its numeric grade.
+const gradeNumeric = (grade) => (grade === '0' || grade === 'Kindergarten' ? 0 : Number(grade));
 
-const getRangeLow = (scoreMode, taskId) => {
-  if (scoreMode === 'Percentile') {
-    return 0;
-  } else if (scoreMode === 'Raw Score') {
-    if (taskId === 'pa') return 0;
-    else if (taskId === 'sre') return 0;
-    else if (taskId === 'swr') return 100;
-  }
-  return 0;
-};
+const facetEntries = computed(() => {
+  if (!props.facets) return [];
+  return facetKind.value === 'grade' ? (props.facets.scoreBinsByGrade ?? []) : (props.facets.scoreBinsBySchool ?? []);
+});
 
-const getRangeHigh = (scoreMode, taskId) => {
-  if (scoreMode === 'Percentile') {
-    return 100;
-  } else if (scoreMode === 'Raw Score') {
-    if (taskId === 'pa') return 57;
-    else if (taskId === 'sre') return 130;
-    else if (taskId === 'swr') return 900;
-  }
-  return 100;
-};
-
-// With Percentile View, only display runs under grade 6
-const computedRuns = computed(() => {
-  if (props.orgType === 'district') {
-    const facet = facetKind.value;
-    const modeKey = scoreMode.value.name === 'Percentile' ? 'percentile' : 'raw';
-    const scoreKey = scoreMode.value.name === 'Percentile' ? 'stdPercentile' : 'rawScore';
-
-    const levels = ['above', 'some', 'below'];
-    const rows = [];
-
-    // if backend provided keyed bins (preferred)
-    const hasKeyed = levels.some((k) => props?.runs?.[k]?.[modeKey]);
-    if (hasKeyed) {
-      for (const levelKey of levels) {
-        const binsObj = props?.runs?.[levelKey]?.[modeKey];
-        if (binsObj) {
-          rows.push(...makeRunsFromBins({ binsObj, facet, scoreKey, levelKey }));
-        }
+// Flatten the per-facet pre-binned distributions into Vega rows. The backend bins
+// (`{ binStart, binEnd, count }`) are consumed directly via `bin: 'binned'` — no
+// client-side re-binning, so the histogram exactly reflects the server aggregation.
+const binValues = computed(() => {
+  const scoreKey = scoreMode.value.key === 'stdPercentile' ? 'percentile' : 'rawScore';
+  const rows = [];
+  for (const entry of facetEntries.value) {
+    if (facetKind.value === 'grade') {
+      const gradeNum = gradeNumeric(entry.grade);
+      // Percentile view is only meaningful for early grades — preserve the prior <6 filter.
+      if (scoreMode.value.key === 'stdPercentile' && gradeNum >= 6) continue;
+      for (const bin of entry[scoreKey] ?? []) {
+        rows.push({
+          facet: trimGrade(entry.grade),
+          gradeNumeric: gradeNum,
+          binStart: bin.binStart,
+          binEnd: bin.binEnd,
+          count: bin.count,
+        });
       }
     } else {
-      // fallback to flat shape: props.runs.percentile / props.runs.raw (no color by level)
-      rows.push(...makeRunsFromBins({ binsObj: props?.runs?.[modeKey], facet, scoreKey }));
+      const name = entry.schoolName ?? 'Unknown school';
+      for (const bin of entry[scoreKey] ?? []) {
+        rows.push({ facet: name, gradeNumeric: null, binStart: bin.binStart, binEnd: bin.binEnd, count: bin.count });
+      }
     }
-
-    return rows;
   }
-
-  // non-district (original)
-  if (scoreMode.value.name === 'Percentile' && props.facetMode.name === 'Grade') {
-    return props.runs.filter((run) => Number(run.grade) < 6);
-  }
-  return props.runs;
+  return rows;
 });
+
+// Percentile is a fixed 0–100 axis; raw-score axes fit the server's bin range.
+const xDomain = computed(() => {
+  if (scoreMode.value.key === 'stdPercentile') return [0, 100];
+  const starts = binValues.value.map((b) => b.binStart);
+  const ends = binValues.value.map((b) => b.binEnd);
+  if (!starts.length) return [0, 100];
+  return [Math.min(...starts), Math.max(...ends)];
+});
+
 const distributionChartFacet = computed(() => {
   if (isLoadingTasksDictionary.value) return {};
   return {
@@ -190,22 +141,14 @@ const distributionChartFacet = computed(() => {
       dx: 70,
     },
     data: {
-      values: computedRuns.value,
+      values: binValues.value,
     },
-    transform: isGradeFacet.value
-      ? [
-          {
-            calculate: "datum.grade === '0' || datum.grade === 'Kindergarten' ? 0 : toNumber(datum.grade)",
-            as: 'gradeNumeric',
-          },
-        ]
-      : [],
     mark: 'bar',
     height: 50,
     width: 360,
     encoding: {
       row: {
-        field: isGradeFacet.value ? 'gradeNumeric' : `user.${props.facetMode.key}`,
+        field: isGradeFacet.value ? 'gradeNumeric' : 'facet',
         type: isGradeFacet.value ? 'quantitative' : 'ordinal',
         title: '',
         header: {
@@ -236,12 +179,11 @@ const distributionChartFacet = computed(() => {
       },
 
       x: {
-        field: `scores.${scoreMode.value.key}`,
+        field: 'binStart',
+        bin: 'binned',
+        type: 'quantitative',
         title: scoreMode.value.name,
-        bin: {
-          step: getBinSize(scoreMode.value.name, props.taskId),
-          extent: [getRangeLow(scoreMode.value.name, props.taskId), getRangeHigh(scoreMode.value.name, props.taskId)],
-        },
+        scale: { domain: xDomain.value },
         sort: 'ascending',
         axis: {
           labelAngle: 0,
@@ -250,10 +192,11 @@ const distributionChartFacet = computed(() => {
           labelFontSize: 14,
         },
       },
+      x2: { field: 'binEnd' },
 
       y: {
+        field: 'count',
         type: 'quantitative',
-        aggregate: 'count',
         title: 'Count',
         sort: 'ascending',
         axis: {
@@ -268,14 +211,10 @@ const distributionChartFacet = computed(() => {
         },
       },
       tooltip: [
-        {
-          field: `scores.${scoreMode.value.key}`,
-          title: `${scoreMode.value.name}`,
-          type: 'quantitative',
-          format: `.0f`,
-        },
-        props.facetMode.name === 'Grade' ? { field: 'grade', title: 'Student Grade' } : {},
-        { aggregate: 'count', title: 'Student Count' },
+        { field: 'binStart', title: `${scoreMode.value.name} (min)`, type: 'quantitative', format: '.0f' },
+        { field: 'binEnd', title: `${scoreMode.value.name} (max)`, type: 'quantitative', format: '.0f' },
+        isGradeFacet.value ? { field: 'gradeNumeric', title: 'Student Grade' } : { field: 'facet', title: 'School' },
+        { field: 'count', title: 'Student Count', type: 'quantitative' },
       ],
     },
     resolve: {
@@ -297,28 +236,10 @@ const draw = async () => {
   await embed(`#roar-distribution-chart-${props.taskId}`, chartSpecDist);
 };
 
-const isGradeFacet = computed(() => props.facetMode.key === 'grade');
-
-// Watch for changes to the computed chart specification (includes tasksDictionary loading)
+// Redraw whenever the computed chart spec changes (covers facets, facetMode,
+// scoreMode, and tasksDictionary loading).
 watch(
   () => distributionChartFacet.value,
-  () => {
-    draw();
-  },
-  { deep: true },
-);
-
-// Update Distribution Graph on external facetMode change
-watch(
-  () => props.facetMode,
-  () => {
-    draw();
-  },
-);
-
-// Update Distribution Graph on computedRuns recalculation
-watch(
-  () => computedRuns,
   () => {
     draw();
   },

--- a/apps/dashboard/src/components/reports/DistributionChartOverview.vue
+++ b/apps/dashboard/src/components/reports/DistributionChartOverview.vue
@@ -21,6 +21,15 @@ const props = defineProps({
     type: Array,
     required: false,
   },
+  // Backend-aggregated support-level counts from the score-overview endpoint,
+  // shaped `{ needsExtraSupport: { count }, developingSkill: { count }, achievedSkill: { count } }`.
+  // When provided, it is the chart's data source and `runs` is ignored — this is
+  // the server-computed replacement for the client-side `runs` aggregation.
+  supportLevelCounts: {
+    type: Object,
+    required: false,
+    default: undefined,
+  },
   orgType: {
     type: String,
     required: true,
@@ -47,13 +56,30 @@ const props = defineProps({
 
 const { data: tasksDictionary, isLoading: isLoadingTasksDictionary } = useTasksDictionaryQuery();
 
+// Maps the score-overview endpoint's support-level keys to the chart's display
+// categories (which match the color-scale domain below).
+const BACKEND_SUPPORT_LEVEL_LABELS = {
+  needsExtraSupport: 'Needs Extra Support',
+  developingSkill: 'Developing Skill',
+  achievedSkill: 'Achieved Skill',
+};
+
 const supportLevelsOverview = computed(() => {
+  // Preferred path: server-aggregated counts from the score-overview endpoint.
+  if (props.supportLevelCounts) {
+    return Object.entries(BACKEND_SUPPORT_LEVEL_LABELS).map(([key, category]) => ({
+      category,
+      value: props.supportLevelCounts[key]?.count ?? 0,
+    }));
+  }
+  // Legacy Firestore paths (district aggregate object / per-run array). Guard
+  // first so an absent `runs` can't throw in the district branch below.
+  if (!props.runs) return [];
   if (props.orgType === 'district') {
     return Object.entries(props.runs)
       .filter(([support_level]) => MATCHING_SUPPORT_LEVELS[support_level] != undefined)
       .map(([support_level, total]) => ({ category: MATCHING_SUPPORT_LEVELS[support_level], value: total.total }));
   }
-  if (!props.runs) return [];
   let values = {};
   for (const { scores } of props.runs) {
     const support_level = scores.support_level;
@@ -129,7 +155,7 @@ const draw = async () => {
 };
 
 watch(
-  [() => overviewDistributionChart.value, () => props.runs, () => props.orgType],
+  [() => overviewDistributionChart.value, () => props.runs, () => props.supportLevelCounts, () => props.orgType],
   () => {
     if (props.taskId !== 'letter') {
       draw();

--- a/apps/dashboard/src/components/reports/DistributionChartSupport.vue
+++ b/apps/dashboard/src/components/reports/DistributionChartSupport.vue
@@ -43,9 +43,12 @@ const props = defineProps({
     type: String,
     required: true,
   },
-  runs: {
-    type: Array,
-    required: true,
+  facets: {
+    // Per-task facet aggregation from `getScoreFacets` (supportLevelByGrade /
+    // supportLevelBySchool). Null while the query is loading.
+    type: Object,
+    required: false,
+    default: null,
   },
   facetMode: {
     type: Object,
@@ -56,95 +59,30 @@ const props = defineProps({
   },
 });
 
-const districtGradeSupportBreakdown = computed(() => {
-  // For district-level aggregation: { above/some/below: { grades: { "1": n, ... } } }
-  if (props.orgType === 'district') {
-    const supportLevelIndexMap = { below: 0, some: 1, above: 2 }; // matches chart order
-    const gradeMap = new Map(); // key = grade
+// Leading-zero trim matches the prior client behavior (e.g. "01" → "1").
+const trimGrade = (grade) => String(grade ?? '').replace(/^0+(?=\D|\d)/, '');
 
-    ['below', 'some', 'above'].forEach((level) => {
-      const grades = props?.runs?.[level]?.grades ?? {};
-      Object.entries(grades).forEach(([grade, count]) => {
-        // Trim grades of leading zeros
-        const trimmedGrade = grade.replace(/^0+(?=\D|\d)/, '');
-        if (!gradeMap.has(trimmedGrade)) {
-          gradeMap.set(trimmedGrade, { category: trimmedGrade, support_levels: [0, 0, 0], totalStudents: 0 });
-        }
-        const row = gradeMap.get(trimmedGrade);
-        row.support_levels[supportLevelIndexMap[level]] += count;
-        row.totalStudents += count;
-      });
-    });
-
-    return Array.from(gradeMap.values());
-  }
-
-  // For school- or class-level aggregation
-  const gradeCounts = [];
-  for (const run of props.runs) {
-    const rawGrade = run?.user?.grade;
-    // Trim grades of leading zeros
-    const trimmedGrade = rawGrade.replace(/^0+(?=\D|\d)/, '');
-    let gradeCounter = gradeCounts.find((g) => g.category === trimmedGrade);
-    if (!gradeCounter) {
-      gradeCounter = { category: trimmedGrade, support_levels: [0, 0, 0], totalStudents: 0 };
-      gradeCounts.push(gradeCounter);
-    }
-
-    const supportLevel = run?.scores?.support_level;
-    if (supportLevel === 'Needs Extra Support') gradeCounter.support_levels[0]++;
-    else if (supportLevel === 'Developing Skill') gradeCounter.support_levels[1]++;
-    else if (supportLevel === 'Achieved Skill') gradeCounter.support_levels[2]++;
-    else continue; // skip null or undefined support levels
-
-    gradeCounter.totalStudents++;
-  }
-  return gradeCounts;
+// Map a backend support-level facet entry to the chart's intermediate shape.
+// `totalStudents` is the sum of the three classified levels — the Percent-mode
+// denominator — and intentionally excludes optional/null levels, matching the
+// prior client aggregation (which only counted runs with a classified level).
+const toBreakdownRow = (category, entry) => ({
+  category,
+  support_levels: [entry.needsExtraSupport.count, entry.developingSkill.count, entry.achievedSkill.count],
+  totalStudents: entry.needsExtraSupport.count + entry.developingSkill.count + entry.achievedSkill.count,
 });
 
-const districtSchoolSupportBreakdown = computed(() => {
-  // For district-level aggregation: { above/some/below: { schools: { name: n, ... } } }
-  if (props.orgType === 'district') {
-    const supportLevelIndexMap = { below: 0, some: 1, above: 2 };
-    const schoolMap = new Map(); // key = school name
+const gradeSupportBreakdown = computed(() =>
+  (props.facets?.supportLevelByGrade ?? []).map((entry) => toBreakdownRow(trimGrade(entry.grade), entry)),
+);
 
-    ['below', 'some', 'above'].forEach((level) => {
-      const schools = props?.runs?.[level]?.schools ?? {};
-      Object.values(schools).forEach(({ name, count }) => {
-        const key = name ?? 'Unknown school';
-        if (!schoolMap.has(key)) {
-          schoolMap.set(key, { category: key, support_levels: [0, 0, 0], totalStudents: 0 });
-        }
-        const row = schoolMap.get(key);
-        row.support_levels[supportLevelIndexMap[level]] += count;
-        row.totalStudents += count;
-      });
-    });
-
-    return Array.from(schoolMap.values());
-  }
-
-  // For non-district orgs (class, school, group, etc.)
-  const schoolCounts = [];
-  for (const run of props.runs) {
-    const schoolName = run?.user?.schoolName ?? 'Unknown school';
-    let schoolCounter = schoolCounts.find((s) => s.category === schoolName);
-    if (!schoolCounter) {
-      schoolCounter = { category: schoolName, support_levels: [0, 0, 0], totalStudents: 0 };
-      schoolCounts.push(schoolCounter);
-    }
-
-    const supportLevel = run?.scores?.support_level;
-    if (supportLevel === 'Needs Extra Support') schoolCounter.support_levels[0]++;
-    else if (supportLevel === 'Developing Skill') schoolCounter.support_levels[1]++;
-    else if (supportLevel === 'Achieved Skill') schoolCounter.support_levels[2]++;
-    else return; // skip null or undefined support levels
-
-    schoolCounter.totalStudents++;
-  }
-
-  return schoolCounts;
-});
+// Empty at non-district scope — the backend returns empty school arrays there
+// (the school-facet toggle is district-only).
+const schoolSupportBreakdown = computed(() =>
+  (props.facets?.supportLevelBySchool ?? []).map((entry) =>
+    toBreakdownRow(entry.schoolName ?? 'Unknown school', entry),
+  ),
+);
 
 const xMode = ref({ name: 'Percent' });
 const xModes = [{ name: 'Percent' }, { name: 'Count' }];
@@ -180,8 +118,8 @@ function returnValueByIndex(index, xMode, grade) {
 }
 
 const returnSupportLevelValues = computed(() => {
-  const gradeCounts = districtGradeSupportBreakdown.value;
-  const schoolCounts = districtSchoolSupportBreakdown.value;
+  const gradeCounts = gradeSupportBreakdown.value;
+  const schoolCounts = schoolSupportBreakdown.value;
   const counts = props.facetMode.name === 'Grade' ? gradeCounts : schoolCounts;
   const values = [];
 
@@ -324,7 +262,7 @@ const draw = async () => {
 };
 
 watch(
-  [() => distributionBySupport.value, () => props.facetMode, () => props.runs],
+  [() => distributionBySupport.value, () => props.facetMode, () => props.facets],
   () => {
     draw();
   },

--- a/apps/dashboard/src/components/reports/TableScoreTag.vue
+++ b/apps/dashboard/src/components/reports/TableScoreTag.vue
@@ -181,6 +181,8 @@ function handleSubskillToolTip(_taskId, _subskillId, _toolTip, _colData) {
 
 function getFlags(colData, taskId) {
   const flags = colData.scores[taskId]?.engagementFlags;
+  // engagementFlags may be an array (backend score shape) or a legacy object map — normalize.
+  const flagKeys = Array.isArray(flags) ? flags : Object.keys(flags ?? {});
   const flagMessages = {
     accuracyTooLow: 'Responses were inaccurate',
     notEnoughResponses: `Incomplete. This student may retake ${
@@ -194,14 +196,14 @@ function getFlags(colData, taskId) {
   if (flags && !colData.scores[taskId].reliable) {
     if (includedValidityFlags[taskId]) {
       // only display flags that are included in the includedValidityFlags object
-      const filteredFlags = Object.keys(flags).filter((flag) => includedValidityFlags[taskId].includes(flag));
+      const filteredFlags = flagKeys.filter((flag) => includedValidityFlags[taskId].includes(flag));
       const reliabilityFlags = filteredFlags.map((flag) => {
         return flagMessages[flag] || _lowerCase(flag);
       });
       if (reliabilityFlags.length === 0) return '';
       return 'Unreliable Score' + '\n' + ' - ' + reliabilityFlags.join('\n - ') + '\n\n';
     } else {
-      const reliabilityFlags = Object.keys(flags).map((flag) => {
+      const reliabilityFlags = flagKeys.map((flag) => {
         return flagMessages[flag] || _lowerCase(flag);
       });
       if (reliabilityFlags.length > 0) {

--- a/apps/dashboard/src/components/reports/tasks/TaskReport.vue
+++ b/apps/dashboard/src/components/reports/tasks/TaskReport.vue
@@ -8,7 +8,7 @@
     </div>
   </div>
   <div v-if="tasksToDisplayGraphs.includes(taskId)" :id="'tab-view-chart-' + taskId" class="chart-toggle-wrapper">
-    <div v-if="orgType === 'district'" class="mb-3" data-html2canvas-ignore="true">
+    <div v-if="hasSchoolFacets" class="mb-3" data-html2canvas-ignore="true">
       <div class="flex uppercase text-xs font-light justify-content-center align-items-center">view rows by</div>
       <PvSelectButton
         v-model="facetMode"
@@ -26,7 +26,7 @@
           :org-type="orgType"
           :org-id="orgId"
           :task-id="taskId"
-          :runs="runs"
+          :facets="facets"
           :facet-mode="facetMode"
         />
       </div>
@@ -37,7 +37,7 @@
           :org-type="orgType"
           :org-id="orgId"
           :task-id="taskId"
-          :runs="runs"
+          :facets="facets"
           :facet-mode="facetMode"
           :min-grade-by-runs="minGradeByRuns"
         />
@@ -166,9 +166,11 @@ const props = defineProps({
     type: String,
     required: true,
   },
-  runs: {
-    type: Array,
-    required: true,
+  facets: {
+    // Per-task facet aggregation from `getScoreFacets`; null while loading.
+    type: Object,
+    required: false,
+    default: null,
   },
   taskScoringVersions: {
     type: Object,
@@ -184,25 +186,22 @@ const facetModes = [
   { name: 'School', key: 'schoolName' },
 ];
 
+// Kindergarten / "0" sort as grade 0; everything else is its numeric grade.
+const gradeNumeric = (grade) => (grade === '0' || grade === 'Kindergarten' ? 0 : Number(grade));
+
+// Lowest grade present in the task's grade facets — drives whether the facet chart
+// offers the Raw/Percentile toggle (percentile is meaningful for early grades only).
 const minGradeByRuns = computed(() => {
-  if (props.orgType === 'district') {
-    // For district, props.runs is an object with support categories
-    // We need to extract all grade values from the nested structure
-    if (!props.runs || typeof props.runs !== 'object') {
-      return 0;
-    }
-    const allGrades = [];
-    Object.values(props.runs).forEach((category) => {
-      if (category && typeof category === 'object' && category.grades) {
-        allGrades.push(...Object.keys(category.grades));
-      }
-    });
-    return allGrades.length > 0 ? Math.min(...allGrades.map(Number)) : 0;
-  }
-  return Math.min(
-    ...props.runs.filter((run) => run.scores.rawScore || run.scores.stdPercentile).map((run) => run.grade),
-  );
+  const grades = (props.facets?.scoreBinsByGrade ?? [])
+    .map((entry) => gradeNumeric(entry.grade))
+    .filter((n) => Number.isFinite(n));
+  return grades.length ? Math.min(...grades) : 0;
 });
+
+// The school-facet toggle is shown only when the backend supplies school facets,
+// which happens at district scope (empty arrays elsewhere). This replaces the prior
+// explicit `orgType === 'district'` check — the data drives the UI.
+const hasSchoolFacets = computed(() => (props.facets?.supportLevelBySchool?.length ?? 0) > 0);
 
 const taskDesc = computed(() => {
   return replaceScoreRange(taskInfoById[props.taskId]?.desc, props.taskId, props.taskScoringVersions[props.taskId]);

--- a/apps/dashboard/src/composables/queries/useAdministrationScoreFacetsQuery.js
+++ b/apps/dashboard/src/composables/queries/useAdministrationScoreFacetsQuery.js
@@ -1,0 +1,89 @@
+import { toValue } from 'vue';
+import { useQuery } from '@tanstack/vue-query';
+import { StatusCodes } from 'http-status-codes';
+import { computeQueryOverrides } from '@/helpers/computeQueryOverrides';
+import { getRoarApiClient } from '@/clients/roar-api';
+import { useAuthStore } from '@/store/auth';
+import { isRosteringEndedError, isTerminalAuthError } from '@/utils/api-errors';
+import { ADMINISTRATION_SCORE_FACETS_QUERY_KEY } from '@/constants/queryKeys';
+
+const MAX_RETRIES = 3;
+
+/**
+ * Administration score-distribution-facets query.
+ *
+ * Fetches per-task support-level and score-bin distributions, faceted by grade
+ * and school, from `GET /v1/administrations/:id/reports/scores/facets`, scoped to
+ * a specific org/class/group via `scopeType` + `scopeId`. Not paginated — the
+ * endpoint aggregates across the full population in scope, so this is a single
+ * request (like the overview endpoint).
+ *
+ * Returns the unwrapped payload (`result.body.data`): `{ totalStudents, tasks,
+ * computedAt }` where each task carries `supportLevelByGrade` /
+ * `supportLevelBySchool` and `scoreBinsByGrade` / `scoreBinsBySchool`. The
+ * school-faceted arrays are empty at non-district scope (the school-facet toggle
+ * is district-only). This replaces the client-side facet binning over runs and
+ * the Firestore `useDistrictSupportCategoriesQuery` for the distribution charts.
+ *
+ * **Enablement.** Internally gated on `authStore.accessToken` AND truthy
+ * `administrationId` / `scopeType` / `scopeId`; callers AND extra conditions via
+ * `queryOptions.enabled`.
+ *
+ * @param {import('vue').MaybeRefOrGetter<String>} administrationId – The administration's UUID.
+ * @param {import('vue').MaybeRefOrGetter<String>} scopeType – 'district' | 'school' | 'class' | 'group'.
+ * @param {import('vue').MaybeRefOrGetter<String>} scopeId – The scoping entity's UUID.
+ * @param {Object|undefined} queryOptions – Optional TanStack query options.
+ * @returns {import('@tanstack/vue-query').UseQueryReturnType} Resolves to `{ totalStudents, tasks, computedAt }`.
+ */
+const useAdministrationScoreFacetsQuery = (administrationId, scopeType, scopeId, queryOptions = undefined) => {
+  const authStore = useAuthStore();
+  const conditions = [
+    () => Boolean(authStore.accessToken),
+    () => Boolean(toValue(administrationId)),
+    () => Boolean(toValue(scopeType)),
+    () => Boolean(toValue(scopeId)),
+  ];
+  const { isQueryEnabled, options } = computeQueryOverrides(conditions, queryOptions);
+
+  return useQuery({
+    // Pass scope params as-is (ref or string) so reactive callers update the key;
+    // TanStack unwraps refs in the key array, matching the canonical composable.
+    queryKey: [ADMINISTRATION_SCORE_FACETS_QUERY_KEY, administrationId, scopeType, scopeId],
+    queryFn: async () => {
+      const client = getRoarApiClient();
+      const result = await client.administrations.scoreReports.getScoreFacets({
+        params: { id: toValue(administrationId) },
+        query: {
+          scopeType: toValue(scopeType),
+          scopeId: toValue(scopeId),
+        },
+      });
+
+      if (result.status !== StatusCodes.OK) {
+        // Non-200 ts-rest results are surfaced as thrown errors so TanStack routes
+        // them through `error`. The thrown shape carries the ts-rest response so
+        // downstream error handlers can introspect it.
+        const error = new Error(`Failed to fetch administration score facets with status ${result.status}`);
+        error.status = result.status;
+        error.body = result.body;
+        throw error;
+      }
+
+      // Unwrap the success envelope: { data: { totalStudents, tasks, computedAt } }.
+      return result.body.data;
+    },
+    ...options,
+    enabled: isQueryEnabled,
+    // Terminal auth errors and rostering-ended are not transient; retrying delays
+    // the user-facing error UX. Placed after `...options` so a caller-supplied
+    // `retry` can't silently override the policy.
+    retry: (failureCount, error) => {
+      if (isRosteringEndedError(error) || isTerminalAuthError(error)) {
+        return false;
+      }
+      return failureCount < MAX_RETRIES;
+    },
+  });
+};
+
+export default useAdministrationScoreFacetsQuery;

--- a/apps/dashboard/src/composables/queries/useAdministrationScoreFacetsQuery.test.js
+++ b/apps/dashboard/src/composables/queries/useAdministrationScoreFacetsQuery.test.js
@@ -1,0 +1,169 @@
+import { ref, nextTick, isRef, isReadonly } from 'vue';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { createTestingPinia } from '@pinia/testing';
+import * as VueQuery from '@tanstack/vue-query';
+import { nanoid } from 'nanoid';
+import { StatusCodes } from 'http-status-codes';
+import { withSetup } from '@/test-support/withSetup.js';
+import { useAuthStore } from '@/store/auth';
+import useAdministrationScoreFacetsQuery from './useAdministrationScoreFacetsQuery';
+import { ADMINISTRATION_SCORE_FACETS_QUERY_KEY } from '@/constants/queryKeys';
+
+const mockGetScoreFacets = vi.fn();
+
+vi.mock('@/clients/roar-api', () => ({
+  getRoarApiClient: () => ({
+    administrations: { scoreReports: { getScoreFacets: mockGetScoreFacets } },
+  }),
+}));
+
+vi.mock('@tanstack/vue-query', async (getModule) => {
+  const original = await getModule();
+  return {
+    ...original,
+    useQuery: vi.fn().mockImplementation(original.useQuery),
+  };
+});
+
+// Mirrors the real ScoreFacetsResponseSchema shape.
+const SUPPORT = { achievedSkill: { count: 3 }, developingSkill: { count: 2 }, needsExtraSupport: { count: 1 } };
+const FACETS_RESPONSE = {
+  totalStudents: 6,
+  computedAt: '2026-06-27T00:00:00.000Z',
+  tasks: [
+    {
+      taskId: '11111111-1111-1111-1111-111111111111',
+      taskSlug: 'swr',
+      taskName: 'Word',
+      orderIndex: 0,
+      supportLevelByGrade: [{ grade: '3', totalAssessed: 6, ...SUPPORT }],
+      supportLevelBySchool: [],
+      scoreBinsByGrade: [
+        {
+          grade: '3',
+          rawScore: [{ binStart: 100, binEnd: 130, count: 6 }],
+          percentile: [{ binStart: 0, binEnd: 10, count: 6 }],
+        },
+      ],
+      scoreBinsBySchool: [],
+    },
+  ],
+};
+
+const okResult = () => ({ status: StatusCodes.OK, body: { data: FACETS_RESPONSE } });
+
+describe('useAdministrationScoreFacetsQuery', () => {
+  let piniaInstance;
+  let queryClient;
+
+  beforeEach(() => {
+    piniaInstance = createTestingPinia();
+    queryClient = new VueQuery.QueryClient({ defaultOptions: { queries: { retry: false } } });
+    mockGetScoreFacets.mockReset();
+    mockGetScoreFacets.mockResolvedValue(okResult());
+  });
+
+  afterEach(() => {
+    queryClient?.clear();
+    vi.clearAllMocks();
+  });
+
+  it('calls useQuery with the facets key and a gated, readonly enabled', () => {
+    const authStore = useAuthStore(piniaInstance);
+    authStore.accessToken = 'test-token';
+
+    vi.spyOn(VueQuery, 'useQuery');
+
+    withSetup(() => useAdministrationScoreFacetsQuery(nanoid(), 'district', nanoid()), {
+      plugins: [[VueQuery.VueQueryPlugin, { queryClient }]],
+    });
+
+    const call = vi.mocked(VueQuery.useQuery).mock.calls[0][0];
+    expect(call.queryKey[0]).toBe(ADMINISTRATION_SCORE_FACETS_QUERY_KEY);
+    expect(call.queryFn).toBeInstanceOf(Function);
+    expect(isRef(call.enabled)).toBe(true);
+    expect(isReadonly(call.enabled)).toBe(true);
+    expect(call.enabled.value).toBe(true);
+  });
+
+  it('makes a single (non-paginated) request and unwraps the envelope', async () => {
+    const administrationId = nanoid();
+    const scopeId = nanoid();
+
+    const authStore = useAuthStore(piniaInstance);
+    authStore.accessToken = 'test-token';
+
+    vi.spyOn(VueQuery, 'useQuery');
+
+    withSetup(() => useAdministrationScoreFacetsQuery(administrationId, 'school', scopeId), {
+      plugins: [[VueQuery.VueQueryPlugin, { queryClient }]],
+    });
+
+    const { queryFn } = vi.mocked(VueQuery.useQuery).mock.calls[0][0];
+    const result = await queryFn();
+
+    expect(mockGetScoreFacets).toHaveBeenCalledTimes(1);
+    expect(mockGetScoreFacets).toHaveBeenCalledWith({
+      params: { id: administrationId },
+      query: { scopeType: 'school', scopeId },
+    });
+    expect(result).toEqual(FACETS_RESPONSE);
+    expect(result.tasks[0].supportLevelByGrade[0]).toMatchObject({ grade: '3', achievedSkill: { count: 3 } });
+  });
+
+  it('throws when the API returns a non-200 status', async () => {
+    mockGetScoreFacets.mockResolvedValue({ status: StatusCodes.BAD_REQUEST, body: {} });
+
+    const authStore = useAuthStore(piniaInstance);
+    authStore.accessToken = 'test-token';
+
+    vi.spyOn(VueQuery, 'useQuery');
+
+    withSetup(() => useAdministrationScoreFacetsQuery(nanoid(), 'school', nanoid()), {
+      plugins: [[VueQuery.VueQueryPlugin, { queryClient }]],
+    });
+
+    const { queryFn } = vi.mocked(VueQuery.useQuery).mock.calls[0][0];
+    await expect(queryFn()).rejects.toThrow(/status 400/);
+  });
+
+  it('stays disabled until the access token and scopeId are available', async () => {
+    const scopeId = ref(null);
+    const authStore = useAuthStore(piniaInstance);
+    authStore.accessToken = null;
+
+    withSetup(() => useAdministrationScoreFacetsQuery(nanoid(), 'school', scopeId), {
+      plugins: [[VueQuery.VueQueryPlugin, { queryClient }]],
+    });
+
+    const call = vi.mocked(VueQuery.useQuery).mock.calls[0][0];
+    expect(call.enabled.value).toBe(false);
+
+    authStore.accessToken = 'test-token';
+    scopeId.value = nanoid();
+    await nextTick();
+
+    expect(call.enabled.value).toBe(true);
+  });
+
+  it('does not retry terminal auth / rostering-ended errors but retries transient ones up to 3x', () => {
+    const authStore = useAuthStore(piniaInstance);
+    authStore.accessToken = 'test-token';
+
+    let retryFn;
+    vi.spyOn(VueQuery, 'useQuery').mockImplementation((options) => {
+      retryFn = options.retry;
+      return { data: { value: null }, error: { value: null } };
+    });
+
+    withSetup(() => useAdministrationScoreFacetsQuery(nanoid(), 'school', nanoid()), {
+      plugins: [[VueQuery.VueQueryPlugin, { queryClient }]],
+    });
+
+    expect(retryFn(0, { body: { error: { code: 'auth/token-expired' } } })).toBe(false);
+    expect(retryFn(0, { body: { error: { code: 'auth/rostering-ended' } } })).toBe(false);
+    const networkError = new Error('network down');
+    expect(retryFn(2, networkError)).toBe(true);
+    expect(retryFn(3, networkError)).toBe(false);
+  });
+});

--- a/apps/dashboard/src/composables/queries/useAdministrationScoreOverviewQuery.js
+++ b/apps/dashboard/src/composables/queries/useAdministrationScoreOverviewQuery.js
@@ -1,0 +1,87 @@
+import { toValue } from 'vue';
+import { useQuery } from '@tanstack/vue-query';
+import { StatusCodes } from 'http-status-codes';
+import { computeQueryOverrides } from '@/helpers/computeQueryOverrides';
+import { getRoarApiClient } from '@/clients/roar-api';
+import { useAuthStore } from '@/store/auth';
+import { isRosteringEndedError, isTerminalAuthError } from '@/utils/api-errors';
+import { ADMINISTRATION_SCORE_OVERVIEW_QUERY_KEY } from '@/constants/queryKeys';
+
+const MAX_RETRIES = 3;
+
+/**
+ * Administration score-overview query.
+ *
+ * Fetches aggregated support-level distributions per task from
+ * `GET /v1/administrations/:id/reports/scores/overview`, scoped to a specific
+ * org/class/group via `scopeType` + `scopeId`. Not paginated — the endpoint
+ * aggregates across the full population in scope, so this is a single request
+ * (unlike the paginated student / subscore endpoints).
+ *
+ * Returns the unwrapped overview payload (`result.body.data`): the per-task
+ * aggregated support-level counts the "at a glance" charts at the top of the
+ * score report render. Replaces the client-side `runsByTaskId` aggregation and
+ * the Firestore `useDistrictSupportCategoriesQuery`.
+ *
+ * **Enablement.** Internally gated on `authStore.accessToken` AND truthy
+ * `administrationId` / `scopeType` / `scopeId`; callers AND extra conditions via
+ * `queryOptions.enabled`.
+ *
+ * @param {import('vue').MaybeRefOrGetter<String>} administrationId – The administration's UUID.
+ * @param {import('vue').MaybeRefOrGetter<String>} scopeType – 'district' | 'school' | 'class' | 'group'.
+ * @param {import('vue').MaybeRefOrGetter<String>} scopeId – The scoping entity's UUID.
+ * @param {Object|undefined} queryOptions – Optional TanStack query options.
+ * @returns {import('@tanstack/vue-query').UseQueryReturnType} Resolves to the aggregated overview payload.
+ */
+const useAdministrationScoreOverviewQuery = (administrationId, scopeType, scopeId, queryOptions = undefined) => {
+  const authStore = useAuthStore();
+  const conditions = [
+    () => Boolean(authStore.accessToken),
+    () => Boolean(toValue(administrationId)),
+    () => Boolean(toValue(scopeType)),
+    () => Boolean(toValue(scopeId)),
+  ];
+  const { isQueryEnabled, options } = computeQueryOverrides(conditions, queryOptions);
+
+  return useQuery({
+    // Pass scope params as-is (ref or string) so reactive callers update the key;
+    // TanStack unwraps refs in the key array, matching the canonical composable.
+    queryKey: [ADMINISTRATION_SCORE_OVERVIEW_QUERY_KEY, administrationId, scopeType, scopeId],
+    queryFn: async () => {
+      const client = getRoarApiClient();
+      const result = await client.administrations.scoreReports.getOverview({
+        params: { id: toValue(administrationId) },
+        query: {
+          scopeType: toValue(scopeType),
+          scopeId: toValue(scopeId),
+        },
+      });
+
+      if (result.status !== StatusCodes.OK) {
+        // Non-200 ts-rest results are surfaced as thrown errors so TanStack routes
+        // them through `error`. The thrown shape carries the ts-rest response so
+        // downstream error handlers can introspect it.
+        const error = new Error(`Failed to fetch administration score overview with status ${result.status}`);
+        error.status = result.status;
+        error.body = result.body;
+        throw error;
+      }
+
+      // Unwrap the success envelope: { data: <aggregated overview> }.
+      return result.body.data;
+    },
+    ...options,
+    enabled: isQueryEnabled,
+    // Terminal auth errors and rostering-ended are not transient; retrying delays
+    // the user-facing error UX. Placed after `...options` so a caller-supplied
+    // `retry` can't silently override the policy.
+    retry: (failureCount, error) => {
+      if (isRosteringEndedError(error) || isTerminalAuthError(error)) {
+        return false;
+      }
+      return failureCount < MAX_RETRIES;
+    },
+  });
+};
+
+export default useAdministrationScoreOverviewQuery;

--- a/apps/dashboard/src/composables/queries/useAdministrationScoreOverviewQuery.test.js
+++ b/apps/dashboard/src/composables/queries/useAdministrationScoreOverviewQuery.test.js
@@ -1,0 +1,173 @@
+import { ref, nextTick, isRef, isReadonly } from 'vue';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { createTestingPinia } from '@pinia/testing';
+import * as VueQuery from '@tanstack/vue-query';
+import { nanoid } from 'nanoid';
+import { StatusCodes } from 'http-status-codes';
+import { withSetup } from '@/test-support/withSetup.js';
+import { useAuthStore } from '@/store/auth';
+import useAdministrationScoreOverviewQuery from './useAdministrationScoreOverviewQuery';
+import { ADMINISTRATION_SCORE_OVERVIEW_QUERY_KEY } from '@/constants/queryKeys';
+
+const mockGetOverview = vi.fn();
+
+vi.mock('@/clients/roar-api', () => ({
+  getRoarApiClient: () => ({
+    administrations: { scoreReports: { getOverview: mockGetOverview } },
+  }),
+}));
+
+vi.mock('@tanstack/vue-query', async (getModule) => {
+  const original = await getModule();
+  return {
+    ...original,
+    useQuery: vi.fn().mockImplementation(original.useQuery),
+  };
+});
+
+// Mirrors the real ScoreOverviewResponseSchema shape (taskSlug + supportLevels.<key>.count).
+const SAMPLE_OVERVIEW = {
+  totalStudents: 10,
+  tasks: [
+    {
+      taskId: '11111111-1111-1111-1111-111111111111',
+      taskSlug: 'swr',
+      taskName: 'Word',
+      orderIndex: 0,
+      totalAssessed: 8,
+      totalNotAssessed: { required: 1, optional: 1 },
+      supportLevels: { needsExtraSupport: { count: 2 }, developingSkill: { count: 3 }, achievedSkill: { count: 3 } },
+    },
+  ],
+  computedAt: '2026-06-28T00:00:00.000Z',
+  exclusions: {},
+};
+
+describe('useAdministrationScoreOverviewQuery', () => {
+  let piniaInstance;
+  let queryClient;
+
+  beforeEach(() => {
+    piniaInstance = createTestingPinia();
+    queryClient = new VueQuery.QueryClient({ defaultOptions: { queries: { retry: false } } });
+    mockGetOverview.mockReset();
+    mockGetOverview.mockResolvedValue({ status: StatusCodes.OK, body: { data: SAMPLE_OVERVIEW } });
+  });
+
+  afterEach(() => {
+    queryClient?.clear();
+    vi.clearAllMocks();
+  });
+
+  it('calls useQuery with the score-overview key and a gated, readonly enabled', () => {
+    const authStore = useAuthStore(piniaInstance);
+    authStore.accessToken = 'test-token';
+
+    vi.spyOn(VueQuery, 'useQuery');
+
+    withSetup(() => useAdministrationScoreOverviewQuery(nanoid(), 'school', nanoid()), {
+      plugins: [[VueQuery.VueQueryPlugin, { queryClient }]],
+    });
+
+    const call = vi.mocked(VueQuery.useQuery).mock.calls[0][0];
+    expect(call.queryKey[0]).toBe(ADMINISTRATION_SCORE_OVERVIEW_QUERY_KEY);
+    expect(call.queryFn).toBeInstanceOf(Function);
+    expect(isRef(call.enabled)).toBe(true);
+    expect(isReadonly(call.enabled)).toBe(true);
+    expect(call.enabled.value).toBe(true);
+  });
+
+  it('fetches the overview with the scope params and returns the unwrapped payload', async () => {
+    const administrationId = nanoid();
+    const scopeId = nanoid();
+    const authStore = useAuthStore(piniaInstance);
+    authStore.accessToken = 'test-token';
+
+    vi.spyOn(VueQuery, 'useQuery');
+
+    withSetup(() => useAdministrationScoreOverviewQuery(administrationId, 'school', scopeId), {
+      plugins: [[VueQuery.VueQueryPlugin, { queryClient }]],
+    });
+
+    const { queryFn } = vi.mocked(VueQuery.useQuery).mock.calls[0][0];
+    const data = await queryFn();
+
+    expect(mockGetOverview).toHaveBeenCalledWith({
+      params: { id: administrationId },
+      query: { scopeType: 'school', scopeId },
+    });
+    expect(data).toEqual(SAMPLE_OVERVIEW);
+  });
+
+  it('throws when the API returns a non-200 status', async () => {
+    mockGetOverview.mockResolvedValue({ status: StatusCodes.FORBIDDEN, body: {} });
+
+    const authStore = useAuthStore(piniaInstance);
+    authStore.accessToken = 'test-token';
+
+    vi.spyOn(VueQuery, 'useQuery');
+
+    withSetup(() => useAdministrationScoreOverviewQuery(nanoid(), 'school', nanoid()), {
+      plugins: [[VueQuery.VueQueryPlugin, { queryClient }]],
+    });
+
+    const { queryFn } = vi.mocked(VueQuery.useQuery).mock.calls[0][0];
+    await expect(queryFn()).rejects.toThrow(/status 403/);
+  });
+
+  it('unwraps a reactive scopeId and stays disabled until it is present', async () => {
+    const scopeId = ref(null);
+    const authStore = useAuthStore(piniaInstance);
+    authStore.accessToken = 'test-token';
+
+    withSetup(() => useAdministrationScoreOverviewQuery(nanoid(), 'school', scopeId), {
+      plugins: [[VueQuery.VueQueryPlugin, { queryClient }]],
+    });
+
+    const call = vi.mocked(VueQuery.useQuery).mock.calls[0][0];
+    expect(call.enabled.value).toBe(false);
+
+    scopeId.value = nanoid();
+    await nextTick();
+
+    expect(call.enabled.value).toBe(true);
+  });
+
+  it('stays disabled until the access token is available', async () => {
+    const authStore = useAuthStore(piniaInstance);
+    authStore.accessToken = null;
+
+    withSetup(() => useAdministrationScoreOverviewQuery(nanoid(), 'school', nanoid()), {
+      plugins: [[VueQuery.VueQueryPlugin, { queryClient }]],
+    });
+
+    const call = vi.mocked(VueQuery.useQuery).mock.calls[0][0];
+    expect(call.enabled.value).toBe(false);
+
+    authStore.accessToken = 'test-token';
+    await nextTick();
+
+    expect(call.enabled.value).toBe(true);
+  });
+
+  it('does not retry terminal auth / rostering-ended errors but retries transient ones up to 3x', () => {
+    const authStore = useAuthStore(piniaInstance);
+    authStore.accessToken = 'test-token';
+
+    let retryFn;
+    vi.spyOn(VueQuery, 'useQuery').mockImplementation((options) => {
+      retryFn = options.retry;
+      return { data: { value: null }, error: { value: null } };
+    });
+
+    withSetup(() => useAdministrationScoreOverviewQuery(nanoid(), 'school', nanoid()), {
+      plugins: [[VueQuery.VueQueryPlugin, { queryClient }]],
+    });
+
+    expect(retryFn(0, { body: { error: { code: 'auth/token-expired' } } })).toBe(false);
+    expect(retryFn(0, { body: { error: { code: 'auth/rostering-ended' } } })).toBe(false);
+    const networkError = new Error('network down');
+    expect(retryFn(2, networkError)).toBe(true);
+    expect(retryFn(3, networkError)).toBe(false);
+  });
+});

--- a/apps/dashboard/src/composables/queries/useAdministrationScoreStudentsQuery.js
+++ b/apps/dashboard/src/composables/queries/useAdministrationScoreStudentsQuery.js
@@ -1,0 +1,116 @@
+import { toValue } from 'vue';
+import { useQuery } from '@tanstack/vue-query';
+import { StatusCodes } from 'http-status-codes';
+import { computeQueryOverrides } from '@/helpers/computeQueryOverrides';
+import { getRoarApiClient } from '@/clients/roar-api';
+import { useAuthStore } from '@/store/auth';
+import { isRosteringEndedError, isTerminalAuthError } from '@/utils/api-errors';
+import { ADMINISTRATION_SCORE_STUDENTS_QUERY_KEY } from '@/constants/queryKeys';
+
+const MAX_RETRIES = 3;
+
+/**
+ * Page size for the student-scores request. The score report renders a
+ * client-side table over the full scoped population, so the composable follows
+ * the response pagination and aggregates every page into a single result
+ * (mirrors `useAdministrationProgressQuery`).
+ */
+const STUDENT_SCORES_PER_PAGE = 100;
+
+/**
+ * Administration per-student scores query.
+ *
+ * Fetches per-student scores for an administration from
+ * `GET /v1/administrations/:id/reports/scores/students`, scoped to a specific
+ * org/class/group via `scopeType` + `scopeId`. Follows the response's pagination
+ * so the full student population for the scope is returned in one composable result.
+ *
+ * Returns domain data `{ students, tasks, exclusions }`:
+ * - `students` — `{ user, scores }` rows. `scores` is keyed by task **UUID**; each
+ *   entry carries `rawScore` / `percentile` / `standardScore` / `supportLevel`
+ *   (`achievedSkill` | `developingSkill` | `needsExtraSupport` | `optional` | null) /
+ *   `reliable` / `engagementFlags` / `optional` / `completed`. The server computes
+ *   the classification, replacing the client-side scoring in `ScoreReport.vue`.
+ * - `tasks` — `{ taskId, taskSlug, taskName, orderIndex }[]` for mapping the
+ *   UUID-keyed scores onto the slug-based table columns.
+ * - `exclusions` — counts of records filtered from the report (e.g. rostering-ended).
+ *
+ * **Enablement.** Internally gated on `authStore.accessToken` AND truthy
+ * `administrationId` / `scopeType` / `scopeId`; callers AND additional conditions
+ * via `queryOptions.enabled`.
+ *
+ * @param {import('vue').MaybeRefOrGetter<String>} administrationId – The administration's UUID.
+ * @param {import('vue').MaybeRefOrGetter<String>} scopeType – 'district' | 'school' | 'class' | 'group'.
+ * @param {import('vue').MaybeRefOrGetter<String>} scopeId – The scoping entity's UUID.
+ * @param {Object|undefined} queryOptions – Optional TanStack query options.
+ * @returns {import('@tanstack/vue-query').UseQueryReturnType} Resolves to `{ students, tasks, exclusions }`.
+ */
+const useAdministrationScoreStudentsQuery = (administrationId, scopeType, scopeId, queryOptions = undefined) => {
+  const authStore = useAuthStore();
+  const conditions = [
+    () => Boolean(authStore.accessToken),
+    () => Boolean(toValue(administrationId)),
+    () => Boolean(toValue(scopeType)),
+    () => Boolean(toValue(scopeId)),
+  ];
+  const { isQueryEnabled, options } = computeQueryOverrides(conditions, queryOptions);
+
+  return useQuery({
+    queryKey: [ADMINISTRATION_SCORE_STUDENTS_QUERY_KEY, administrationId, scopeType, scopeId],
+    queryFn: async () => {
+      const client = getRoarApiClient();
+      const students = [];
+      let tasks = [];
+      let exclusions;
+      let page = 1;
+      let totalPages = 1;
+
+      // Follow the response's pagination so a scope that outgrows one page is
+      // fetched completely rather than silently truncated.
+      do {
+        const result = await client.administrations.scoreReports.listStudents({
+          params: { id: toValue(administrationId) },
+          query: {
+            page,
+            perPage: STUDENT_SCORES_PER_PAGE,
+            scopeType: toValue(scopeType),
+            scopeId: toValue(scopeId),
+          },
+        });
+
+        if (result.status !== StatusCodes.OK) {
+          // Non-200 ts-rest results are surfaced as thrown errors so TanStack routes
+          // them through `error`. The thrown shape carries the ts-rest response so
+          // downstream error handlers can introspect it.
+          const error = new Error(`Failed to fetch administration student scores with status ${result.status}`);
+          error.status = result.status;
+          error.body = result.body;
+          throw error;
+        }
+
+        // Unwrap the success envelope: { data: { tasks, items, pagination, exclusions } }.
+        // tasks/exclusions are identical across pages — keep the latest.
+        students.push(...result.body.data.items);
+        tasks = result.body.data.tasks;
+        exclusions = result.body.data.exclusions;
+        totalPages = result.body.data.pagination.totalPages;
+        page += 1;
+      } while (page <= totalPages);
+
+      return { students, tasks, exclusions };
+    },
+    ...options,
+    enabled: isQueryEnabled,
+    // Terminal auth errors and rostering-ended are not transient; retrying delays
+    // the user-facing error UX. Placed after `...options` so a caller-supplied
+    // `retry` can't silently override the policy.
+    retry: (failureCount, error) => {
+      if (isRosteringEndedError(error) || isTerminalAuthError(error)) {
+        return false;
+      }
+      return failureCount < MAX_RETRIES;
+    },
+  });
+};
+
+export default useAdministrationScoreStudentsQuery;

--- a/apps/dashboard/src/composables/queries/useAdministrationScoreStudentsQuery.test.js
+++ b/apps/dashboard/src/composables/queries/useAdministrationScoreStudentsQuery.test.js
@@ -1,0 +1,171 @@
+import { ref, nextTick, isRef, isReadonly } from 'vue';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { createTestingPinia } from '@pinia/testing';
+import * as VueQuery from '@tanstack/vue-query';
+import { nanoid } from 'nanoid';
+import { StatusCodes } from 'http-status-codes';
+import { withSetup } from '@/test-support/withSetup.js';
+import { useAuthStore } from '@/store/auth';
+import useAdministrationScoreStudentsQuery from './useAdministrationScoreStudentsQuery';
+import { ADMINISTRATION_SCORE_STUDENTS_QUERY_KEY } from '@/constants/queryKeys';
+
+const mockListStudents = vi.fn();
+
+vi.mock('@/clients/roar-api', () => ({
+  getRoarApiClient: () => ({
+    administrations: { scoreReports: { listStudents: mockListStudents } },
+  }),
+}));
+
+vi.mock('@tanstack/vue-query', async (getModule) => {
+  const original = await getModule();
+  return {
+    ...original,
+    useQuery: vi.fn().mockImplementation(original.useQuery),
+  };
+});
+
+// Mirrors the real StudentScoresResponseSchema shape.
+const TASK_UUID = '11111111-1111-1111-1111-111111111111';
+const TASKS = [{ taskId: TASK_UUID, taskSlug: 'swr', taskName: 'Word', orderIndex: 0 }];
+const makeRow = (userId) => ({
+  user: { userId, firstName: 'A', lastName: 'B', grade: '3' },
+  scores: {
+    [TASK_UUID]: {
+      rawScore: 10,
+      percentile: 50,
+      standardScore: 100,
+      supportLevel: 'achievedSkill',
+      reliable: true,
+      engagementFlags: [],
+      optional: false,
+      completed: true,
+    },
+  },
+});
+const makePage = (page, totalPages, items) => ({
+  status: StatusCodes.OK,
+  body: {
+    data: { tasks: TASKS, items, pagination: { page, perPage: 100, totalItems: 2, totalPages }, exclusions: {} },
+  },
+});
+
+describe('useAdministrationScoreStudentsQuery', () => {
+  let piniaInstance;
+  let queryClient;
+
+  beforeEach(() => {
+    piniaInstance = createTestingPinia();
+    queryClient = new VueQuery.QueryClient({ defaultOptions: { queries: { retry: false } } });
+    mockListStudents.mockReset();
+    mockListStudents.mockResolvedValue(makePage(1, 1, [makeRow('u1')]));
+  });
+
+  afterEach(() => {
+    queryClient?.clear();
+    vi.clearAllMocks();
+  });
+
+  it('calls useQuery with the student-scores key and a gated, readonly enabled', () => {
+    const authStore = useAuthStore(piniaInstance);
+    authStore.accessToken = 'test-token';
+
+    vi.spyOn(VueQuery, 'useQuery');
+
+    withSetup(() => useAdministrationScoreStudentsQuery(nanoid(), 'school', nanoid()), {
+      plugins: [[VueQuery.VueQueryPlugin, { queryClient }]],
+    });
+
+    const call = vi.mocked(VueQuery.useQuery).mock.calls[0][0];
+    expect(call.queryKey[0]).toBe(ADMINISTRATION_SCORE_STUDENTS_QUERY_KEY);
+    expect(call.queryFn).toBeInstanceOf(Function);
+    expect(isRef(call.enabled)).toBe(true);
+    expect(isReadonly(call.enabled)).toBe(true);
+    expect(call.enabled.value).toBe(true);
+  });
+
+  it('follows pagination and aggregates all pages into { students, tasks, exclusions }', async () => {
+    const administrationId = nanoid();
+    const scopeId = nanoid();
+    mockListStudents
+      .mockResolvedValueOnce(makePage(1, 2, [makeRow('u1')]))
+      .mockResolvedValueOnce(makePage(2, 2, [makeRow('u2')]));
+
+    const authStore = useAuthStore(piniaInstance);
+    authStore.accessToken = 'test-token';
+
+    vi.spyOn(VueQuery, 'useQuery');
+
+    withSetup(() => useAdministrationScoreStudentsQuery(administrationId, 'school', scopeId), {
+      plugins: [[VueQuery.VueQueryPlugin, { queryClient }]],
+    });
+
+    const { queryFn } = vi.mocked(VueQuery.useQuery).mock.calls[0][0];
+    const result = await queryFn();
+
+    expect(mockListStudents).toHaveBeenCalledTimes(2);
+    expect(mockListStudents).toHaveBeenNthCalledWith(1, {
+      params: { id: administrationId },
+      query: { page: 1, perPage: 100, scopeType: 'school', scopeId },
+    });
+    expect(result.students.map((s) => s.user.userId)).toEqual(['u1', 'u2']);
+    expect(result.tasks).toEqual(TASKS);
+    expect(result.exclusions).toEqual({});
+  });
+
+  it('throws when the API returns a non-200 status', async () => {
+    mockListStudents.mockResolvedValue({ status: StatusCodes.FORBIDDEN, body: {} });
+
+    const authStore = useAuthStore(piniaInstance);
+    authStore.accessToken = 'test-token';
+
+    vi.spyOn(VueQuery, 'useQuery');
+
+    withSetup(() => useAdministrationScoreStudentsQuery(nanoid(), 'school', nanoid()), {
+      plugins: [[VueQuery.VueQueryPlugin, { queryClient }]],
+    });
+
+    const { queryFn } = vi.mocked(VueQuery.useQuery).mock.calls[0][0];
+    await expect(queryFn()).rejects.toThrow(/status 403/);
+  });
+
+  it('stays disabled until the access token and scopeId are available', async () => {
+    const scopeId = ref(null);
+    const authStore = useAuthStore(piniaInstance);
+    authStore.accessToken = null;
+
+    withSetup(() => useAdministrationScoreStudentsQuery(nanoid(), 'school', scopeId), {
+      plugins: [[VueQuery.VueQueryPlugin, { queryClient }]],
+    });
+
+    const call = vi.mocked(VueQuery.useQuery).mock.calls[0][0];
+    expect(call.enabled.value).toBe(false);
+
+    authStore.accessToken = 'test-token';
+    scopeId.value = nanoid();
+    await nextTick();
+
+    expect(call.enabled.value).toBe(true);
+  });
+
+  it('does not retry terminal auth / rostering-ended errors but retries transient ones up to 3x', () => {
+    const authStore = useAuthStore(piniaInstance);
+    authStore.accessToken = 'test-token';
+
+    let retryFn;
+    vi.spyOn(VueQuery, 'useQuery').mockImplementation((options) => {
+      retryFn = options.retry;
+      return { data: { value: null }, error: { value: null } };
+    });
+
+    withSetup(() => useAdministrationScoreStudentsQuery(nanoid(), 'school', nanoid()), {
+      plugins: [[VueQuery.VueQueryPlugin, { queryClient }]],
+    });
+
+    expect(retryFn(0, { body: { error: { code: 'auth/token-expired' } } })).toBe(false);
+    expect(retryFn(0, { body: { error: { code: 'auth/rostering-ended' } } })).toBe(false);
+    const networkError = new Error('network down');
+    expect(retryFn(2, networkError)).toBe(true);
+    expect(retryFn(3, networkError)).toBe(false);
+  });
+});

--- a/apps/dashboard/src/constants/queryKeys.js
+++ b/apps/dashboard/src/constants/queryKeys.js
@@ -7,6 +7,7 @@ export const ADMINISTRATION_PROGRESS_QUERY_KEY = 'administration-progress';
 export const ADMINISTRATION_PROGRESS_OVERVIEW_QUERY_KEY = 'administration-progress-overview';
 export const ADMINISTRATION_SCORE_OVERVIEW_QUERY_KEY = 'administration-score-overview';
 export const ADMINISTRATION_SCORE_STUDENTS_QUERY_KEY = 'administration-score-students';
+export const ADMINISTRATION_SCORE_FACETS_QUERY_KEY = 'administration-score-facets';
 export const ADMINISTRATION_ASSIGNEES_QUERY_KEY = 'administration-assignees';
 export const ADMINISTRATION_TASK_VARIANTS_QUERY_KEY = 'administration-task-variants';
 export const ADMINISTRATION_AGREEMENTS_QUERY_KEY = 'administration-agreements';

--- a/apps/dashboard/src/constants/queryKeys.js
+++ b/apps/dashboard/src/constants/queryKeys.js
@@ -5,6 +5,7 @@ export const ADMINISTRATION_QUERY_KEY = 'administration';
 export const ADMINISTRATION_ASSIGNMENTS_QUERY_KEY = 'administration-assignments';
 export const ADMINISTRATION_PROGRESS_QUERY_KEY = 'administration-progress';
 export const ADMINISTRATION_PROGRESS_OVERVIEW_QUERY_KEY = 'administration-progress-overview';
+export const ADMINISTRATION_SCORE_OVERVIEW_QUERY_KEY = 'administration-score-overview';
 export const ADMINISTRATION_ASSIGNEES_QUERY_KEY = 'administration-assignees';
 export const ADMINISTRATION_TASK_VARIANTS_QUERY_KEY = 'administration-task-variants';
 export const ADMINISTRATION_AGREEMENTS_QUERY_KEY = 'administration-agreements';

--- a/apps/dashboard/src/constants/queryKeys.js
+++ b/apps/dashboard/src/constants/queryKeys.js
@@ -6,6 +6,7 @@ export const ADMINISTRATION_ASSIGNMENTS_QUERY_KEY = 'administration-assignments'
 export const ADMINISTRATION_PROGRESS_QUERY_KEY = 'administration-progress';
 export const ADMINISTRATION_PROGRESS_OVERVIEW_QUERY_KEY = 'administration-progress-overview';
 export const ADMINISTRATION_SCORE_OVERVIEW_QUERY_KEY = 'administration-score-overview';
+export const ADMINISTRATION_SCORE_STUDENTS_QUERY_KEY = 'administration-score-students';
 export const ADMINISTRATION_ASSIGNEES_QUERY_KEY = 'administration-assignees';
 export const ADMINISTRATION_TASK_VARIANTS_QUERY_KEY = 'administration-task-variants';
 export const ADMINISTRATION_AGREEMENTS_QUERY_KEY = 'administration-agreements';

--- a/apps/dashboard/src/pages/ScoreReport.vue
+++ b/apps/dashboard/src/pages/ScoreReport.vue
@@ -58,11 +58,7 @@
                   <div v-for="taskId of sortedAndFilteredTaskIds" :key="taskId" style="width: 33%">
                     <div class="distribution-overview-wrapper">
                       <DistributionChartOverview
-                        :runs="
-                          props.orgType === 'district'
-                            ? aggregatedDistrictSupportCategories[taskId]
-                            : computeAssignmentAndRunData.runsByTaskId[taskId]
-                        "
+                        :support-level-counts="scoreOverviewBySlug[taskId]"
                         :initialized="initialized"
                         :task-id="taskId"
                         :org-type="props.orgType"
@@ -427,6 +423,7 @@ import { getDynamicRouterPath } from '@/helpers/getDynamicRouterPath';
 import useUserType from '@/composables/useUserType';
 import useUserClaimsQuery from '@/composables/queries/useUserClaimsQuery';
 import useAdministrationsQuery from '@/composables/queries/useAdministrationsQuery';
+import useAdministrationScoreOverviewQuery from '@/composables/queries/useAdministrationScoreOverviewQuery';
 import useOrgQuery from '@/composables/queries/useOrgQuery';
 import useDistrictSchoolsQuery from '@/composables/queries/useDistrictSchoolsQuery';
 import useAdministrationAssignmentsQuery from '@/composables/queries/useAdministrationAssignmentsQuery';
@@ -515,6 +512,25 @@ const {
 } = useDistrictSupportCategoriesQuery(props.orgId, props.administrationId, {
   enabled: computed(() => initialized.value && props.orgType === 'district'),
 });
+
+// Server-computed support-level distributions per task: the source of the "at a glance"
+// chart VALUES, scoped to this org/class/group. Keyed by task slug to match the slug-based
+// `sortedAndFilteredTaskIds` the template iterates.
+//
+// NOTE (incremental): only the chart values move to the backend here. Which tasks show a
+// chart (`sortedAndFilteredTaskIds`) and the district loading / empty-state still derive
+// from the Firestore `useAdministrationAssignmentsQuery` / `useDistrictSupportCategoriesQuery`,
+// which also feed the table + subscore tables. They're unified onto the backend in the final
+// score-report cleanup PR once those components are migrated.
+const { data: scoreOverviewData } = useAdministrationScoreOverviewQuery(
+  props.administrationId,
+  props.orgType,
+  props.orgId,
+  { enabled: initialized },
+);
+const scoreOverviewBySlug = computed(() =>
+  Object.fromEntries((scoreOverviewData.value?.tasks ?? []).map((task) => [task.taskSlug, task.supportLevels])),
+);
 
 const getScoringVersions = computed(() => {
   if (!administrationData.value?.assessments) return {};

--- a/apps/dashboard/src/pages/ScoreReport.vue
+++ b/apps/dashboard/src/pages/ScoreReport.vue
@@ -424,6 +424,7 @@ import useUserType from '@/composables/useUserType';
 import useUserClaimsQuery from '@/composables/queries/useUserClaimsQuery';
 import useAdministrationsQuery from '@/composables/queries/useAdministrationsQuery';
 import useAdministrationScoreOverviewQuery from '@/composables/queries/useAdministrationScoreOverviewQuery';
+import useAdministrationScoreStudentsQuery from '@/composables/queries/useAdministrationScoreStudentsQuery';
 import useOrgQuery from '@/composables/queries/useOrgQuery';
 import useDistrictSchoolsQuery from '@/composables/queries/useDistrictSchoolsQuery';
 import useAdministrationAssignmentsQuery from '@/composables/queries/useAdministrationAssignmentsQuery';
@@ -851,7 +852,12 @@ const assignedNormedTaskIds = computed(() => assignedTaskIds.value.filter((id) =
 // Return a faded color if assessment is not reliable
 function returnColorByReliability(assessment, rawScore, support_level, tag_color) {
   if (assessment.reliable !== undefined && !assessment.reliable && assessment.engagementFlags !== undefined) {
-    const engagementFlagExists = Object.keys(assessment.engagementFlags).some((flag) =>
+    // engagementFlags may arrive as an array (backend / normalized rows) or a legacy
+    // Firestore object map (raw assessment) — normalize before reading.
+    const engagementFlags = Array.isArray(assessment.engagementFlags)
+      ? assessment.engagementFlags
+      : Object.keys(assessment.engagementFlags ?? {});
+    const engagementFlagExists = engagementFlags.some((flag) =>
       includedValidityFlags[assessment.taskId]?.includes(flag),
     );
     if (support_level === 'Optional') {
@@ -1102,7 +1108,11 @@ const computeAssignmentAndRunData = computed(() => {
           optional: isOptional,
           supportLevel: support_level,
           reliable: assessment.reliable,
-          engagementFlags: assessment.engagementFlags ?? [],
+          // engagementFlags is normalized to an array of flag-name strings (matching the
+          // backend score shape); legacy Firestore data carries it as an object map.
+          engagementFlags: Array.isArray(assessment.engagementFlags)
+            ? assessment.engagementFlags
+            : Object.keys(assessment.engagementFlags ?? {}),
           tagColor: tagColor,
           percentile: percentile,
           percentileString: percentileString,
@@ -1367,13 +1377,118 @@ const computeAssignmentAndRunData = computed(() => {
   }
 });
 
+// --- Backend per-student scores (the score-report table's core score source) ---
+// The table's core per-task scores (rawScore / percentile / standardScore / supportLevel
+// + reliability) come from the backend; the frontend owns presentation (color per level,
+// number formatting). The per-task "special" fields (percentCorrect, gradeEstimate, ROAM
+// fr/fc, …) and the CSV/PDF export still derive from `computeAssignmentAndRunData` — a
+// deferred follow-up. There is no student table at district scope, so the query is off there.
+const { data: studentScoresData } = useAdministrationScoreStudentsQuery(
+  props.administrationId,
+  props.orgType,
+  props.orgId,
+  { enabled: computed(() => initialized.value && props.orgType !== 'district') },
+);
+
+// The frontend owns the color for each backend support-level enum (`reliable: false` plus a
+// recognized engagement flag fades the color). The backend is the source of truth for the
+// level itself; `optional` / `null` levels keep the client-derived cell.
+const SUPPORT_LEVEL_DISPLAY = {
+  needsExtraSupport: { label: 'Needs Extra Support', color: SCORE_SUPPORT_LEVEL_COLORS.BELOW, faded: '#d6b8c7' },
+  developingSkill: { label: 'Developing Skill', color: SCORE_SUPPORT_LEVEL_COLORS.SOME, faded: '#e8dbb5' },
+  achievedSkill: { label: 'Achieved Skill', color: SCORE_SUPPORT_LEVEL_COLORS.ABOVE, faded: '#c0d9bd' },
+};
+
+// Non-normed tasks whose columns show task-specific values (percent correct, grade estimate,
+// correct/incorrect difference, raw-only) rather than the normed percentile/standard/raw the
+// backend overlay supplies. listStudents maps their `percentile`/`rawScore` to task-specific
+// numbers, so these keep their client-computed cells entirely (deferred follow-up).
+const SPECIAL_TASK_SLUGS = new Set([
+  ...tasksToDisplayPercentCorrect,
+  ...tasksToDisplayTotalCorrect,
+  ...tasksToDisplayGradeEstimate,
+  ...tasksToDisplayCorrectIncorrectDifference,
+  ...rawOnlyTasks,
+]);
+
+// Backend scores re-keyed: userId → { taskSlug → entry }. The table columns are slug-based,
+// while the response keys `scores` by task UUID.
+const backendScoresByUser = computed(() => {
+  const data = studentScoresData.value;
+  if (!data) return {};
+  const slugByUuid = Object.fromEntries(data.tasks.map((task) => [task.taskId, task.taskSlug]));
+  const byUser = {};
+  for (const row of data.students) {
+    const slugScores = {};
+    for (const [taskUuid, entry] of Object.entries(row.scores)) {
+      slugScores[slugByUuid[taskUuid] ?? taskUuid] = entry;
+    }
+    byUser[row.user.userId] = slugScores;
+  }
+  return byUser;
+});
+
+/**
+ * Overlay the backend per-student core scores onto the client-computed table rows.
+ *
+ * For each task the backend scores, the numeric fields (rawScore / percentile /
+ * standardScore) and the support-level classification + color are taken from the backend;
+ * the frontend formats them. Fields the backend leaves null (e.g. percentile for non-normed
+ * tasks) and the per-task "special" fields keep the client value, so the special-task
+ * columns and the CSV/PDF export are unaffected (deferred follow-up).
+ */
+const tableDataWithBackendScores = computed(() => {
+  const clientRows = computeAssignmentAndRunData.value.assignmentTableData;
+  const byUser = backendScoresByUser.value;
+  if (!clientRows.length || Object.keys(byUser).length === 0) return clientRows;
+
+  return clientRows.map((row) => {
+    const backendScores = byUser[row.user.userId];
+    if (!backendScores) return row;
+
+    const mergedScores = {};
+    for (const [slug, clientScore] of Object.entries(row.scores)) {
+      const entry = backendScores[slug];
+      // Special (non-normed) tasks keep their client-computed cell: listStudents maps their
+      // `percentile`/`rawScore` to task-specific values that don't belong in the normed
+      // columns, and those cells + the CSV export stay client-side (deferred follow-up).
+      if (!entry || SPECIAL_TASK_SLUGS.has(slug)) {
+        mergedScores[slug] = clientScore;
+        continue;
+      }
+
+      const merged = { ...clientScore };
+      if (entry.rawScore != null) merged.rawScore = entry.rawScore;
+      // Only the numeric `percentile` (the table cell) comes from the backend; keep the
+      // client's `percentileString`, which carries the >99 / <1 display cap the CSV export uses.
+      if (entry.percentile != null) merged.percentile = entry.percentile;
+      if (entry.standardScore != null) merged.standardScore = entry.standardScore;
+      if (entry.reliable != null) merged.reliable = entry.reliable;
+      if (entry.engagementFlags) merged.engagementFlags = entry.engagementFlags;
+
+      const levelInfo = entry.supportLevel ? SUPPORT_LEVEL_DISPLAY[entry.supportLevel] : null;
+      if (levelInfo) {
+        merged.supportLevel = levelInfo.label;
+        const faded =
+          entry.reliable === false &&
+          (entry.engagementFlags ?? []).some((flag) => includedValidityFlags[slug]?.includes(flag));
+        merged.tagColor = faded ? levelInfo.faded : levelInfo.color;
+      }
+
+      mergedScores[slug] = merged;
+    }
+
+    return { ...row, scores: mergedScores };
+  });
+});
+
 // This composable manages the data which is passed into the FilterBar component slot for filtering
 const filteredTableData = ref([]);
 
 watch(
-  computeAssignmentAndRunData,
+  tableDataWithBackendScores,
   (newValue) => {
-    filteredTableData.value = newValue.assignmentTableData;
+    filteredTableData.value = newValue;
   },
   { immediate: true, deep: true },
 );
@@ -1502,12 +1617,10 @@ const createExportData = ({ rows, includeProgress = false }) => {
 
       // Add reliability information
       if (score.reliable !== undefined && !score.reliable && score.engagementFlags !== undefined) {
-        const engagementFlags = Object.keys(score.engagementFlags);
+        const engagementFlags = score.engagementFlags;
         if (engagementFlags.length > 0) {
           if (includedValidityFlags[taskId]) {
-            const filteredFlags = Object.keys(score.engagementFlags).filter((flag) =>
-              includedValidityFlags[taskId].includes(flag),
-            );
+            const filteredFlags = score.engagementFlags.filter((flag) => includedValidityFlags[taskId].includes(flag));
             tableRow[`${taskName} - Reliability`] =
               filteredFlags.length === 0 ? 'Unreliable' : `Unreliable: ${filteredFlags.map(_lowerCase).join(', ')}`;
           } else {

--- a/apps/dashboard/src/pages/ScoreReport.vue
+++ b/apps/dashboard/src/pages/ScoreReport.vue
@@ -331,11 +331,7 @@
                     :task-id="taskId"
                     :initialized="initialized"
                     :administration-id="administrationId"
-                    :runs="
-                      orgType === 'district'
-                        ? aggregatedDistrictSupportCategories?.[taskId]
-                        : computeAssignmentAndRunData.runsByTaskId?.[taskId]
-                    "
+                    :facets="facetsByTask[taskId]"
                     :org-type="orgType"
                     :org-id="orgId"
                     :org-info="orgData"
@@ -425,6 +421,7 @@ import useUserClaimsQuery from '@/composables/queries/useUserClaimsQuery';
 import useAdministrationsQuery from '@/composables/queries/useAdministrationsQuery';
 import useAdministrationScoreOverviewQuery from '@/composables/queries/useAdministrationScoreOverviewQuery';
 import useAdministrationScoreStudentsQuery from '@/composables/queries/useAdministrationScoreStudentsQuery';
+import useAdministrationScoreFacetsQuery from '@/composables/queries/useAdministrationScoreFacetsQuery';
 import useOrgQuery from '@/composables/queries/useOrgQuery';
 import useDistrictSchoolsQuery from '@/composables/queries/useDistrictSchoolsQuery';
 import useAdministrationAssignmentsQuery from '@/composables/queries/useAdministrationAssignmentsQuery';
@@ -531,6 +528,21 @@ const { data: scoreOverviewData } = useAdministrationScoreOverviewQuery(
 );
 const scoreOverviewBySlug = computed(() =>
   Object.fromEntries((scoreOverviewData.value?.tasks ?? []).map((task) => [task.taskSlug, task.supportLevels])),
+);
+
+// Server-computed distribution facets per task (support-level + score bins, faceted by
+// grade and school) — the source for the per-task TaskReport distribution charts at ALL
+// scopes. This replaces both the client-side facet binning (non-district) and the Firestore
+// `aggregatedDistrictSupportCategories` feed (district); the charts no longer distinguish
+// scope. School facets are populated at district scope only (empty arrays elsewhere).
+const { data: scoreFacetsData } = useAdministrationScoreFacetsQuery(
+  props.administrationId,
+  props.orgType,
+  props.orgId,
+  { enabled: initialized },
+);
+const facetsByTask = computed(() =>
+  Object.fromEntries((scoreFacetsData.value?.tasks ?? []).map((task) => [task.taskSlug, task])),
 );
 
 const getScoringVersions = computed(() => {


### PR DESCRIPTION
## Summary

This PR cuts the score report's **distribution facets** over to the backend `getScoreFacets` endpoint — the third slice of the score-report frontend migration. The two per-task charts inside each `TaskReport` tab (`DistributionChartSupport` = support-level bars, `DistributionChartFacet` = score histograms) previously binned client-side over runs at non-district scope and read a separate Firestore aggregate (`aggregatedDistrictSupportCategories`) at district scope. Per the agreed direction, this **eliminates that frontend distinction**: both scopes now render from the same endpoint and the same code path, with no client-side binning.

> Stacked on `enh/score-report-students` → `enh/score-report-overview`. Merge bottom-up.

## Changes

- **`useAdministrationScoreFacetsQuery`** (new) — non-paginated composable for `client.administrations.scoreReports.getScoreFacets`, returning `{ totalStudents, tasks, computedAt }`. Mirrors `useAdministrationScoreOverviewQuery` (token + scope gating, envelope unwrap, structured errors, pinned retry). Unit test included.
- **`ScoreReport.vue`** — calls the query, builds `facetsByTask` (taskSlug → facet), and passes `:facets="facetsByTask[taskId]"` to `TaskReport` in place of the old `:runs` ternary.
- **`TaskReport.vue`** — `:runs` prop → `:facets`; `minGradeByRuns` now derives from `scoreBinsByGrade`; the Grade/School toggle is gated on `hasSchoolFacets` (district-only, data-driven) instead of `orgType === 'district'`.
- **`DistributionChartSupport.vue`** — reads `supportLevelByGrade` / `supportLevelBySchool`, mapping each entry onto the existing `{ category, support_levels:[below,some,above], totalStudents }` shape. The Vega spec is unchanged; only the data source moved. `totalStudents` = sum of the three classified levels (the Percent-mode denominator), matching the prior client aggregation.
- **`DistributionChartFacet.vue`** — rewritten to consume the pre-aggregated bins (`scoreBinsByGrade` / `scoreBinsBySchool`) directly via Vega-Lite `bin: 'binned'` (`x`=binStart, `x2`=binEnd, `y`=count). No client re-binning, so the histogram exactly reflects the server aggregation. Raw-score axes fit the server bin range; percentile stays fixed 0–100; the percentile-view "grades < 6" filter is preserved.

## Deliberately deferred (kept client-side)

- **Which task tabs appear** (`sortedAndFilteredSubscoreTaskIds`) and the **subscore tables** still derive from `computeAssignmentAndRunData` / `aggregatedDistrictSupportCategories` — those move in the subscore-tables PR (#4) and the final cleanup PR. Only the two distribution charts move here, so `runsByTaskId` / `aggregatedDistrictSupportCategories` remain in use elsewhere.
- **Now-unused pass-through props** on the two charts (`orgType` / `orgId` / `administrationId` / `initialized` — the charts no longer fetch) are left declared to keep this diff focused on the data cutover; the cleanup PR that restructures these components removes them.

## Testing

- Composable unit test (key, single-request unwrap, gating, error, retry). `prettier --check` and `@vue/compiler-sfc` compile pass.
- ⚠️ **Manual chart QA required before merge** (Vega doesn't render in the sandbox). For a known administration, compare against the prior charts:
  - **Non-district** (school/class/group): support bars per grade; histograms per grade in both Raw and Percentile modes; School toggle hidden.
  - **District**: School toggle present; support bars + histograms by both Grade and School; Percent vs Count mode on the support chart.
  - Confirm support-level **colors/order** (Needs Extra Support / Developing / Achieved), grade labels (K…12), and that counts/percentages match the old client-binned charts. Watch for zero-width single-value raw bins and the raw-axis range.



> [!NOTE]
> **Cross-fork stacking.** Because intermediate branches live only on `richford`, a `yeatmanlab/roar-dashboard` PR cannot use one as its base — every PR in this series targets `project/backend-refactor`, and they are reviewed/merged **bottom-up** so each shows only its own slice once its parent merges.

> [!IMPORTANT]
> **Merge order:** stacked on `enh/score-report-students` (#1980) — merge #1980 first; until it lands, this PR's diff sits on top of that branch's commits.

Resolves #1963
Part of #1958