### PR TITLE
Score report: cut the individual report (admin path) to the backend

### DIFF
--- a/apps/dashboard/src/components/reports/DistributionChartFacet.vue
+++ b/apps/dashboard/src/components/reports/DistributionChartFacet.vue
@@ -54,9 +54,13 @@ const props = defineProps({
       return { name: 'Grade', key: 'grade' };
     },
   },
-  runs: {
-    type: Array,
-    required: true,
+  facets: {
+    // Per-task facet aggregation from `getScoreFacets` (scoreBinsByGrade /
+    // scoreBinsBySchool). Each bin is `{ binStart, binEnd, count }`, already
+    // computed server-side. Null while the query is loading.
+    type: Object,
+    required: false,
+    default: null,
   },
   minGradeByRuns: {
     type: Number,
@@ -64,47 +68,11 @@ const props = defineProps({
   },
 });
 
-const makeRunsFromBins = ({ binsObj, facet, scoreKey }) => {
-  const rows = [];
-  if (!binsObj || typeof binsObj !== 'object') return rows;
-
-  for (const [binLabel, payload] of Object.entries(binsObj)) {
-    const [a, b] = String(binLabel).split('-').map(Number);
-    const value = Number.isFinite(a) && Number.isFinite(b) ? (a + b) / 2 : NaN;
-    if (!Number.isFinite(value)) continue;
-
-    if (facet === 'grade') {
-      const grades = payload?.grades ?? {};
-      for (const [gradeKey, countRaw] of Object.entries(grades)) {
-        const count = Number(countRaw) || 0;
-        for (let i = 0; i < count; i++) {
-          rows.push({
-            grade: String(gradeKey),
-            scores: { [scoreKey]: value },
-          });
-        }
-      }
-    } else {
-      const schools = payload?.schools ?? {};
-      for (const school of Object.values(schools)) {
-        const name = school?.name ?? 'Unknown school';
-        const count = Number(school?.count) || 0;
-        for (let i = 0; i < count; i++) {
-          rows.push({
-            user: { schoolName: name },
-            scores: { [scoreKey]: value },
-          });
-        }
-      }
-    }
-  }
-  return rows;
-};
+const { data: tasksDictionary, isLoading: isLoadingTasksDictionary } = useTasksDictionaryQuery();
 
 // Normalize facet mode to 'grade' | 'school'
 const facetKind = computed(() => (props.facetMode?.name === 'Grade' ? 'grade' : 'school'));
-
-const { data: tasksDictionary, isLoading: isLoadingTasksDictionary } = useTasksDictionaryQuery();
+const isGradeFacet = computed(() => props.facetMode.key === 'grade');
 
 const scoreMode = ref({ name: 'Raw Score', key: 'rawScore' });
 const scoreModes = [
@@ -112,72 +80,55 @@ const scoreModes = [
   { name: 'Percentile', key: 'stdPercentile' },
 ];
 
-const getBinSize = (scoreMode, taskId) => {
-  if (scoreMode === 'Percentile') {
-    return 10;
-  } else if (scoreMode === 'Raw Score') {
-    if (taskId === 'pa') return 5;
-    else if (taskId === 'sre') return 10;
-    else if (taskId === 'swr') return 50;
-  }
-  return 10;
-};
+// Leading-zero trim matches the prior client behavior (e.g. "01" → "1").
+const trimGrade = (grade) => String(grade ?? '').replace(/^0+(?=\D|\d)/, '');
+// Kindergarten / "0" sort as grade 0; everything else is its numeric grade.
+const gradeNumeric = (grade) => (grade === '0' || grade === 'Kindergarten' ? 0 : Number(grade));
 
-const getRangeLow = (scoreMode, taskId) => {
-  if (scoreMode === 'Percentile') {
-    return 0;
-  } else if (scoreMode === 'Raw Score') {
-    if (taskId === 'pa') return 0;
-    else if (taskId === 'sre') return 0;
-    else if (taskId === 'swr') return 100;
-  }
-  return 0;
-};
+const facetEntries = computed(() => {
+  if (!props.facets) return [];
+  return facetKind.value === 'grade' ? (props.facets.scoreBinsByGrade ?? []) : (props.facets.scoreBinsBySchool ?? []);
+});
 
-const getRangeHigh = (scoreMode, taskId) => {
-  if (scoreMode === 'Percentile') {
-    return 100;
-  } else if (scoreMode === 'Raw Score') {
-    if (taskId === 'pa') return 57;
-    else if (taskId === 'sre') return 130;
-    else if (taskId === 'swr') return 900;
-  }
-  return 100;
-};
-
-// With Percentile View, only display runs under grade 6
-const computedRuns = computed(() => {
-  if (props.orgType === 'district') {
-    const facet = facetKind.value;
-    const modeKey = scoreMode.value.name === 'Percentile' ? 'percentile' : 'raw';
-    const scoreKey = scoreMode.value.name === 'Percentile' ? 'stdPercentile' : 'rawScore';
-
-    const levels = ['above', 'some', 'below'];
-    const rows = [];
-
-    // if backend provided keyed bins (preferred)
-    const hasKeyed = levels.some((k) => props?.runs?.[k]?.[modeKey]);
-    if (hasKeyed) {
-      for (const levelKey of levels) {
-        const binsObj = props?.runs?.[levelKey]?.[modeKey];
-        if (binsObj) {
-          rows.push(...makeRunsFromBins({ binsObj, facet, scoreKey, levelKey }));
-        }
+// Flatten the per-facet pre-binned distributions into Vega rows. The backend bins
+// (`{ binStart, binEnd, count }`) are consumed directly via `bin: 'binned'` — no
+// client-side re-binning, so the histogram exactly reflects the server aggregation.
+const binValues = computed(() => {
+  const scoreKey = scoreMode.value.key === 'stdPercentile' ? 'percentile' : 'rawScore';
+  const rows = [];
+  for (const entry of facetEntries.value) {
+    if (facetKind.value === 'grade') {
+      const gradeNum = gradeNumeric(entry.grade);
+      // Percentile view is only meaningful for early grades — preserve the prior <6 filter.
+      if (scoreMode.value.key === 'stdPercentile' && gradeNum >= 6) continue;
+      for (const bin of entry[scoreKey] ?? []) {
+        rows.push({
+          facet: trimGrade(entry.grade),
+          gradeNumeric: gradeNum,
+          binStart: bin.binStart,
+          binEnd: bin.binEnd,
+          count: bin.count,
+        });
       }
     } else {
-      // fallback to flat shape: props.runs.percentile / props.runs.raw (no color by level)
-      rows.push(...makeRunsFromBins({ binsObj: props?.runs?.[modeKey], facet, scoreKey }));
+      const name = entry.schoolName ?? 'Unknown school';
+      for (const bin of entry[scoreKey] ?? []) {
+        rows.push({ facet: name, gradeNumeric: null, binStart: bin.binStart, binEnd: bin.binEnd, count: bin.count });
+      }
     }
-
-    return rows;
   }
-
-  // non-district (original)
-  if (scoreMode.value.name === 'Percentile' && props.facetMode.name === 'Grade') {
-    return props.runs.filter((run) => Number(run.grade) < 6);
-  }
-  return props.runs;
+  return rows;
 });
+
+// Percentile is a fixed 0–100 axis; raw-score axes fit the server's bin range.
+const xDomain = computed(() => {
+  if (scoreMode.value.key === 'stdPercentile') return [0, 100];
+  const starts = binValues.value.map((b) => b.binStart);
+  const ends = binValues.value.map((b) => b.binEnd);
+  if (!starts.length) return [0, 100];
+  return [Math.min(...starts), Math.max(...ends)];
+});
+
 const distributionChartFacet = computed(() => {
   if (isLoadingTasksDictionary.value) return {};
   return {
@@ -190,22 +141,14 @@ const distributionChartFacet = computed(() => {
       dx: 70,
     },
     data: {
-      values: computedRuns.value,
+      values: binValues.value,
     },
-    transform: isGradeFacet.value
-      ? [
-          {
-            calculate: "datum.grade === '0' || datum.grade === 'Kindergarten' ? 0 : toNumber(datum.grade)",
-            as: 'gradeNumeric',
-          },
-        ]
-      : [],
     mark: 'bar',
     height: 50,
     width: 360,
     encoding: {
       row: {
-        field: isGradeFacet.value ? 'gradeNumeric' : `user.${props.facetMode.key}`,
+        field: isGradeFacet.value ? 'gradeNumeric' : 'facet',
         type: isGradeFacet.value ? 'quantitative' : 'ordinal',
         title: '',
         header: {
@@ -236,12 +179,11 @@ const distributionChartFacet = computed(() => {
       },
 
       x: {
-        field: `scores.${scoreMode.value.key}`,
+        field: 'binStart',
+        bin: 'binned',
+        type: 'quantitative',
         title: scoreMode.value.name,
-        bin: {
-          step: getBinSize(scoreMode.value.name, props.taskId),
-          extent: [getRangeLow(scoreMode.value.name, props.taskId), getRangeHigh(scoreMode.value.name, props.taskId)],
-        },
+        scale: { domain: xDomain.value },
         sort: 'ascending',
         axis: {
           labelAngle: 0,
@@ -250,10 +192,11 @@ const distributionChartFacet = computed(() => {
           labelFontSize: 14,
         },
       },
+      x2: { field: 'binEnd' },
 
       y: {
+        field: 'count',
         type: 'quantitative',
-        aggregate: 'count',
         title: 'Count',
         sort: 'ascending',
         axis: {
@@ -268,14 +211,10 @@ const distributionChartFacet = computed(() => {
         },
       },
       tooltip: [
-        {
-          field: `scores.${scoreMode.value.key}`,
-          title: `${scoreMode.value.name}`,
-          type: 'quantitative',
-          format: `.0f`,
-        },
-        props.facetMode.name === 'Grade' ? { field: 'grade', title: 'Student Grade' } : {},
-        { aggregate: 'count', title: 'Student Count' },
+        { field: 'binStart', title: `${scoreMode.value.name} (min)`, type: 'quantitative', format: '.0f' },
+        { field: 'binEnd', title: `${scoreMode.value.name} (max)`, type: 'quantitative', format: '.0f' },
+        isGradeFacet.value ? { field: 'gradeNumeric', title: 'Student Grade' } : { field: 'facet', title: 'School' },
+        { field: 'count', title: 'Student Count', type: 'quantitative' },
       ],
     },
     resolve: {
@@ -297,28 +236,10 @@ const draw = async () => {
   await embed(`#roar-distribution-chart-${props.taskId}`, chartSpecDist);
 };
 
-const isGradeFacet = computed(() => props.facetMode.key === 'grade');
-
-// Watch for changes to the computed chart specification (includes tasksDictionary loading)
+// Redraw whenever the computed chart spec changes (covers facets, facetMode,
+// scoreMode, and tasksDictionary loading).
 watch(
   () => distributionChartFacet.value,
-  () => {
-    draw();
-  },
-  { deep: true },
-);
-
-// Update Distribution Graph on external facetMode change
-watch(
-  () => props.facetMode,
-  () => {
-    draw();
-  },
-);
-
-// Update Distribution Graph on computedRuns recalculation
-watch(
-  () => computedRuns,
   () => {
     draw();
   },

--- a/apps/dashboard/src/components/reports/DistributionChartOverview.vue
+++ b/apps/dashboard/src/components/reports/DistributionChartOverview.vue
@@ -21,6 +21,15 @@ const props = defineProps({
     type: Array,
     required: false,
   },
+  // Backend-aggregated support-level counts from the score-overview endpoint,
+  // shaped `{ needsExtraSupport: { count }, developingSkill: { count }, achievedSkill: { count } }`.
+  // When provided, it is the chart's data source and `runs` is ignored — this is
+  // the server-computed replacement for the client-side `runs` aggregation.
+  supportLevelCounts: {
+    type: Object,
+    required: false,
+    default: undefined,
+  },
   orgType: {
     type: String,
     required: true,
@@ -47,13 +56,30 @@ const props = defineProps({
 
 const { data: tasksDictionary, isLoading: isLoadingTasksDictionary } = useTasksDictionaryQuery();
 
+// Maps the score-overview endpoint's support-level keys to the chart's display
+// categories (which match the color-scale domain below).
+const BACKEND_SUPPORT_LEVEL_LABELS = {
+  needsExtraSupport: 'Needs Extra Support',
+  developingSkill: 'Developing Skill',
+  achievedSkill: 'Achieved Skill',
+};
+
 const supportLevelsOverview = computed(() => {
+  // Preferred path: server-aggregated counts from the score-overview endpoint.
+  if (props.supportLevelCounts) {
+    return Object.entries(BACKEND_SUPPORT_LEVEL_LABELS).map(([key, category]) => ({
+      category,
+      value: props.supportLevelCounts[key]?.count ?? 0,
+    }));
+  }
+  // Legacy Firestore paths (district aggregate object / per-run array). Guard
+  // first so an absent `runs` can't throw in the district branch below.
+  if (!props.runs) return [];
   if (props.orgType === 'district') {
     return Object.entries(props.runs)
       .filter(([support_level]) => MATCHING_SUPPORT_LEVELS[support_level] != undefined)
       .map(([support_level, total]) => ({ category: MATCHING_SUPPORT_LEVELS[support_level], value: total.total }));
   }
-  if (!props.runs) return [];
   let values = {};
   for (const { scores } of props.runs) {
     const support_level = scores.support_level;
@@ -129,7 +155,7 @@ const draw = async () => {
 };
 
 watch(
-  [() => overviewDistributionChart.value, () => props.runs, () => props.orgType],
+  [() => overviewDistributionChart.value, () => props.runs, () => props.supportLevelCounts, () => props.orgType],
   () => {
     if (props.taskId !== 'letter') {
       draw();

--- a/apps/dashboard/src/components/reports/DistributionChartSupport.vue
+++ b/apps/dashboard/src/components/reports/DistributionChartSupport.vue
@@ -43,9 +43,12 @@ const props = defineProps({
     type: String,
     required: true,
   },
-  runs: {
-    type: Array,
-    required: true,
+  facets: {
+    // Per-task facet aggregation from `getScoreFacets` (supportLevelByGrade /
+    // supportLevelBySchool). Null while the query is loading.
+    type: Object,
+    required: false,
+    default: null,
   },
   facetMode: {
     type: Object,
@@ -56,95 +59,30 @@ const props = defineProps({
   },
 });
 
-const districtGradeSupportBreakdown = computed(() => {
-  // For district-level aggregation: { above/some/below: { grades: { "1": n, ... } } }
-  if (props.orgType === 'district') {
-    const supportLevelIndexMap = { below: 0, some: 1, above: 2 }; // matches chart order
-    const gradeMap = new Map(); // key = grade
+// Leading-zero trim matches the prior client behavior (e.g. "01" → "1").
+const trimGrade = (grade) => String(grade ?? '').replace(/^0+(?=\D|\d)/, '');
 
-    ['below', 'some', 'above'].forEach((level) => {
-      const grades = props?.runs?.[level]?.grades ?? {};
-      Object.entries(grades).forEach(([grade, count]) => {
-        // Trim grades of leading zeros
-        const trimmedGrade = grade.replace(/^0+(?=\D|\d)/, '');
-        if (!gradeMap.has(trimmedGrade)) {
-          gradeMap.set(trimmedGrade, { category: trimmedGrade, support_levels: [0, 0, 0], totalStudents: 0 });
-        }
-        const row = gradeMap.get(trimmedGrade);
-        row.support_levels[supportLevelIndexMap[level]] += count;
-        row.totalStudents += count;
-      });
-    });
-
-    return Array.from(gradeMap.values());
-  }
-
-  // For school- or class-level aggregation
-  const gradeCounts = [];
-  for (const run of props.runs) {
-    const rawGrade = run?.user?.grade;
-    // Trim grades of leading zeros
-    const trimmedGrade = rawGrade.replace(/^0+(?=\D|\d)/, '');
-    let gradeCounter = gradeCounts.find((g) => g.category === trimmedGrade);
-    if (!gradeCounter) {
-      gradeCounter = { category: trimmedGrade, support_levels: [0, 0, 0], totalStudents: 0 };
-      gradeCounts.push(gradeCounter);
-    }
-
-    const supportLevel = run?.scores?.support_level;
-    if (supportLevel === 'Needs Extra Support') gradeCounter.support_levels[0]++;
-    else if (supportLevel === 'Developing Skill') gradeCounter.support_levels[1]++;
-    else if (supportLevel === 'Achieved Skill') gradeCounter.support_levels[2]++;
-    else continue; // skip null or undefined support levels
-
-    gradeCounter.totalStudents++;
-  }
-  return gradeCounts;
+// Map a backend support-level facet entry to the chart's intermediate shape.
+// `totalStudents` is the sum of the three classified levels — the Percent-mode
+// denominator — and intentionally excludes optional/null levels, matching the
+// prior client aggregation (which only counted runs with a classified level).
+const toBreakdownRow = (category, entry) => ({
+  category,
+  support_levels: [entry.needsExtraSupport.count, entry.developingSkill.count, entry.achievedSkill.count],
+  totalStudents: entry.needsExtraSupport.count + entry.developingSkill.count + entry.achievedSkill.count,
 });
 
-const districtSchoolSupportBreakdown = computed(() => {
-  // For district-level aggregation: { above/some/below: { schools: { name: n, ... } } }
-  if (props.orgType === 'district') {
-    const supportLevelIndexMap = { below: 0, some: 1, above: 2 };
-    const schoolMap = new Map(); // key = school name
+const gradeSupportBreakdown = computed(() =>
+  (props.facets?.supportLevelByGrade ?? []).map((entry) => toBreakdownRow(trimGrade(entry.grade), entry)),
+);
 
-    ['below', 'some', 'above'].forEach((level) => {
-      const schools = props?.runs?.[level]?.schools ?? {};
-      Object.values(schools).forEach(({ name, count }) => {
-        const key = name ?? 'Unknown school';
-        if (!schoolMap.has(key)) {
-          schoolMap.set(key, { category: key, support_levels: [0, 0, 0], totalStudents: 0 });
-        }
-        const row = schoolMap.get(key);
-        row.support_levels[supportLevelIndexMap[level]] += count;
-        row.totalStudents += count;
-      });
-    });
-
-    return Array.from(schoolMap.values());
-  }
-
-  // For non-district orgs (class, school, group, etc.)
-  const schoolCounts = [];
-  for (const run of props.runs) {
-    const schoolName = run?.user?.schoolName ?? 'Unknown school';
-    let schoolCounter = schoolCounts.find((s) => s.category === schoolName);
-    if (!schoolCounter) {
-      schoolCounter = { category: schoolName, support_levels: [0, 0, 0], totalStudents: 0 };
-      schoolCounts.push(schoolCounter);
-    }
-
-    const supportLevel = run?.scores?.support_level;
-    if (supportLevel === 'Needs Extra Support') schoolCounter.support_levels[0]++;
-    else if (supportLevel === 'Developing Skill') schoolCounter.support_levels[1]++;
-    else if (supportLevel === 'Achieved Skill') schoolCounter.support_levels[2]++;
-    else return; // skip null or undefined support levels
-
-    schoolCounter.totalStudents++;
-  }
-
-  return schoolCounts;
-});
+// Empty at non-district scope — the backend returns empty school arrays there
+// (the school-facet toggle is district-only).
+const schoolSupportBreakdown = computed(() =>
+  (props.facets?.supportLevelBySchool ?? []).map((entry) =>
+    toBreakdownRow(entry.schoolName ?? 'Unknown school', entry),
+  ),
+);
 
 const xMode = ref({ name: 'Percent' });
 const xModes = [{ name: 'Percent' }, { name: 'Count' }];
@@ -180,8 +118,8 @@ function returnValueByIndex(index, xMode, grade) {
 }
 
 const returnSupportLevelValues = computed(() => {
-  const gradeCounts = districtGradeSupportBreakdown.value;
-  const schoolCounts = districtSchoolSupportBreakdown.value;
+  const gradeCounts = gradeSupportBreakdown.value;
+  const schoolCounts = schoolSupportBreakdown.value;
   const counts = props.facetMode.name === 'Grade' ? gradeCounts : schoolCounts;
   const values = [];
 
@@ -324,7 +262,7 @@ const draw = async () => {
 };
 
 watch(
-  [() => distributionBySupport.value, () => props.facetMode, () => props.runs],
+  [() => distributionBySupport.value, () => props.facetMode, () => props.facets],
   () => {
     draw();
   },

--- a/apps/dashboard/src/components/reports/SubscoreTable.vue
+++ b/apps/dashboard/src/components/reports/SubscoreTable.vue
@@ -2,32 +2,27 @@
   <h2 class="header-text">{{ _toUpper(taskName) }} SCORE TABLE</h2>
   <RoarDataTable
     :columns="columns"
-    :data="computedTableData"
+    :data="students"
     :page-limit="pageLimit"
+    :loading="isLoading"
     :allow-filtering="false"
     @export-all="exportAll"
     @export-selected="exportSelected"
   />
 </template>
 <script setup>
-import { computed, ref, onMounted } from 'vue';
-import _get from 'lodash/get';
+import { computed, ref } from 'vue';
 import _kebabCase from 'lodash/kebabCase';
-import _set from 'lodash/set';
 import _toUpper from 'lodash/toUpper';
 import { exportCsv } from '@/helpers/query/utils';
-import { useAuthStore } from '@/store/auth';
 import RoarDataTable from '@/components/RoarDataTable';
-import {
-  roamAlpacaSubskills,
-  roamAlpacaSubskillHeaders,
-  roamFluencySubskillHeaders,
-  roamFluencyTasks,
-} from '@/helpers/reports';
+import useAdministrationTaskSubscoresQuery from '@/composables/queries/useAdministrationTaskSubscoresQuery';
 
 const props = defineProps({
   administrationId: { type: String, default: '' },
-  computedTableData: { type: Array, default: () => [] },
+  // Task UUID — the subscores endpoint is keyed by UUID (not the slug). Resolved
+  // upstream from the report's task metadata; null until that loads.
+  taskUuid: { type: String, default: '' },
   taskId: { type: String, required: true },
   taskName: { type: String, required: true },
   orgType: { type: String, default: '' },
@@ -36,286 +31,79 @@ const props = defineProps({
   orgName: { type: String, default: '' },
 });
 
-const authStore = useAuthStore();
-
-const initialized = ref(false);
-
 const pageLimit = ref(10);
 
+// The server computes the per-task subscore breakdown and declares its columns,
+// so the table renders from `subscoreColumns` instead of hard-coding column lists
+// per task slug. Gating (token + ids) lives in the composable.
+const { data: subscoreData, isLoading } = useAdministrationTaskSubscoresQuery(
+  computed(() => props.administrationId),
+  computed(() => props.taskUuid),
+  computed(() => props.orgType),
+  computed(() => props.orgId),
+);
+
+const students = computed(() => subscoreData.value?.students ?? []);
+const subscoreColumns = computed(() => subscoreData.value?.subscoreColumns ?? []);
+
 const columns = computed(() => {
+  const rows = students.value;
   const tableColumns = [];
-  if (props.computedTableData.find((assignment) => assignment.user?.username)) {
-    tableColumns.push({
-      field: 'user.username',
-      header: 'Username',
-      dataType: 'text',
-      pinned: true,
-      sort: true,
-      filter: true,
-    });
+  if (rows.find((row) => row.user?.username)) {
+    tableColumns.push({ field: 'user.username', header: 'Username', dataType: 'text', pinned: true, sort: true });
   }
-  if (props.computedTableData.find((assignment) => assignment.user?.email)) {
-    tableColumns.push({
-      field: 'user.email',
-      header: 'Email',
-      dataType: 'text',
-      pinned: true,
-      sort: true,
-      filter: true,
-    });
+  if (rows.find((row) => row.user?.email)) {
+    tableColumns.push({ field: 'user.email', header: 'Email', dataType: 'text', pinned: true, sort: true });
   }
-  if (props.computedTableData.find((assignment) => assignment.user?.firstName)) {
-    tableColumns.push({ field: 'user.firstName', header: 'First Name', dataType: 'text', sort: true, filter: true });
+  if (rows.find((row) => row.user?.firstName)) {
+    tableColumns.push({ field: 'user.firstName', header: 'First Name', dataType: 'text', sort: true });
   }
-  if (props.computedTableData.find((assignment) => assignment.user?.lastName)) {
-    tableColumns.push({ field: 'user.lastName', header: 'Last Name', dataType: 'text', sort: true, filter: true });
+  if (rows.find((row) => row.user?.lastName)) {
+    tableColumns.push({ field: 'user.lastName', header: 'Last Name', dataType: 'text', sort: true });
   }
-  tableColumns.push({ field: 'user.grade', header: 'Grade', dataType: 'text', sort: true, filter: true });
-
+  tableColumns.push({ field: 'user.grade', header: 'Grade', dataType: 'text', sort: true });
   if (props.orgType === 'district') {
-    tableColumns.push({
-      field: 'user.schoolName',
-      header: 'School',
-      dataType: 'text',
-      sort: true,
-      filter: true,
-    });
+    tableColumns.push({ field: 'user.schoolName', header: 'School', dataType: 'text', sort: true });
   }
-  if (props.taskId === 'letter' || props.taskId === 'letter-en-ca') {
-    tableColumns.push(
-      { field: `scores.${props.taskId}.lowerCaseScore`, header: 'Lower Case', dataType: 'text', sort: false },
-      { field: `scores.${props.taskId}.upperCaseScore`, header: 'Upper Case', dataType: 'text', sort: false },
-      { field: `scores.${props.taskId}.phonemeScore`, header: 'Letter Sounds', dataType: 'text', sort: false },
-      { field: `scores.${props.taskId}.totalScore`, header: 'Total', dataType: 'text', sort: false },
-      { field: `scores.${props.taskId}.incorrectLetters`, header: 'Letters To Work On', dataType: 'text', sort: false },
-      { field: `scores.${props.taskId}.incorrectPhonemes`, header: 'Sounds To Work On', dataType: 'text', sort: false },
-    );
-  }
-  if (props.taskId === 'pa') {
-    tableColumns.push(
-      { field: 'scores.pa.firstSound', header: 'First Sound', dataType: 'text', sort: false },
-      { field: 'scores.pa.lastSound', header: 'Last Sound', dataType: 'text', sort: false },
-      { field: 'scores.pa.deletion', header: 'Deletion', dataType: 'text', sort: false },
-      { field: 'scores.pa.total', header: 'Total', dataType: 'text', sort: false },
-      { field: 'scores.pa.skills', header: 'Skills To Work On', dataType: 'text', sort: false },
-    );
-  }
-  if (roamFluencyTasks.includes(props.taskId)) {
-    tableColumns.push(
-      { field: `scores.${props.taskId}.fr.rawScore`, header: 'Free Response', dataType: 'text', sort: false },
-      { field: `scores.${props.taskId}.fc.rawScore`, header: 'Multiple Choice', dataType: 'text', sort: false },
-    );
-  }
-  if (props.taskId === 'phonics') {
-    const subcategories = [
-      { field: 'cvc', header: 'CVC' },
-      { field: 'digraph', header: 'Digraph' },
-      { field: 'initial_blend', header: 'Initial Blend' },
-      { field: 'tri_blend', header: 'Triple Blend' },
-      { field: 'final_blend', header: 'Final Blend' },
-      { field: 'r_controlled', header: 'R-Controlled' },
-      { field: 'r_cluster', header: 'R-Cluster' },
-      { field: 'silent_e', header: 'Silent E' },
-      { field: 'vowel_team', header: 'Vowel Team' },
-    ];
 
-    // Add columns for each subcategory
-    subcategories.forEach(({ field, header }) => {
-      tableColumns.push({
-        field: `scores.${props.taskId}.composite.subscores.${field}`,
-        header: header,
-        dataType: 'text',
-        sort: true,
-        tooltip: false,
-        body: (row) => {
-          return _get(row, `scores.${props.taskId}.composite.subscores.${field}`) || '0/0';
-        },
-      });
-    });
-
-    // Add total percentage
-    tableColumns.push({
-      field: `scores.${props.taskId}.composite.totalPercentCorrect`,
-      header: 'Total % Correct',
-      dataType: 'number',
-      sort: true,
-      tooltip: false,
-      body: (row) => {
-        const totalPercent = _get(row, `scores.${props.taskId}.composite.totalPercentCorrect`);
-        return typeof totalPercent === 'number' ? `${Math.round(totalPercent)}%` : '0%';
-      },
-    });
-
-    // Hide skills to work on
-    // tableColumns.push({
-    //   field: `scores.${props.taskId}.skillsToWorkOn`,
-    //   header: 'Skills To Work On',
-    //   dataType: 'text',
-    //   sort: false,
-    //   tooltip: false,
-    // });
-  }
-  if (props.taskId === 'roam-alpaca') {
-    const gradeEstimate = `scores.${props.taskId}.gradeEstimate`;
-    tableColumns.push({
-      field: `scores.${props.taskId}.composite.roarScore`,
-      header: 'Raw Score',
-      dataType: 'text',
-      tagColor: `scores.${props.taskId}.composite.tagColor`,
-      sort: false,
-    });
-    Object.entries(roamAlpacaSubskills).forEach(([subskillId, subskill]) => {
-      tableColumns.push({
-        field: `scores.${props.taskId}.${subskillId}.percentCorrect`,
-        header: subskill,
-        dataType: 'text',
-        sort: false,
-        tagColor: `scores.${props.taskId}.${subskillId}.tagColor`,
-        ...(gradeEstimate && { gradeEstimate }),
-      });
-    });
-    tableColumns.push({
-      field: `scores.${props.taskId}.composite.incorrectSkills`,
-      header: 'Skills To Work On',
-      dataType: 'text',
-      sort: false,
-    });
+  // One column per server-declared subscore; values are looked up by key from each
+  // row's `subscores` map. Sort is disabled because cells mix display strings
+  // ("15/19", comma lists) and numbers.
+  for (const column of subscoreColumns.value) {
+    tableColumns.push({ field: `subscores.${column.key}`, header: column.label, dataType: 'text', sort: false });
   }
   return tableColumns;
 });
 
-const exportSelected = (selectedRows) => {
-  const computedExportData = selectedRows.map(({ user, scores }) => {
-    let tableRow = {
-      Username: _get(user, 'username'),
-      First: _get(user, 'firstName'),
-      Last: _get(user, 'lastName'),
-      Grade: _get(user, 'grade'),
+// Build CSV rows from the same server data: student identity columns + one column
+// per declared subscore (keyed by label).
+const buildExportRows = (rows) =>
+  rows.map(({ user, subscores }) => {
+    const tableRow = {
+      Username: user?.username,
+      First: user?.firstName,
+      Last: user?.lastName,
+      Grade: user?.grade,
     };
-    if (props.taskId === 'letter' || props.taskId === 'letter-en-ca') {
-      _set(tableRow, 'Lower Case', _get(scores, `${props.taskId}.lowerCaseScore`));
-      _set(tableRow, 'Upper Case', _get(scores, `${props.taskId}.upperCaseScore`));
-      _set(tableRow, 'Letter Sounds', _get(scores, `${props.taskId}.phonemeScore`));
-      _set(tableRow, 'Total', _get(scores, `${props.taskId}.totalScore`));
-      _set(tableRow, 'Letters To Work On', _get(scores, `${props.taskId}.incorrectLetters`));
-      _set(tableRow, 'Sounds To Work On', _get(scores, `${props.taskId}.incorrectPhonemes`));
+    if (props.orgType === 'district') {
+      tableRow.School = user?.schoolName;
     }
-    if (props.taskId === 'pa') {
-      _set(tableRow, 'First Sound', _get(scores, 'pa.firstSound'));
-      _set(tableRow, 'Last Sound', _get(scores, 'pa.lastSound'));
-      _set(tableRow, 'Deletion', _get(scores, 'pa.deletion'));
-      _set(tableRow, 'Total', _get(scores, 'pa.total'));
-      _set(tableRow, 'Skills To Work On', _get(scores, 'pa.skills'));
-    }
-    if (roamFluencyTasks.includes(props.taskId)) {
-      Object.entries(roamFluencySubskillHeaders).forEach(([property, propertyHeader]) => {
-        _set(tableRow, `Free Response - ${propertyHeader}`, _get(scores, `${props.taskId}.fr.${property}`));
-      });
-
-      Object.entries(roamFluencySubskillHeaders).forEach(([property, propertyHeader]) => {
-        _set(tableRow, `Multiple Choice - ${propertyHeader}`, _get(scores, `${props.taskId}.fc.${property}`));
-      });
-    }
-    if (props.taskId === 'phonics') {
-      const subcategories = [
-        'cvc',
-        'digraph',
-        'initial_blend',
-        'tri_blend',
-        'final_blend',
-        'r_controlled',
-        'r_cluster',
-        'silent_e',
-        'vowel_team',
-      ];
-      subcategories.forEach((category) => {
-        const subscore = _get(scores, `${props.taskId}.composite.subscores.${category}`);
-        _set(
-          tableRow,
-          `${category} (Correct/Attempted)`,
-          subscore ? `${subscore.correct}/${subscore.attempted}` : '0/0',
-        );
-      });
-      _set(tableRow, 'Total % Correct', _get(scores, `${props.taskId}.composite.totalPercentCorrect`));
-      _set(tableRow, 'Skills To Work On', _get(scores, `${props.taskId}.skillsToWorkOn`));
-    }
-    if (props.taskId === 'roam-alpaca') {
-      _set(tableRow, 'Raw Score', _get(scores, `${props.taskId}.composite.roarScore`));
-      _set(tableRow, 'Grade Estimate', _get(scores, `${props.taskId}.composite.gradeEstimate`));
-      Object.entries(roamAlpacaSubskills).forEach(([subskillId, subskill]) => {
-        Object.entries(roamAlpacaSubskillHeaders).forEach(([property, propertyHeader]) => {
-          _set(tableRow, `${subskill} - ${propertyHeader}`, _get(scores, `${props.taskId}.${subskillId}.${property}`));
-        });
-      });
-      _set(tableRow, 'Skills To Work On', _get(scores, `${props.taskId}.composite.incorrectSkills`));
+    for (const column of subscoreColumns.value) {
+      tableRow[column.label] = subscores?.[column.key] ?? '';
     }
     return tableRow;
   });
-  exportCsv(computedExportData, `roar-scores-${_kebabCase(props.taskId)}-selected.csv`);
-  return;
+
+const exportSelected = (selectedRows) => {
+  exportCsv(buildExportRows(selectedRows), `roar-scores-${_kebabCase(props.taskId)}-selected.csv`);
 };
 
-const exportAll = async () => {
-  const computedExportData = props.computedTableData.map(({ user, scores }) => {
-    let tableRow = {
-      Username: _get(user, 'username'),
-      First: _get(user, 'firstName'),
-      Last: _get(user, 'lastName'),
-      Grade: _get(user, 'grade'),
-    };
-    if (props.taskId === 'letter' || props.taskId === 'letter-en-ca') {
-      _set(tableRow, 'Lower Case', _get(scores, `${props.taskId}.lowerCaseScore`));
-      _set(tableRow, 'Upper Case', _get(scores, `${props.taskId}.upperCaseScore`));
-      _set(tableRow, 'Letter Sounds', _get(scores, `${props.taskId}.phonemeScore`));
-      _set(tableRow, 'Total', _get(scores, `${props.taskId}.totalScore`));
-      _set(tableRow, 'Letters To Work On', _get(scores, `${props.taskId}.incorrectLetters`));
-      _set(tableRow, 'Sounds To Work On', _get(scores, `${props.taskId}.incorrectPhonemes`));
-    } else if (props.taskId === 'pa') {
-      _set(tableRow, 'First Sound', _get(scores, 'pa.firstSound'));
-      _set(tableRow, 'Last Sound', _get(scores, 'pa.lastSound'));
-      _set(tableRow, 'Deletion', _get(scores, 'pa.deletion'));
-      _set(tableRow, 'Total', _get(scores, 'pa.total'));
-      _set(tableRow, 'Skills To Work On', _get(scores, 'pa.skills'));
-    } else if (roamFluencyTasks.includes(props.taskId)) {
-      Object.entries(roamFluencySubskillHeaders).forEach(([property, propertyHeader]) => {
-        _set(tableRow, `Free Response - ${propertyHeader}`, _get(scores, `${props.taskId}.fr.${property}`));
-      });
-
-      Object.entries(roamFluencySubskillHeaders).forEach(([property, propertyHeader]) => {
-        _set(tableRow, `Multiple Choice - ${propertyHeader}`, _get(scores, `${props.taskId}.fc.${property}`));
-      });
-    } else if (props.taskId === 'roam-alpaca') {
-      _set(tableRow, 'Raw Score', _get(scores, `${props.taskId}.composite.roarScore`));
-      _set(tableRow, 'Grade Estimate', _get(scores, `${props.taskId}.composite.gradeEstimate`));
-      Object.entries(roamAlpacaSubskills).forEach(([subskillId, subskill]) => {
-        Object.entries(roamAlpacaSubskillHeaders).forEach(([property, propertyHeader]) => {
-          _set(tableRow, `${subskill} - ${propertyHeader}`, _get(scores, `${props.taskId}.${subskillId}.${property}`));
-        });
-      });
-      _set(tableRow, 'Skills To Work On', _get(scores, `${props.taskId}.composite.incorrectSkills`));
-    }
-    return tableRow;
-  });
+const exportAll = () => {
   exportCsv(
-    computedExportData,
+    buildExportRows(students.value),
     `roar-scores-${_kebabCase(props.taskId)}-${_kebabCase(props.administrationName)}-${_kebabCase(props.orgName)}.csv`,
   );
-  return;
 };
-
-let unsubscribe;
-const refresh = () => {
-  if (unsubscribe) unsubscribe();
-  initialized.value = true;
-};
-
-unsubscribe = authStore.$subscribe(async (mutation, state) => {
-  if (state.accessToken) refresh();
-});
-
-onMounted(async () => {
-  if (authStore.isAuthReady) refresh();
-});
 </script>
 <style>
 .header-text {

--- a/apps/dashboard/src/components/reports/TableScoreTag.vue
+++ b/apps/dashboard/src/components/reports/TableScoreTag.vue
@@ -181,6 +181,8 @@ function handleSubskillToolTip(_taskId, _subskillId, _toolTip, _colData) {
 
 function getFlags(colData, taskId) {
   const flags = colData.scores[taskId]?.engagementFlags;
+  // engagementFlags may be an array (backend score shape) or a legacy object map — normalize.
+  const flagKeys = Array.isArray(flags) ? flags : Object.keys(flags ?? {});
   const flagMessages = {
     accuracyTooLow: 'Responses were inaccurate',
     notEnoughResponses: `Incomplete. This student may retake ${
@@ -194,14 +196,14 @@ function getFlags(colData, taskId) {
   if (flags && !colData.scores[taskId].reliable) {
     if (includedValidityFlags[taskId]) {
       // only display flags that are included in the includedValidityFlags object
-      const filteredFlags = Object.keys(flags).filter((flag) => includedValidityFlags[taskId].includes(flag));
+      const filteredFlags = flagKeys.filter((flag) => includedValidityFlags[taskId].includes(flag));
       const reliabilityFlags = filteredFlags.map((flag) => {
         return flagMessages[flag] || _lowerCase(flag);
       });
       if (reliabilityFlags.length === 0) return '';
       return 'Unreliable Score' + '\n' + ' - ' + reliabilityFlags.join('\n - ') + '\n\n';
     } else {
-      const reliabilityFlags = Object.keys(flags).map((flag) => {
+      const reliabilityFlags = flagKeys.map((flag) => {
         return flagMessages[flag] || _lowerCase(flag);
       });
       if (reliabilityFlags.length > 0) {

--- a/apps/dashboard/src/components/reports/tasks/TaskReport.vue
+++ b/apps/dashboard/src/components/reports/tasks/TaskReport.vue
@@ -46,81 +46,15 @@
   </div>
   <div v-if="orgType !== 'district'" class="my-2 mx-4">
     <SubscoreTable
-      v-if="taskId === 'phonics' && !isLoadingTasksDictionary"
-      task-id="phonics"
-      :task-name="tasksDictionary['phonics'].nameSimple"
+      v-if="tasksWithSubscores.includes(taskId) && taskUuid && !isLoadingTasksDictionary"
+      :task-id="taskId"
+      :task-uuid="taskUuid"
+      :task-name="tasksDictionary[taskId]?.nameSimple ?? taskId"
       :administration-id="administrationId"
       :org-type="orgType"
       :org-id="orgId"
       :administration-name="administrationInfo.name ?? undefined"
       :org-name="orgInfo.name ?? undefined"
-      :computed-table-data="computedTableData"
-    />
-    <SubscoreTable
-      v-if="taskId === 'letter' && !isLoadingTasksDictionary"
-      task-id="letter"
-      :task-name="tasksDictionary['letter'].nameSimple"
-      :administration-id="administrationId"
-      :org-type="orgType"
-      :org-id="orgId"
-      :administration-name="administrationInfo.name ?? undefined"
-      :org-name="orgInfo.name ?? undefined"
-      :computed-table-data="computedTableData"
-    />
-    <SubscoreTable
-      v-if="taskId === 'letter-en-ca' && !isLoadingTasksDictionary"
-      task-id="letter-en-ca"
-      :task-name="tasksDictionary['letter-en-ca'].nameSimple"
-      :administration-id="administrationId"
-      :org-type="orgType"
-      :org-id="orgId"
-      :administration-name="administrationInfo.name ?? undefined"
-      :org-name="orgInfo.name ?? undefined"
-      :computed-table-data="computedTableData"
-    />
-    <SubscoreTable
-      v-if="taskId === 'pa' && !isLoadingTasksDictionary"
-      task-id="pa"
-      :task-name="tasksDictionary['pa'].nameSimple"
-      :administration-id="administrationId"
-      :org-type="orgType"
-      :org-id="orgId"
-      :administration-name="administrationInfo.name ?? undefined"
-      :org-name="orgInfo.name ?? undefined"
-      :computed-table-data="computedTableData"
-    />
-    <SubscoreTable
-      v-if="taskId === 'fluency-calf' && !isLoadingTasksDictionary"
-      task-id="fluency-calf"
-      :task-name="tasksDictionary['fluency-calf'].nameSimple"
-      :administration-id="administrationId"
-      :org-type="orgType"
-      :org-id="orgId"
-      :administration-name="administrationInfo.name ?? undefined"
-      :org-name="orgInfo.name ?? undefined"
-      :computed-table-data="computedTableData"
-    />
-    <SubscoreTable
-      v-if="taskId === 'fluency-arf' && !isLoadingTasksDictionary"
-      task-id="fluency-arf"
-      :task-name="tasksDictionary['fluency-arf'].nameSimple"
-      :administration-id="administrationId"
-      :org-type="orgType"
-      :org-id="orgId"
-      :administration-name="administrationInfo.name ?? undefined"
-      :org-name="orgInfo.name ?? undefined"
-      :computed-table-data="computedTableData"
-    />
-    <SubscoreTable
-      v-if="taskId === 'roam-alpaca' && !isLoadingTasksDictionary"
-      task-id="roam-alpaca"
-      :task-name="tasksDictionary['roam-alpaca'].nameSimple"
-      :administration-id="administrationId"
-      :org-type="orgType"
-      :org-id="orgId"
-      :administration-name="administrationInfo.name ?? undefined"
-      :org-name="orgInfo.name ?? undefined"
-      :computed-table-data="computedTableData"
     />
   </div>
 </template>
@@ -146,10 +80,6 @@ const props = defineProps({
     type: Object,
     required: true,
   },
-  computedTableData: {
-    type: Array,
-    required: true,
-  },
   orgType: {
     type: String,
     required: true,
@@ -165,6 +95,12 @@ const props = defineProps({
   taskId: {
     type: String,
     required: true,
+  },
+  taskUuid: {
+    // Task UUID for the subscores endpoint (path param); resolved upstream from
+    // the report's task metadata. Empty until that loads.
+    type: String,
+    default: '',
   },
   facets: {
     // Per-task facet aggregation from `getScoreFacets`; null while loading.
@@ -185,6 +121,10 @@ const facetModes = [
   { name: 'Grade', key: 'grade' },
   { name: 'School', key: 'schoolName' },
 ];
+
+// Tasks with a registered backend subscore schema — only these render a subscore
+// table. Others (e.g. SWR/SRE) have no subscore schema and 400 from the endpoint.
+const tasksWithSubscores = ['phonics', 'letter', 'letter-en-ca', 'pa', 'fluency-calf', 'fluency-arf', 'roam-alpaca'];
 
 // Kindergarten / "0" sort as grade 0; everything else is its numeric grade.
 const gradeNumeric = (grade) => (grade === '0' || grade === 'Kindergarten' ? 0 : Number(grade));

--- a/apps/dashboard/src/components/reports/tasks/TaskReport.vue
+++ b/apps/dashboard/src/components/reports/tasks/TaskReport.vue
@@ -8,7 +8,7 @@
     </div>
   </div>
   <div v-if="tasksToDisplayGraphs.includes(taskId)" :id="'tab-view-chart-' + taskId" class="chart-toggle-wrapper">
-    <div v-if="orgType === 'district'" class="mb-3" data-html2canvas-ignore="true">
+    <div v-if="hasSchoolFacets" class="mb-3" data-html2canvas-ignore="true">
       <div class="flex uppercase text-xs font-light justify-content-center align-items-center">view rows by</div>
       <PvSelectButton
         v-model="facetMode"
@@ -26,7 +26,7 @@
           :org-type="orgType"
           :org-id="orgId"
           :task-id="taskId"
-          :runs="runs"
+          :facets="facets"
           :facet-mode="facetMode"
         />
       </div>
@@ -37,7 +37,7 @@
           :org-type="orgType"
           :org-id="orgId"
           :task-id="taskId"
-          :runs="runs"
+          :facets="facets"
           :facet-mode="facetMode"
           :min-grade-by-runs="minGradeByRuns"
         />
@@ -166,9 +166,11 @@ const props = defineProps({
     type: String,
     required: true,
   },
-  runs: {
-    type: Array,
-    required: true,
+  facets: {
+    // Per-task facet aggregation from `getScoreFacets`; null while loading.
+    type: Object,
+    required: false,
+    default: null,
   },
   taskScoringVersions: {
     type: Object,
@@ -184,25 +186,22 @@ const facetModes = [
   { name: 'School', key: 'schoolName' },
 ];
 
+// Kindergarten / "0" sort as grade 0; everything else is its numeric grade.
+const gradeNumeric = (grade) => (grade === '0' || grade === 'Kindergarten' ? 0 : Number(grade));
+
+// Lowest grade present in the task's grade facets — drives whether the facet chart
+// offers the Raw/Percentile toggle (percentile is meaningful for early grades only).
 const minGradeByRuns = computed(() => {
-  if (props.orgType === 'district') {
-    // For district, props.runs is an object with support categories
-    // We need to extract all grade values from the nested structure
-    if (!props.runs || typeof props.runs !== 'object') {
-      return 0;
-    }
-    const allGrades = [];
-    Object.values(props.runs).forEach((category) => {
-      if (category && typeof category === 'object' && category.grades) {
-        allGrades.push(...Object.keys(category.grades));
-      }
-    });
-    return allGrades.length > 0 ? Math.min(...allGrades.map(Number)) : 0;
-  }
-  return Math.min(
-    ...props.runs.filter((run) => run.scores.rawScore || run.scores.stdPercentile).map((run) => run.grade),
-  );
+  const grades = (props.facets?.scoreBinsByGrade ?? [])
+    .map((entry) => gradeNumeric(entry.grade))
+    .filter((n) => Number.isFinite(n));
+  return grades.length ? Math.min(...grades) : 0;
 });
+
+// The school-facet toggle is shown only when the backend supplies school facets,
+// which happens at district scope (empty arrays elsewhere). This replaces the prior
+// explicit `orgType === 'district'` check — the data drives the UI.
+const hasSchoolFacets = computed(() => (props.facets?.supportLevelBySchool?.length ?? 0) > 0);
 
 const taskDesc = computed(() => {
   return replaceScoreRange(taskInfoById[props.taskId]?.desc, props.taskId, props.taskScoringVersions[props.taskId]);

--- a/apps/dashboard/src/composables/queries/useAdministrationIndividualScoreReportQuery.js
+++ b/apps/dashboard/src/composables/queries/useAdministrationIndividualScoreReportQuery.js
@@ -1,0 +1,97 @@
+import { toValue } from 'vue';
+import { useQuery } from '@tanstack/vue-query';
+import { StatusCodes } from 'http-status-codes';
+import { computeQueryOverrides } from '@/helpers/computeQueryOverrides';
+import { getRoarApiClient } from '@/clients/roar-api';
+import { useAuthStore } from '@/store/auth';
+import { isRosteringEndedError, isTerminalAuthError } from '@/utils/api-errors';
+import { ADMINISTRATION_INDIVIDUAL_REPORT_QUERY_KEY } from '@/constants/queryKeys';
+
+const MAX_RETRIES = 3;
+
+/**
+ * Administration individual-student-report query (administrator path).
+ *
+ * Fetches one student's complete scoreboard for one administration from
+ * `GET /v1/administrations/:id/reports/scores/students/:userId`, scoped via
+ * `scopeType` + `scopeId`. Not paginated — a single resource.
+ *
+ * Returns the unwrapped payload (`result.body.data`):
+ * `{ student, administration, tasks, completedTaskCount, totalTaskCount }`.
+ * Each task carries server-computed `scores` (`rawScore` / `percentile` /
+ * `standardScore`), `supportLevel`, `tags`, optional `subscores` /
+ * `skillsToWorkOn`, and per-task `historicalScores` for the longitudinal trend —
+ * replacing the Firestore `useUserRunPageQuery` + `useUserLongitudinalRunsQuery`
+ * for the administrator-scoped report.
+ *
+ * This is the administrator path. The guardian/parent path is a separate
+ * longitudinal endpoint (`getGuardianStudentReport`) — see its own composable.
+ *
+ * **Enablement.** Internally gated on `authStore.accessToken` AND truthy
+ * `administrationId` / `userId` / `scopeType` / `scopeId`; callers AND extra
+ * conditions via `queryOptions.enabled`.
+ *
+ * @param {import('vue').MaybeRefOrGetter<String>} administrationId – The administration's UUID.
+ * @param {import('vue').MaybeRefOrGetter<String>} userId – The student's UUID.
+ * @param {import('vue').MaybeRefOrGetter<String>} scopeType – 'district' | 'school' | 'class' | 'group'.
+ * @param {import('vue').MaybeRefOrGetter<String>} scopeId – The scoping entity's UUID.
+ * @param {Object|undefined} queryOptions – Optional TanStack query options.
+ * @returns {import('@tanstack/vue-query').UseQueryReturnType} Resolves to the individual-report payload.
+ */
+const useAdministrationIndividualScoreReportQuery = (
+  administrationId,
+  userId,
+  scopeType,
+  scopeId,
+  queryOptions = undefined,
+) => {
+  const authStore = useAuthStore();
+  const conditions = [
+    () => Boolean(authStore.accessToken),
+    () => Boolean(toValue(administrationId)),
+    () => Boolean(toValue(userId)),
+    () => Boolean(toValue(scopeType)),
+    () => Boolean(toValue(scopeId)),
+  ];
+  const { isQueryEnabled, options } = computeQueryOverrides(conditions, queryOptions);
+
+  return useQuery({
+    queryKey: [ADMINISTRATION_INDIVIDUAL_REPORT_QUERY_KEY, administrationId, userId, scopeType, scopeId],
+    queryFn: async () => {
+      const client = getRoarApiClient();
+      const result = await client.administrations.scoreReports.getIndividualStudentReport({
+        params: { id: toValue(administrationId), userId: toValue(userId) },
+        query: {
+          scopeType: toValue(scopeType),
+          scopeId: toValue(scopeId),
+        },
+      });
+
+      if (result.status !== StatusCodes.OK) {
+        // Non-200 ts-rest results are surfaced as thrown errors so TanStack routes
+        // them through `error`. The thrown shape carries the ts-rest response so
+        // downstream error handlers can introspect it.
+        const error = new Error(`Failed to fetch individual student report with status ${result.status}`);
+        error.status = result.status;
+        error.body = result.body;
+        throw error;
+      }
+
+      // Unwrap the success envelope: { data: { student, administration, tasks, ... } }.
+      return result.body.data;
+    },
+    ...options,
+    enabled: isQueryEnabled,
+    // Terminal auth errors and rostering-ended are not transient; retrying delays
+    // the user-facing error UX. Placed after `...options` so a caller-supplied
+    // `retry` can't silently override the policy.
+    retry: (failureCount, error) => {
+      if (isRosteringEndedError(error) || isTerminalAuthError(error)) {
+        return false;
+      }
+      return failureCount < MAX_RETRIES;
+    },
+  });
+};
+
+export default useAdministrationIndividualScoreReportQuery;

--- a/apps/dashboard/src/composables/queries/useAdministrationIndividualScoreReportQuery.test.js
+++ b/apps/dashboard/src/composables/queries/useAdministrationIndividualScoreReportQuery.test.js
@@ -1,0 +1,174 @@
+import { ref, nextTick, isRef, isReadonly } from 'vue';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { createTestingPinia } from '@pinia/testing';
+import * as VueQuery from '@tanstack/vue-query';
+import { nanoid } from 'nanoid';
+import { StatusCodes } from 'http-status-codes';
+import { withSetup } from '@/test-support/withSetup.js';
+import { useAuthStore } from '@/store/auth';
+import useAdministrationIndividualScoreReportQuery from './useAdministrationIndividualScoreReportQuery';
+import { ADMINISTRATION_INDIVIDUAL_REPORT_QUERY_KEY } from '@/constants/queryKeys';
+
+const mockGetIndividualStudentReport = vi.fn();
+
+vi.mock('@/clients/roar-api', () => ({
+  getRoarApiClient: () => ({
+    administrations: { scoreReports: { getIndividualStudentReport: mockGetIndividualStudentReport } },
+  }),
+}));
+
+vi.mock('@tanstack/vue-query', async (getModule) => {
+  const original = await getModule();
+  return {
+    ...original,
+    useQuery: vi.fn().mockImplementation(original.useQuery),
+  };
+});
+
+// Mirrors the real IndividualStudentReportResponseSchema shape.
+const REPORT = {
+  student: { userId: nanoid(), firstName: 'A', lastName: 'B', username: 'ab', grade: '3' },
+  administration: {
+    id: '11111111-1111-1111-1111-111111111111',
+    name: 'Fall 2025',
+    dateStart: '2025-09-01T00:00:00.000Z',
+    dateEnd: '2025-12-01T00:00:00.000Z',
+  },
+  tasks: [
+    {
+      taskId: '22222222-2222-2222-2222-222222222222',
+      taskSlug: 'swr',
+      taskName: 'Word',
+      orderIndex: 0,
+      scores: { rawScore: 500, percentile: 50, standardScore: 100 },
+      supportLevel: 'achievedSkill',
+      reliable: true,
+      optional: false,
+      completed: true,
+      engagementFlags: [],
+      tags: [],
+      historicalScores: [],
+    },
+  ],
+  completedTaskCount: 1,
+  totalTaskCount: 1,
+};
+
+const okResult = () => ({ status: StatusCodes.OK, body: { data: REPORT } });
+
+describe('useAdministrationIndividualScoreReportQuery', () => {
+  let piniaInstance;
+  let queryClient;
+
+  beforeEach(() => {
+    piniaInstance = createTestingPinia();
+    queryClient = new VueQuery.QueryClient({ defaultOptions: { queries: { retry: false } } });
+    mockGetIndividualStudentReport.mockReset();
+    mockGetIndividualStudentReport.mockResolvedValue(okResult());
+  });
+
+  afterEach(() => {
+    queryClient?.clear();
+    vi.clearAllMocks();
+  });
+
+  it('calls useQuery with the individual-report key and a gated, readonly enabled', () => {
+    const authStore = useAuthStore(piniaInstance);
+    authStore.accessToken = 'test-token';
+
+    vi.spyOn(VueQuery, 'useQuery');
+
+    withSetup(() => useAdministrationIndividualScoreReportQuery(nanoid(), nanoid(), 'school', nanoid()), {
+      plugins: [[VueQuery.VueQueryPlugin, { queryClient }]],
+    });
+
+    const call = vi.mocked(VueQuery.useQuery).mock.calls[0][0];
+    expect(call.queryKey[0]).toBe(ADMINISTRATION_INDIVIDUAL_REPORT_QUERY_KEY);
+    expect(call.queryFn).toBeInstanceOf(Function);
+    expect(isRef(call.enabled)).toBe(true);
+    expect(isReadonly(call.enabled)).toBe(true);
+    expect(call.enabled.value).toBe(true);
+  });
+
+  it('makes a single request with the right params and unwraps the envelope', async () => {
+    const administrationId = nanoid();
+    const userId = nanoid();
+    const scopeId = nanoid();
+
+    const authStore = useAuthStore(piniaInstance);
+    authStore.accessToken = 'test-token';
+
+    vi.spyOn(VueQuery, 'useQuery');
+
+    withSetup(() => useAdministrationIndividualScoreReportQuery(administrationId, userId, 'class', scopeId), {
+      plugins: [[VueQuery.VueQueryPlugin, { queryClient }]],
+    });
+
+    const { queryFn } = vi.mocked(VueQuery.useQuery).mock.calls[0][0];
+    const result = await queryFn();
+
+    expect(mockGetIndividualStudentReport).toHaveBeenCalledTimes(1);
+    expect(mockGetIndividualStudentReport).toHaveBeenCalledWith({
+      params: { id: administrationId, userId },
+      query: { scopeType: 'class', scopeId },
+    });
+    expect(result).toEqual(REPORT);
+    expect(result.tasks[0].taskSlug).toBe('swr');
+  });
+
+  it('throws when the API returns a non-200 status', async () => {
+    mockGetIndividualStudentReport.mockResolvedValue({ status: StatusCodes.FORBIDDEN, body: {} });
+
+    const authStore = useAuthStore(piniaInstance);
+    authStore.accessToken = 'test-token';
+
+    vi.spyOn(VueQuery, 'useQuery');
+
+    withSetup(() => useAdministrationIndividualScoreReportQuery(nanoid(), nanoid(), 'school', nanoid()), {
+      plugins: [[VueQuery.VueQueryPlugin, { queryClient }]],
+    });
+
+    const { queryFn } = vi.mocked(VueQuery.useQuery).mock.calls[0][0];
+    await expect(queryFn()).rejects.toThrow(/status 403/);
+  });
+
+  it('stays disabled until the access token, userId, and scopeId are available', async () => {
+    const userId = ref(null);
+    const authStore = useAuthStore(piniaInstance);
+    authStore.accessToken = null;
+
+    withSetup(() => useAdministrationIndividualScoreReportQuery(nanoid(), userId, 'school', nanoid()), {
+      plugins: [[VueQuery.VueQueryPlugin, { queryClient }]],
+    });
+
+    const call = vi.mocked(VueQuery.useQuery).mock.calls[0][0];
+    expect(call.enabled.value).toBe(false);
+
+    authStore.accessToken = 'test-token';
+    userId.value = nanoid();
+    await nextTick();
+
+    expect(call.enabled.value).toBe(true);
+  });
+
+  it('does not retry terminal auth / rostering-ended errors but retries transient ones up to 3x', () => {
+    const authStore = useAuthStore(piniaInstance);
+    authStore.accessToken = 'test-token';
+
+    let retryFn;
+    vi.spyOn(VueQuery, 'useQuery').mockImplementation((options) => {
+      retryFn = options.retry;
+      return { data: { value: null }, error: { value: null } };
+    });
+
+    withSetup(() => useAdministrationIndividualScoreReportQuery(nanoid(), nanoid(), 'school', nanoid()), {
+      plugins: [[VueQuery.VueQueryPlugin, { queryClient }]],
+    });
+
+    expect(retryFn(0, { body: { error: { code: 'auth/token-expired' } } })).toBe(false);
+    expect(retryFn(0, { body: { error: { code: 'auth/rostering-ended' } } })).toBe(false);
+    const networkError = new Error('network down');
+    expect(retryFn(2, networkError)).toBe(true);
+    expect(retryFn(3, networkError)).toBe(false);
+  });
+});

--- a/apps/dashboard/src/composables/queries/useAdministrationScoreFacetsQuery.js
+++ b/apps/dashboard/src/composables/queries/useAdministrationScoreFacetsQuery.js
@@ -1,0 +1,89 @@
+import { toValue } from 'vue';
+import { useQuery } from '@tanstack/vue-query';
+import { StatusCodes } from 'http-status-codes';
+import { computeQueryOverrides } from '@/helpers/computeQueryOverrides';
+import { getRoarApiClient } from '@/clients/roar-api';
+import { useAuthStore } from '@/store/auth';
+import { isRosteringEndedError, isTerminalAuthError } from '@/utils/api-errors';
+import { ADMINISTRATION_SCORE_FACETS_QUERY_KEY } from '@/constants/queryKeys';
+
+const MAX_RETRIES = 3;
+
+/**
+ * Administration score-distribution-facets query.
+ *
+ * Fetches per-task support-level and score-bin distributions, faceted by grade
+ * and school, from `GET /v1/administrations/:id/reports/scores/facets`, scoped to
+ * a specific org/class/group via `scopeType` + `scopeId`. Not paginated — the
+ * endpoint aggregates across the full population in scope, so this is a single
+ * request (like the overview endpoint).
+ *
+ * Returns the unwrapped payload (`result.body.data`): `{ totalStudents, tasks,
+ * computedAt }` where each task carries `supportLevelByGrade` /
+ * `supportLevelBySchool` and `scoreBinsByGrade` / `scoreBinsBySchool`. The
+ * school-faceted arrays are empty at non-district scope (the school-facet toggle
+ * is district-only). This replaces the client-side facet binning over runs and
+ * the Firestore `useDistrictSupportCategoriesQuery` for the distribution charts.
+ *
+ * **Enablement.** Internally gated on `authStore.accessToken` AND truthy
+ * `administrationId` / `scopeType` / `scopeId`; callers AND extra conditions via
+ * `queryOptions.enabled`.
+ *
+ * @param {import('vue').MaybeRefOrGetter<String>} administrationId – The administration's UUID.
+ * @param {import('vue').MaybeRefOrGetter<String>} scopeType – 'district' | 'school' | 'class' | 'group'.
+ * @param {import('vue').MaybeRefOrGetter<String>} scopeId – The scoping entity's UUID.
+ * @param {Object|undefined} queryOptions – Optional TanStack query options.
+ * @returns {import('@tanstack/vue-query').UseQueryReturnType} Resolves to `{ totalStudents, tasks, computedAt }`.
+ */
+const useAdministrationScoreFacetsQuery = (administrationId, scopeType, scopeId, queryOptions = undefined) => {
+  const authStore = useAuthStore();
+  const conditions = [
+    () => Boolean(authStore.accessToken),
+    () => Boolean(toValue(administrationId)),
+    () => Boolean(toValue(scopeType)),
+    () => Boolean(toValue(scopeId)),
+  ];
+  const { isQueryEnabled, options } = computeQueryOverrides(conditions, queryOptions);
+
+  return useQuery({
+    // Pass scope params as-is (ref or string) so reactive callers update the key;
+    // TanStack unwraps refs in the key array, matching the canonical composable.
+    queryKey: [ADMINISTRATION_SCORE_FACETS_QUERY_KEY, administrationId, scopeType, scopeId],
+    queryFn: async () => {
+      const client = getRoarApiClient();
+      const result = await client.administrations.scoreReports.getScoreFacets({
+        params: { id: toValue(administrationId) },
+        query: {
+          scopeType: toValue(scopeType),
+          scopeId: toValue(scopeId),
+        },
+      });
+
+      if (result.status !== StatusCodes.OK) {
+        // Non-200 ts-rest results are surfaced as thrown errors so TanStack routes
+        // them through `error`. The thrown shape carries the ts-rest response so
+        // downstream error handlers can introspect it.
+        const error = new Error(`Failed to fetch administration score facets with status ${result.status}`);
+        error.status = result.status;
+        error.body = result.body;
+        throw error;
+      }
+
+      // Unwrap the success envelope: { data: { totalStudents, tasks, computedAt } }.
+      return result.body.data;
+    },
+    ...options,
+    enabled: isQueryEnabled,
+    // Terminal auth errors and rostering-ended are not transient; retrying delays
+    // the user-facing error UX. Placed after `...options` so a caller-supplied
+    // `retry` can't silently override the policy.
+    retry: (failureCount, error) => {
+      if (isRosteringEndedError(error) || isTerminalAuthError(error)) {
+        return false;
+      }
+      return failureCount < MAX_RETRIES;
+    },
+  });
+};
+
+export default useAdministrationScoreFacetsQuery;

--- a/apps/dashboard/src/composables/queries/useAdministrationScoreFacetsQuery.test.js
+++ b/apps/dashboard/src/composables/queries/useAdministrationScoreFacetsQuery.test.js
@@ -1,0 +1,169 @@
+import { ref, nextTick, isRef, isReadonly } from 'vue';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { createTestingPinia } from '@pinia/testing';
+import * as VueQuery from '@tanstack/vue-query';
+import { nanoid } from 'nanoid';
+import { StatusCodes } from 'http-status-codes';
+import { withSetup } from '@/test-support/withSetup.js';
+import { useAuthStore } from '@/store/auth';
+import useAdministrationScoreFacetsQuery from './useAdministrationScoreFacetsQuery';
+import { ADMINISTRATION_SCORE_FACETS_QUERY_KEY } from '@/constants/queryKeys';
+
+const mockGetScoreFacets = vi.fn();
+
+vi.mock('@/clients/roar-api', () => ({
+  getRoarApiClient: () => ({
+    administrations: { scoreReports: { getScoreFacets: mockGetScoreFacets } },
+  }),
+}));
+
+vi.mock('@tanstack/vue-query', async (getModule) => {
+  const original = await getModule();
+  return {
+    ...original,
+    useQuery: vi.fn().mockImplementation(original.useQuery),
+  };
+});
+
+// Mirrors the real ScoreFacetsResponseSchema shape.
+const SUPPORT = { achievedSkill: { count: 3 }, developingSkill: { count: 2 }, needsExtraSupport: { count: 1 } };
+const FACETS_RESPONSE = {
+  totalStudents: 6,
+  computedAt: '2026-06-27T00:00:00.000Z',
+  tasks: [
+    {
+      taskId: '11111111-1111-1111-1111-111111111111',
+      taskSlug: 'swr',
+      taskName: 'Word',
+      orderIndex: 0,
+      supportLevelByGrade: [{ grade: '3', totalAssessed: 6, ...SUPPORT }],
+      supportLevelBySchool: [],
+      scoreBinsByGrade: [
+        {
+          grade: '3',
+          rawScore: [{ binStart: 100, binEnd: 130, count: 6 }],
+          percentile: [{ binStart: 0, binEnd: 10, count: 6 }],
+        },
+      ],
+      scoreBinsBySchool: [],
+    },
+  ],
+};
+
+const okResult = () => ({ status: StatusCodes.OK, body: { data: FACETS_RESPONSE } });
+
+describe('useAdministrationScoreFacetsQuery', () => {
+  let piniaInstance;
+  let queryClient;
+
+  beforeEach(() => {
+    piniaInstance = createTestingPinia();
+    queryClient = new VueQuery.QueryClient({ defaultOptions: { queries: { retry: false } } });
+    mockGetScoreFacets.mockReset();
+    mockGetScoreFacets.mockResolvedValue(okResult());
+  });
+
+  afterEach(() => {
+    queryClient?.clear();
+    vi.clearAllMocks();
+  });
+
+  it('calls useQuery with the facets key and a gated, readonly enabled', () => {
+    const authStore = useAuthStore(piniaInstance);
+    authStore.accessToken = 'test-token';
+
+    vi.spyOn(VueQuery, 'useQuery');
+
+    withSetup(() => useAdministrationScoreFacetsQuery(nanoid(), 'district', nanoid()), {
+      plugins: [[VueQuery.VueQueryPlugin, { queryClient }]],
+    });
+
+    const call = vi.mocked(VueQuery.useQuery).mock.calls[0][0];
+    expect(call.queryKey[0]).toBe(ADMINISTRATION_SCORE_FACETS_QUERY_KEY);
+    expect(call.queryFn).toBeInstanceOf(Function);
+    expect(isRef(call.enabled)).toBe(true);
+    expect(isReadonly(call.enabled)).toBe(true);
+    expect(call.enabled.value).toBe(true);
+  });
+
+  it('makes a single (non-paginated) request and unwraps the envelope', async () => {
+    const administrationId = nanoid();
+    const scopeId = nanoid();
+
+    const authStore = useAuthStore(piniaInstance);
+    authStore.accessToken = 'test-token';
+
+    vi.spyOn(VueQuery, 'useQuery');
+
+    withSetup(() => useAdministrationScoreFacetsQuery(administrationId, 'school', scopeId), {
+      plugins: [[VueQuery.VueQueryPlugin, { queryClient }]],
+    });
+
+    const { queryFn } = vi.mocked(VueQuery.useQuery).mock.calls[0][0];
+    const result = await queryFn();
+
+    expect(mockGetScoreFacets).toHaveBeenCalledTimes(1);
+    expect(mockGetScoreFacets).toHaveBeenCalledWith({
+      params: { id: administrationId },
+      query: { scopeType: 'school', scopeId },
+    });
+    expect(result).toEqual(FACETS_RESPONSE);
+    expect(result.tasks[0].supportLevelByGrade[0]).toMatchObject({ grade: '3', achievedSkill: { count: 3 } });
+  });
+
+  it('throws when the API returns a non-200 status', async () => {
+    mockGetScoreFacets.mockResolvedValue({ status: StatusCodes.BAD_REQUEST, body: {} });
+
+    const authStore = useAuthStore(piniaInstance);
+    authStore.accessToken = 'test-token';
+
+    vi.spyOn(VueQuery, 'useQuery');
+
+    withSetup(() => useAdministrationScoreFacetsQuery(nanoid(), 'school', nanoid()), {
+      plugins: [[VueQuery.VueQueryPlugin, { queryClient }]],
+    });
+
+    const { queryFn } = vi.mocked(VueQuery.useQuery).mock.calls[0][0];
+    await expect(queryFn()).rejects.toThrow(/status 400/);
+  });
+
+  it('stays disabled until the access token and scopeId are available', async () => {
+    const scopeId = ref(null);
+    const authStore = useAuthStore(piniaInstance);
+    authStore.accessToken = null;
+
+    withSetup(() => useAdministrationScoreFacetsQuery(nanoid(), 'school', scopeId), {
+      plugins: [[VueQuery.VueQueryPlugin, { queryClient }]],
+    });
+
+    const call = vi.mocked(VueQuery.useQuery).mock.calls[0][0];
+    expect(call.enabled.value).toBe(false);
+
+    authStore.accessToken = 'test-token';
+    scopeId.value = nanoid();
+    await nextTick();
+
+    expect(call.enabled.value).toBe(true);
+  });
+
+  it('does not retry terminal auth / rostering-ended errors but retries transient ones up to 3x', () => {
+    const authStore = useAuthStore(piniaInstance);
+    authStore.accessToken = 'test-token';
+
+    let retryFn;
+    vi.spyOn(VueQuery, 'useQuery').mockImplementation((options) => {
+      retryFn = options.retry;
+      return { data: { value: null }, error: { value: null } };
+    });
+
+    withSetup(() => useAdministrationScoreFacetsQuery(nanoid(), 'school', nanoid()), {
+      plugins: [[VueQuery.VueQueryPlugin, { queryClient }]],
+    });
+
+    expect(retryFn(0, { body: { error: { code: 'auth/token-expired' } } })).toBe(false);
+    expect(retryFn(0, { body: { error: { code: 'auth/rostering-ended' } } })).toBe(false);
+    const networkError = new Error('network down');
+    expect(retryFn(2, networkError)).toBe(true);
+    expect(retryFn(3, networkError)).toBe(false);
+  });
+});

--- a/apps/dashboard/src/composables/queries/useAdministrationScoreOverviewQuery.js
+++ b/apps/dashboard/src/composables/queries/useAdministrationScoreOverviewQuery.js
@@ -1,0 +1,87 @@
+import { toValue } from 'vue';
+import { useQuery } from '@tanstack/vue-query';
+import { StatusCodes } from 'http-status-codes';
+import { computeQueryOverrides } from '@/helpers/computeQueryOverrides';
+import { getRoarApiClient } from '@/clients/roar-api';
+import { useAuthStore } from '@/store/auth';
+import { isRosteringEndedError, isTerminalAuthError } from '@/utils/api-errors';
+import { ADMINISTRATION_SCORE_OVERVIEW_QUERY_KEY } from '@/constants/queryKeys';
+
+const MAX_RETRIES = 3;
+
+/**
+ * Administration score-overview query.
+ *
+ * Fetches aggregated support-level distributions per task from
+ * `GET /v1/administrations/:id/reports/scores/overview`, scoped to a specific
+ * org/class/group via `scopeType` + `scopeId`. Not paginated — the endpoint
+ * aggregates across the full population in scope, so this is a single request
+ * (unlike the paginated student / subscore endpoints).
+ *
+ * Returns the unwrapped overview payload (`result.body.data`): the per-task
+ * aggregated support-level counts the "at a glance" charts at the top of the
+ * score report render. Replaces the client-side `runsByTaskId` aggregation and
+ * the Firestore `useDistrictSupportCategoriesQuery`.
+ *
+ * **Enablement.** Internally gated on `authStore.accessToken` AND truthy
+ * `administrationId` / `scopeType` / `scopeId`; callers AND extra conditions via
+ * `queryOptions.enabled`.
+ *
+ * @param {import('vue').MaybeRefOrGetter<String>} administrationId – The administration's UUID.
+ * @param {import('vue').MaybeRefOrGetter<String>} scopeType – 'district' | 'school' | 'class' | 'group'.
+ * @param {import('vue').MaybeRefOrGetter<String>} scopeId – The scoping entity's UUID.
+ * @param {Object|undefined} queryOptions – Optional TanStack query options.
+ * @returns {import('@tanstack/vue-query').UseQueryReturnType} Resolves to the aggregated overview payload.
+ */
+const useAdministrationScoreOverviewQuery = (administrationId, scopeType, scopeId, queryOptions = undefined) => {
+  const authStore = useAuthStore();
+  const conditions = [
+    () => Boolean(authStore.accessToken),
+    () => Boolean(toValue(administrationId)),
+    () => Boolean(toValue(scopeType)),
+    () => Boolean(toValue(scopeId)),
+  ];
+  const { isQueryEnabled, options } = computeQueryOverrides(conditions, queryOptions);
+
+  return useQuery({
+    // Pass scope params as-is (ref or string) so reactive callers update the key;
+    // TanStack unwraps refs in the key array, matching the canonical composable.
+    queryKey: [ADMINISTRATION_SCORE_OVERVIEW_QUERY_KEY, administrationId, scopeType, scopeId],
+    queryFn: async () => {
+      const client = getRoarApiClient();
+      const result = await client.administrations.scoreReports.getOverview({
+        params: { id: toValue(administrationId) },
+        query: {
+          scopeType: toValue(scopeType),
+          scopeId: toValue(scopeId),
+        },
+      });
+
+      if (result.status !== StatusCodes.OK) {
+        // Non-200 ts-rest results are surfaced as thrown errors so TanStack routes
+        // them through `error`. The thrown shape carries the ts-rest response so
+        // downstream error handlers can introspect it.
+        const error = new Error(`Failed to fetch administration score overview with status ${result.status}`);
+        error.status = result.status;
+        error.body = result.body;
+        throw error;
+      }
+
+      // Unwrap the success envelope: { data: <aggregated overview> }.
+      return result.body.data;
+    },
+    ...options,
+    enabled: isQueryEnabled,
+    // Terminal auth errors and rostering-ended are not transient; retrying delays
+    // the user-facing error UX. Placed after `...options` so a caller-supplied
+    // `retry` can't silently override the policy.
+    retry: (failureCount, error) => {
+      if (isRosteringEndedError(error) || isTerminalAuthError(error)) {
+        return false;
+      }
+      return failureCount < MAX_RETRIES;
+    },
+  });
+};
+
+export default useAdministrationScoreOverviewQuery;

--- a/apps/dashboard/src/composables/queries/useAdministrationScoreOverviewQuery.test.js
+++ b/apps/dashboard/src/composables/queries/useAdministrationScoreOverviewQuery.test.js
@@ -1,0 +1,173 @@
+import { ref, nextTick, isRef, isReadonly } from 'vue';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { createTestingPinia } from '@pinia/testing';
+import * as VueQuery from '@tanstack/vue-query';
+import { nanoid } from 'nanoid';
+import { StatusCodes } from 'http-status-codes';
+import { withSetup } from '@/test-support/withSetup.js';
+import { useAuthStore } from '@/store/auth';
+import useAdministrationScoreOverviewQuery from './useAdministrationScoreOverviewQuery';
+import { ADMINISTRATION_SCORE_OVERVIEW_QUERY_KEY } from '@/constants/queryKeys';
+
+const mockGetOverview = vi.fn();
+
+vi.mock('@/clients/roar-api', () => ({
+  getRoarApiClient: () => ({
+    administrations: { scoreReports: { getOverview: mockGetOverview } },
+  }),
+}));
+
+vi.mock('@tanstack/vue-query', async (getModule) => {
+  const original = await getModule();
+  return {
+    ...original,
+    useQuery: vi.fn().mockImplementation(original.useQuery),
+  };
+});
+
+// Mirrors the real ScoreOverviewResponseSchema shape (taskSlug + supportLevels.<key>.count).
+const SAMPLE_OVERVIEW = {
+  totalStudents: 10,
+  tasks: [
+    {
+      taskId: '11111111-1111-1111-1111-111111111111',
+      taskSlug: 'swr',
+      taskName: 'Word',
+      orderIndex: 0,
+      totalAssessed: 8,
+      totalNotAssessed: { required: 1, optional: 1 },
+      supportLevels: { needsExtraSupport: { count: 2 }, developingSkill: { count: 3 }, achievedSkill: { count: 3 } },
+    },
+  ],
+  computedAt: '2026-06-28T00:00:00.000Z',
+  exclusions: {},
+};
+
+describe('useAdministrationScoreOverviewQuery', () => {
+  let piniaInstance;
+  let queryClient;
+
+  beforeEach(() => {
+    piniaInstance = createTestingPinia();
+    queryClient = new VueQuery.QueryClient({ defaultOptions: { queries: { retry: false } } });
+    mockGetOverview.mockReset();
+    mockGetOverview.mockResolvedValue({ status: StatusCodes.OK, body: { data: SAMPLE_OVERVIEW } });
+  });
+
+  afterEach(() => {
+    queryClient?.clear();
+    vi.clearAllMocks();
+  });
+
+  it('calls useQuery with the score-overview key and a gated, readonly enabled', () => {
+    const authStore = useAuthStore(piniaInstance);
+    authStore.accessToken = 'test-token';
+
+    vi.spyOn(VueQuery, 'useQuery');
+
+    withSetup(() => useAdministrationScoreOverviewQuery(nanoid(), 'school', nanoid()), {
+      plugins: [[VueQuery.VueQueryPlugin, { queryClient }]],
+    });
+
+    const call = vi.mocked(VueQuery.useQuery).mock.calls[0][0];
+    expect(call.queryKey[0]).toBe(ADMINISTRATION_SCORE_OVERVIEW_QUERY_KEY);
+    expect(call.queryFn).toBeInstanceOf(Function);
+    expect(isRef(call.enabled)).toBe(true);
+    expect(isReadonly(call.enabled)).toBe(true);
+    expect(call.enabled.value).toBe(true);
+  });
+
+  it('fetches the overview with the scope params and returns the unwrapped payload', async () => {
+    const administrationId = nanoid();
+    const scopeId = nanoid();
+    const authStore = useAuthStore(piniaInstance);
+    authStore.accessToken = 'test-token';
+
+    vi.spyOn(VueQuery, 'useQuery');
+
+    withSetup(() => useAdministrationScoreOverviewQuery(administrationId, 'school', scopeId), {
+      plugins: [[VueQuery.VueQueryPlugin, { queryClient }]],
+    });
+
+    const { queryFn } = vi.mocked(VueQuery.useQuery).mock.calls[0][0];
+    const data = await queryFn();
+
+    expect(mockGetOverview).toHaveBeenCalledWith({
+      params: { id: administrationId },
+      query: { scopeType: 'school', scopeId },
+    });
+    expect(data).toEqual(SAMPLE_OVERVIEW);
+  });
+
+  it('throws when the API returns a non-200 status', async () => {
+    mockGetOverview.mockResolvedValue({ status: StatusCodes.FORBIDDEN, body: {} });
+
+    const authStore = useAuthStore(piniaInstance);
+    authStore.accessToken = 'test-token';
+
+    vi.spyOn(VueQuery, 'useQuery');
+
+    withSetup(() => useAdministrationScoreOverviewQuery(nanoid(), 'school', nanoid()), {
+      plugins: [[VueQuery.VueQueryPlugin, { queryClient }]],
+    });
+
+    const { queryFn } = vi.mocked(VueQuery.useQuery).mock.calls[0][0];
+    await expect(queryFn()).rejects.toThrow(/status 403/);
+  });
+
+  it('unwraps a reactive scopeId and stays disabled until it is present', async () => {
+    const scopeId = ref(null);
+    const authStore = useAuthStore(piniaInstance);
+    authStore.accessToken = 'test-token';
+
+    withSetup(() => useAdministrationScoreOverviewQuery(nanoid(), 'school', scopeId), {
+      plugins: [[VueQuery.VueQueryPlugin, { queryClient }]],
+    });
+
+    const call = vi.mocked(VueQuery.useQuery).mock.calls[0][0];
+    expect(call.enabled.value).toBe(false);
+
+    scopeId.value = nanoid();
+    await nextTick();
+
+    expect(call.enabled.value).toBe(true);
+  });
+
+  it('stays disabled until the access token is available', async () => {
+    const authStore = useAuthStore(piniaInstance);
+    authStore.accessToken = null;
+
+    withSetup(() => useAdministrationScoreOverviewQuery(nanoid(), 'school', nanoid()), {
+      plugins: [[VueQuery.VueQueryPlugin, { queryClient }]],
+    });
+
+    const call = vi.mocked(VueQuery.useQuery).mock.calls[0][0];
+    expect(call.enabled.value).toBe(false);
+
+    authStore.accessToken = 'test-token';
+    await nextTick();
+
+    expect(call.enabled.value).toBe(true);
+  });
+
+  it('does not retry terminal auth / rostering-ended errors but retries transient ones up to 3x', () => {
+    const authStore = useAuthStore(piniaInstance);
+    authStore.accessToken = 'test-token';
+
+    let retryFn;
+    vi.spyOn(VueQuery, 'useQuery').mockImplementation((options) => {
+      retryFn = options.retry;
+      return { data: { value: null }, error: { value: null } };
+    });
+
+    withSetup(() => useAdministrationScoreOverviewQuery(nanoid(), 'school', nanoid()), {
+      plugins: [[VueQuery.VueQueryPlugin, { queryClient }]],
+    });
+
+    expect(retryFn(0, { body: { error: { code: 'auth/token-expired' } } })).toBe(false);
+    expect(retryFn(0, { body: { error: { code: 'auth/rostering-ended' } } })).toBe(false);
+    const networkError = new Error('network down');
+    expect(retryFn(2, networkError)).toBe(true);
+    expect(retryFn(3, networkError)).toBe(false);
+  });
+});

--- a/apps/dashboard/src/composables/queries/useAdministrationScoreStudentsQuery.js
+++ b/apps/dashboard/src/composables/queries/useAdministrationScoreStudentsQuery.js
@@ -1,0 +1,116 @@
+import { toValue } from 'vue';
+import { useQuery } from '@tanstack/vue-query';
+import { StatusCodes } from 'http-status-codes';
+import { computeQueryOverrides } from '@/helpers/computeQueryOverrides';
+import { getRoarApiClient } from '@/clients/roar-api';
+import { useAuthStore } from '@/store/auth';
+import { isRosteringEndedError, isTerminalAuthError } from '@/utils/api-errors';
+import { ADMINISTRATION_SCORE_STUDENTS_QUERY_KEY } from '@/constants/queryKeys';
+
+const MAX_RETRIES = 3;
+
+/**
+ * Page size for the student-scores request. The score report renders a
+ * client-side table over the full scoped population, so the composable follows
+ * the response pagination and aggregates every page into a single result
+ * (mirrors `useAdministrationProgressQuery`).
+ */
+const STUDENT_SCORES_PER_PAGE = 100;
+
+/**
+ * Administration per-student scores query.
+ *
+ * Fetches per-student scores for an administration from
+ * `GET /v1/administrations/:id/reports/scores/students`, scoped to a specific
+ * org/class/group via `scopeType` + `scopeId`. Follows the response's pagination
+ * so the full student population for the scope is returned in one composable result.
+ *
+ * Returns domain data `{ students, tasks, exclusions }`:
+ * - `students` — `{ user, scores }` rows. `scores` is keyed by task **UUID**; each
+ *   entry carries `rawScore` / `percentile` / `standardScore` / `supportLevel`
+ *   (`achievedSkill` | `developingSkill` | `needsExtraSupport` | `optional` | null) /
+ *   `reliable` / `engagementFlags` / `optional` / `completed`. The server computes
+ *   the classification, replacing the client-side scoring in `ScoreReport.vue`.
+ * - `tasks` — `{ taskId, taskSlug, taskName, orderIndex }[]` for mapping the
+ *   UUID-keyed scores onto the slug-based table columns.
+ * - `exclusions` — counts of records filtered from the report (e.g. rostering-ended).
+ *
+ * **Enablement.** Internally gated on `authStore.accessToken` AND truthy
+ * `administrationId` / `scopeType` / `scopeId`; callers AND additional conditions
+ * via `queryOptions.enabled`.
+ *
+ * @param {import('vue').MaybeRefOrGetter<String>} administrationId – The administration's UUID.
+ * @param {import('vue').MaybeRefOrGetter<String>} scopeType – 'district' | 'school' | 'class' | 'group'.
+ * @param {import('vue').MaybeRefOrGetter<String>} scopeId – The scoping entity's UUID.
+ * @param {Object|undefined} queryOptions – Optional TanStack query options.
+ * @returns {import('@tanstack/vue-query').UseQueryReturnType} Resolves to `{ students, tasks, exclusions }`.
+ */
+const useAdministrationScoreStudentsQuery = (administrationId, scopeType, scopeId, queryOptions = undefined) => {
+  const authStore = useAuthStore();
+  const conditions = [
+    () => Boolean(authStore.accessToken),
+    () => Boolean(toValue(administrationId)),
+    () => Boolean(toValue(scopeType)),
+    () => Boolean(toValue(scopeId)),
+  ];
+  const { isQueryEnabled, options } = computeQueryOverrides(conditions, queryOptions);
+
+  return useQuery({
+    queryKey: [ADMINISTRATION_SCORE_STUDENTS_QUERY_KEY, administrationId, scopeType, scopeId],
+    queryFn: async () => {
+      const client = getRoarApiClient();
+      const students = [];
+      let tasks = [];
+      let exclusions;
+      let page = 1;
+      let totalPages = 1;
+
+      // Follow the response's pagination so a scope that outgrows one page is
+      // fetched completely rather than silently truncated.
+      do {
+        const result = await client.administrations.scoreReports.listStudents({
+          params: { id: toValue(administrationId) },
+          query: {
+            page,
+            perPage: STUDENT_SCORES_PER_PAGE,
+            scopeType: toValue(scopeType),
+            scopeId: toValue(scopeId),
+          },
+        });
+
+        if (result.status !== StatusCodes.OK) {
+          // Non-200 ts-rest results are surfaced as thrown errors so TanStack routes
+          // them through `error`. The thrown shape carries the ts-rest response so
+          // downstream error handlers can introspect it.
+          const error = new Error(`Failed to fetch administration student scores with status ${result.status}`);
+          error.status = result.status;
+          error.body = result.body;
+          throw error;
+        }
+
+        // Unwrap the success envelope: { data: { tasks, items, pagination, exclusions } }.
+        // tasks/exclusions are identical across pages — keep the latest.
+        students.push(...result.body.data.items);
+        tasks = result.body.data.tasks;
+        exclusions = result.body.data.exclusions;
+        totalPages = result.body.data.pagination.totalPages;
+        page += 1;
+      } while (page <= totalPages);
+
+      return { students, tasks, exclusions };
+    },
+    ...options,
+    enabled: isQueryEnabled,
+    // Terminal auth errors and rostering-ended are not transient; retrying delays
+    // the user-facing error UX. Placed after `...options` so a caller-supplied
+    // `retry` can't silently override the policy.
+    retry: (failureCount, error) => {
+      if (isRosteringEndedError(error) || isTerminalAuthError(error)) {
+        return false;
+      }
+      return failureCount < MAX_RETRIES;
+    },
+  });
+};
+
+export default useAdministrationScoreStudentsQuery;

--- a/apps/dashboard/src/composables/queries/useAdministrationScoreStudentsQuery.test.js
+++ b/apps/dashboard/src/composables/queries/useAdministrationScoreStudentsQuery.test.js
@@ -1,0 +1,171 @@
+import { ref, nextTick, isRef, isReadonly } from 'vue';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { createTestingPinia } from '@pinia/testing';
+import * as VueQuery from '@tanstack/vue-query';
+import { nanoid } from 'nanoid';
+import { StatusCodes } from 'http-status-codes';
+import { withSetup } from '@/test-support/withSetup.js';
+import { useAuthStore } from '@/store/auth';
+import useAdministrationScoreStudentsQuery from './useAdministrationScoreStudentsQuery';
+import { ADMINISTRATION_SCORE_STUDENTS_QUERY_KEY } from '@/constants/queryKeys';
+
+const mockListStudents = vi.fn();
+
+vi.mock('@/clients/roar-api', () => ({
+  getRoarApiClient: () => ({
+    administrations: { scoreReports: { listStudents: mockListStudents } },
+  }),
+}));
+
+vi.mock('@tanstack/vue-query', async (getModule) => {
+  const original = await getModule();
+  return {
+    ...original,
+    useQuery: vi.fn().mockImplementation(original.useQuery),
+  };
+});
+
+// Mirrors the real StudentScoresResponseSchema shape.
+const TASK_UUID = '11111111-1111-1111-1111-111111111111';
+const TASKS = [{ taskId: TASK_UUID, taskSlug: 'swr', taskName: 'Word', orderIndex: 0 }];
+const makeRow = (userId) => ({
+  user: { userId, firstName: 'A', lastName: 'B', grade: '3' },
+  scores: {
+    [TASK_UUID]: {
+      rawScore: 10,
+      percentile: 50,
+      standardScore: 100,
+      supportLevel: 'achievedSkill',
+      reliable: true,
+      engagementFlags: [],
+      optional: false,
+      completed: true,
+    },
+  },
+});
+const makePage = (page, totalPages, items) => ({
+  status: StatusCodes.OK,
+  body: {
+    data: { tasks: TASKS, items, pagination: { page, perPage: 100, totalItems: 2, totalPages }, exclusions: {} },
+  },
+});
+
+describe('useAdministrationScoreStudentsQuery', () => {
+  let piniaInstance;
+  let queryClient;
+
+  beforeEach(() => {
+    piniaInstance = createTestingPinia();
+    queryClient = new VueQuery.QueryClient({ defaultOptions: { queries: { retry: false } } });
+    mockListStudents.mockReset();
+    mockListStudents.mockResolvedValue(makePage(1, 1, [makeRow('u1')]));
+  });
+
+  afterEach(() => {
+    queryClient?.clear();
+    vi.clearAllMocks();
+  });
+
+  it('calls useQuery with the student-scores key and a gated, readonly enabled', () => {
+    const authStore = useAuthStore(piniaInstance);
+    authStore.accessToken = 'test-token';
+
+    vi.spyOn(VueQuery, 'useQuery');
+
+    withSetup(() => useAdministrationScoreStudentsQuery(nanoid(), 'school', nanoid()), {
+      plugins: [[VueQuery.VueQueryPlugin, { queryClient }]],
+    });
+
+    const call = vi.mocked(VueQuery.useQuery).mock.calls[0][0];
+    expect(call.queryKey[0]).toBe(ADMINISTRATION_SCORE_STUDENTS_QUERY_KEY);
+    expect(call.queryFn).toBeInstanceOf(Function);
+    expect(isRef(call.enabled)).toBe(true);
+    expect(isReadonly(call.enabled)).toBe(true);
+    expect(call.enabled.value).toBe(true);
+  });
+
+  it('follows pagination and aggregates all pages into { students, tasks, exclusions }', async () => {
+    const administrationId = nanoid();
+    const scopeId = nanoid();
+    mockListStudents
+      .mockResolvedValueOnce(makePage(1, 2, [makeRow('u1')]))
+      .mockResolvedValueOnce(makePage(2, 2, [makeRow('u2')]));
+
+    const authStore = useAuthStore(piniaInstance);
+    authStore.accessToken = 'test-token';
+
+    vi.spyOn(VueQuery, 'useQuery');
+
+    withSetup(() => useAdministrationScoreStudentsQuery(administrationId, 'school', scopeId), {
+      plugins: [[VueQuery.VueQueryPlugin, { queryClient }]],
+    });
+
+    const { queryFn } = vi.mocked(VueQuery.useQuery).mock.calls[0][0];
+    const result = await queryFn();
+
+    expect(mockListStudents).toHaveBeenCalledTimes(2);
+    expect(mockListStudents).toHaveBeenNthCalledWith(1, {
+      params: { id: administrationId },
+      query: { page: 1, perPage: 100, scopeType: 'school', scopeId },
+    });
+    expect(result.students.map((s) => s.user.userId)).toEqual(['u1', 'u2']);
+    expect(result.tasks).toEqual(TASKS);
+    expect(result.exclusions).toEqual({});
+  });
+
+  it('throws when the API returns a non-200 status', async () => {
+    mockListStudents.mockResolvedValue({ status: StatusCodes.FORBIDDEN, body: {} });
+
+    const authStore = useAuthStore(piniaInstance);
+    authStore.accessToken = 'test-token';
+
+    vi.spyOn(VueQuery, 'useQuery');
+
+    withSetup(() => useAdministrationScoreStudentsQuery(nanoid(), 'school', nanoid()), {
+      plugins: [[VueQuery.VueQueryPlugin, { queryClient }]],
+    });
+
+    const { queryFn } = vi.mocked(VueQuery.useQuery).mock.calls[0][0];
+    await expect(queryFn()).rejects.toThrow(/status 403/);
+  });
+
+  it('stays disabled until the access token and scopeId are available', async () => {
+    const scopeId = ref(null);
+    const authStore = useAuthStore(piniaInstance);
+    authStore.accessToken = null;
+
+    withSetup(() => useAdministrationScoreStudentsQuery(nanoid(), 'school', scopeId), {
+      plugins: [[VueQuery.VueQueryPlugin, { queryClient }]],
+    });
+
+    const call = vi.mocked(VueQuery.useQuery).mock.calls[0][0];
+    expect(call.enabled.value).toBe(false);
+
+    authStore.accessToken = 'test-token';
+    scopeId.value = nanoid();
+    await nextTick();
+
+    expect(call.enabled.value).toBe(true);
+  });
+
+  it('does not retry terminal auth / rostering-ended errors but retries transient ones up to 3x', () => {
+    const authStore = useAuthStore(piniaInstance);
+    authStore.accessToken = 'test-token';
+
+    let retryFn;
+    vi.spyOn(VueQuery, 'useQuery').mockImplementation((options) => {
+      retryFn = options.retry;
+      return { data: { value: null }, error: { value: null } };
+    });
+
+    withSetup(() => useAdministrationScoreStudentsQuery(nanoid(), 'school', nanoid()), {
+      plugins: [[VueQuery.VueQueryPlugin, { queryClient }]],
+    });
+
+    expect(retryFn(0, { body: { error: { code: 'auth/token-expired' } } })).toBe(false);
+    expect(retryFn(0, { body: { error: { code: 'auth/rostering-ended' } } })).toBe(false);
+    const networkError = new Error('network down');
+    expect(retryFn(2, networkError)).toBe(true);
+    expect(retryFn(3, networkError)).toBe(false);
+  });
+});

--- a/apps/dashboard/src/composables/queries/useAdministrationTaskSubscoresQuery.js
+++ b/apps/dashboard/src/composables/queries/useAdministrationTaskSubscoresQuery.js
@@ -1,0 +1,129 @@
+import { toValue } from 'vue';
+import { useQuery } from '@tanstack/vue-query';
+import { StatusCodes } from 'http-status-codes';
+import { computeQueryOverrides } from '@/helpers/computeQueryOverrides';
+import { getRoarApiClient } from '@/clients/roar-api';
+import { useAuthStore } from '@/store/auth';
+import { isRosteringEndedError, isTerminalAuthError } from '@/utils/api-errors';
+import { ADMINISTRATION_TASK_SUBSCORES_QUERY_KEY } from '@/constants/queryKeys';
+
+const MAX_RETRIES = 3;
+
+/**
+ * Page size for the task-subscores request. The subscore table renders the full
+ * scoped population client-side, so the composable follows the response
+ * pagination and aggregates every page into a single result (mirrors
+ * `useAdministrationScoreStudentsQuery`).
+ */
+const SUBSCORES_PER_PAGE = 100;
+
+/**
+ * Administration per-task subscores query.
+ *
+ * Fetches per-student subscore rows for a single task from
+ * `GET /v1/administrations/:id/reports/scores/tasks/:taskId`, scoped via
+ * `scopeType` + `scopeId`. Follows the response's pagination so the full
+ * population for the scope is returned in one composable result.
+ *
+ * Returns `{ task, subscoreColumns, students, pagination }`:
+ * - `subscoreColumns` — `{ key, label }[]` declaring the task's subscore columns;
+ *   the frontend renders headers from this instead of hard-coding column lists
+ *   per task slug.
+ * - `students` — `{ user, subscores }` rows. `subscores` is keyed by the
+ *   `subscoreColumns[].key` values; each value is a string (`"15/19"` / comma
+ *   lists), a number (percent / total / raw), or null.
+ * - `task` — `{ taskId, taskSlug, taskName, orderIndex }` metadata.
+ *
+ * Tasks with no registered subscore schema (e.g. SWR, SRE) return **400** — the
+ * caller should only render a subscore table for tasks that have one. A 400 is
+ * treated as terminal (not retried).
+ *
+ * **Enablement.** Internally gated on `authStore.accessToken` AND truthy
+ * `administrationId` / `taskId` / `scopeType` / `scopeId`; callers AND extra
+ * conditions via `queryOptions.enabled`.
+ *
+ * @param {import('vue').MaybeRefOrGetter<String>} administrationId – The administration's UUID.
+ * @param {import('vue').MaybeRefOrGetter<String>} taskId – The task's UUID (not the slug).
+ * @param {import('vue').MaybeRefOrGetter<String>} scopeType – 'district' | 'school' | 'class' | 'group'.
+ * @param {import('vue').MaybeRefOrGetter<String>} scopeId – The scoping entity's UUID.
+ * @param {Object|undefined} queryOptions – Optional TanStack query options.
+ * @returns {import('@tanstack/vue-query').UseQueryReturnType} Resolves to `{ task, subscoreColumns, students, pagination }`.
+ */
+const useAdministrationTaskSubscoresQuery = (
+  administrationId,
+  taskId,
+  scopeType,
+  scopeId,
+  queryOptions = undefined,
+) => {
+  const authStore = useAuthStore();
+  const conditions = [
+    () => Boolean(authStore.accessToken),
+    () => Boolean(toValue(administrationId)),
+    () => Boolean(toValue(taskId)),
+    () => Boolean(toValue(scopeType)),
+    () => Boolean(toValue(scopeId)),
+  ];
+  const { isQueryEnabled, options } = computeQueryOverrides(conditions, queryOptions);
+
+  return useQuery({
+    queryKey: [ADMINISTRATION_TASK_SUBSCORES_QUERY_KEY, administrationId, taskId, scopeType, scopeId],
+    queryFn: async () => {
+      const client = getRoarApiClient();
+      const students = [];
+      let task;
+      let subscoreColumns = [];
+      let pagination;
+      let page = 1;
+      let totalPages = 1;
+
+      // Follow the response's pagination so a scope that outgrows one page is
+      // fetched completely rather than silently truncated.
+      do {
+        const result = await client.administrations.scoreReports.listTaskSubscores({
+          params: { id: toValue(administrationId), taskId: toValue(taskId) },
+          query: {
+            page,
+            perPage: SUBSCORES_PER_PAGE,
+            scopeType: toValue(scopeType),
+            scopeId: toValue(scopeId),
+          },
+        });
+
+        if (result.status !== StatusCodes.OK) {
+          // Non-200 ts-rest results are surfaced as thrown errors so TanStack routes
+          // them through `error`. The thrown shape carries the ts-rest response so
+          // downstream error handlers can introspect it.
+          const error = new Error(`Failed to fetch task subscores with status ${result.status}`);
+          error.status = result.status;
+          error.body = result.body;
+          throw error;
+        }
+
+        // Unwrap the success envelope: { data: { task, subscoreColumns, items, pagination } }.
+        // task/subscoreColumns are identical across pages — keep the latest.
+        students.push(...result.body.data.items);
+        task = result.body.data.task;
+        subscoreColumns = result.body.data.subscoreColumns;
+        pagination = result.body.data.pagination;
+        totalPages = result.body.data.pagination.totalPages;
+        page += 1;
+      } while (page <= totalPages);
+
+      return { task, subscoreColumns, students, pagination };
+    },
+    ...options,
+    enabled: isQueryEnabled,
+    // Terminal auth, rostering-ended, and 400 (task has no subscore schema /
+    // invalid request) are not transient — retrying just delays the error UX.
+    // Placed after `...options` so a caller-supplied `retry` can't override it.
+    retry: (failureCount, error) => {
+      if (isRosteringEndedError(error) || isTerminalAuthError(error) || error?.status === StatusCodes.BAD_REQUEST) {
+        return false;
+      }
+      return failureCount < MAX_RETRIES;
+    },
+  });
+};
+
+export default useAdministrationTaskSubscoresQuery;

--- a/apps/dashboard/src/composables/queries/useAdministrationTaskSubscoresQuery.test.js
+++ b/apps/dashboard/src/composables/queries/useAdministrationTaskSubscoresQuery.test.js
@@ -1,0 +1,176 @@
+import { ref, nextTick, isRef, isReadonly } from 'vue';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { createTestingPinia } from '@pinia/testing';
+import * as VueQuery from '@tanstack/vue-query';
+import { nanoid } from 'nanoid';
+import { StatusCodes } from 'http-status-codes';
+import { withSetup } from '@/test-support/withSetup.js';
+import { useAuthStore } from '@/store/auth';
+import useAdministrationTaskSubscoresQuery from './useAdministrationTaskSubscoresQuery';
+import { ADMINISTRATION_TASK_SUBSCORES_QUERY_KEY } from '@/constants/queryKeys';
+
+const mockListTaskSubscores = vi.fn();
+
+vi.mock('@/clients/roar-api', () => ({
+  getRoarApiClient: () => ({
+    administrations: { scoreReports: { listTaskSubscores: mockListTaskSubscores } },
+  }),
+}));
+
+vi.mock('@tanstack/vue-query', async (getModule) => {
+  const original = await getModule();
+  return {
+    ...original,
+    useQuery: vi.fn().mockImplementation(original.useQuery),
+  };
+});
+
+// Mirrors the real TaskSubscoresResponseSchema shape.
+const TASK = {
+  taskId: '11111111-1111-1111-1111-111111111111',
+  taskSlug: 'phonics',
+  taskName: 'Phonics',
+  orderIndex: 3,
+};
+const COLUMNS = [
+  { key: 'cvc', label: 'CVC' },
+  { key: 'totalPercentCorrect', label: 'Total % Correct' },
+];
+const makeRow = (userId) => ({
+  user: { userId, firstName: 'A', lastName: 'B', grade: '3', username: null, email: null },
+  subscores: { cvc: '15/19', totalPercentCorrect: 78 },
+});
+const makePage = (page, totalPages, items) => ({
+  status: StatusCodes.OK,
+  body: {
+    data: {
+      task: TASK,
+      subscoreColumns: COLUMNS,
+      items,
+      pagination: { page, perPage: 100, totalItems: 2, totalPages },
+    },
+  },
+});
+
+describe('useAdministrationTaskSubscoresQuery', () => {
+  let piniaInstance;
+  let queryClient;
+
+  beforeEach(() => {
+    piniaInstance = createTestingPinia();
+    queryClient = new VueQuery.QueryClient({ defaultOptions: { queries: { retry: false } } });
+    mockListTaskSubscores.mockReset();
+    mockListTaskSubscores.mockResolvedValue(makePage(1, 1, [makeRow('u1')]));
+  });
+
+  afterEach(() => {
+    queryClient?.clear();
+    vi.clearAllMocks();
+  });
+
+  it('calls useQuery with the subscores key and a gated, readonly enabled', () => {
+    const authStore = useAuthStore(piniaInstance);
+    authStore.accessToken = 'test-token';
+
+    vi.spyOn(VueQuery, 'useQuery');
+
+    withSetup(() => useAdministrationTaskSubscoresQuery(nanoid(), nanoid(), 'school', nanoid()), {
+      plugins: [[VueQuery.VueQueryPlugin, { queryClient }]],
+    });
+
+    const call = vi.mocked(VueQuery.useQuery).mock.calls[0][0];
+    expect(call.queryKey[0]).toBe(ADMINISTRATION_TASK_SUBSCORES_QUERY_KEY);
+    expect(call.queryFn).toBeInstanceOf(Function);
+    expect(isRef(call.enabled)).toBe(true);
+    expect(isReadonly(call.enabled)).toBe(true);
+    expect(call.enabled.value).toBe(true);
+  });
+
+  it('follows pagination and aggregates into { task, subscoreColumns, students, pagination }', async () => {
+    const administrationId = nanoid();
+    const taskId = nanoid();
+    const scopeId = nanoid();
+    mockListTaskSubscores
+      .mockResolvedValueOnce(makePage(1, 2, [makeRow('u1')]))
+      .mockResolvedValueOnce(makePage(2, 2, [makeRow('u2')]));
+
+    const authStore = useAuthStore(piniaInstance);
+    authStore.accessToken = 'test-token';
+
+    vi.spyOn(VueQuery, 'useQuery');
+
+    withSetup(() => useAdministrationTaskSubscoresQuery(administrationId, taskId, 'school', scopeId), {
+      plugins: [[VueQuery.VueQueryPlugin, { queryClient }]],
+    });
+
+    const { queryFn } = vi.mocked(VueQuery.useQuery).mock.calls[0][0];
+    const result = await queryFn();
+
+    expect(mockListTaskSubscores).toHaveBeenCalledTimes(2);
+    expect(mockListTaskSubscores).toHaveBeenNthCalledWith(1, {
+      params: { id: administrationId, taskId },
+      query: { page: 1, perPage: 100, scopeType: 'school', scopeId },
+    });
+    expect(result.students.map((s) => s.user.userId)).toEqual(['u1', 'u2']);
+    expect(result.subscoreColumns).toEqual(COLUMNS);
+    expect(result.task).toEqual(TASK);
+  });
+
+  it('throws when the API returns a non-200 status', async () => {
+    mockListTaskSubscores.mockResolvedValue({ status: StatusCodes.BAD_REQUEST, body: {} });
+
+    const authStore = useAuthStore(piniaInstance);
+    authStore.accessToken = 'test-token';
+
+    vi.spyOn(VueQuery, 'useQuery');
+
+    withSetup(() => useAdministrationTaskSubscoresQuery(nanoid(), nanoid(), 'school', nanoid()), {
+      plugins: [[VueQuery.VueQueryPlugin, { queryClient }]],
+    });
+
+    const { queryFn } = vi.mocked(VueQuery.useQuery).mock.calls[0][0];
+    await expect(queryFn()).rejects.toThrow(/status 400/);
+  });
+
+  it('stays disabled until the access token, taskId, and scopeId are available', async () => {
+    const taskId = ref(null);
+    const authStore = useAuthStore(piniaInstance);
+    authStore.accessToken = null;
+
+    withSetup(() => useAdministrationTaskSubscoresQuery(nanoid(), taskId, 'school', nanoid()), {
+      plugins: [[VueQuery.VueQueryPlugin, { queryClient }]],
+    });
+
+    const call = vi.mocked(VueQuery.useQuery).mock.calls[0][0];
+    expect(call.enabled.value).toBe(false);
+
+    authStore.accessToken = 'test-token';
+    taskId.value = nanoid();
+    await nextTick();
+
+    expect(call.enabled.value).toBe(true);
+  });
+
+  it('does not retry terminal auth / rostering-ended / 400 errors but retries transient ones up to 3x', () => {
+    const authStore = useAuthStore(piniaInstance);
+    authStore.accessToken = 'test-token';
+
+    let retryFn;
+    vi.spyOn(VueQuery, 'useQuery').mockImplementation((options) => {
+      retryFn = options.retry;
+      return { data: { value: null }, error: { value: null } };
+    });
+
+    withSetup(() => useAdministrationTaskSubscoresQuery(nanoid(), nanoid(), 'school', nanoid()), {
+      plugins: [[VueQuery.VueQueryPlugin, { queryClient }]],
+    });
+
+    expect(retryFn(0, { body: { error: { code: 'auth/token-expired' } } })).toBe(false);
+    expect(retryFn(0, { body: { error: { code: 'auth/rostering-ended' } } })).toBe(false);
+    // 400 (task without a subscore schema) is terminal.
+    expect(retryFn(0, { status: StatusCodes.BAD_REQUEST })).toBe(false);
+    const networkError = new Error('network down');
+    expect(retryFn(2, networkError)).toBe(true);
+    expect(retryFn(3, networkError)).toBe(false);
+  });
+});

--- a/apps/dashboard/src/constants/queryKeys.js
+++ b/apps/dashboard/src/constants/queryKeys.js
@@ -7,6 +7,7 @@ export const ADMINISTRATION_PROGRESS_QUERY_KEY = 'administration-progress';
 export const ADMINISTRATION_PROGRESS_OVERVIEW_QUERY_KEY = 'administration-progress-overview';
 export const ADMINISTRATION_SCORE_OVERVIEW_QUERY_KEY = 'administration-score-overview';
 export const ADMINISTRATION_SCORE_STUDENTS_QUERY_KEY = 'administration-score-students';
+export const ADMINISTRATION_SCORE_FACETS_QUERY_KEY = 'administration-score-facets';
 export const ADMINISTRATION_ASSIGNEES_QUERY_KEY = 'administration-assignees';
 export const ADMINISTRATION_TASK_VARIANTS_QUERY_KEY = 'administration-task-variants';
 export const ADMINISTRATION_AGREEMENTS_QUERY_KEY = 'administration-agreements';

--- a/apps/dashboard/src/constants/queryKeys.js
+++ b/apps/dashboard/src/constants/queryKeys.js
@@ -8,6 +8,7 @@ export const ADMINISTRATION_PROGRESS_OVERVIEW_QUERY_KEY = 'administration-progre
 export const ADMINISTRATION_SCORE_OVERVIEW_QUERY_KEY = 'administration-score-overview';
 export const ADMINISTRATION_SCORE_STUDENTS_QUERY_KEY = 'administration-score-students';
 export const ADMINISTRATION_SCORE_FACETS_QUERY_KEY = 'administration-score-facets';
+export const ADMINISTRATION_TASK_SUBSCORES_QUERY_KEY = 'administration-task-subscores';
 export const ADMINISTRATION_ASSIGNEES_QUERY_KEY = 'administration-assignees';
 export const ADMINISTRATION_TASK_VARIANTS_QUERY_KEY = 'administration-task-variants';
 export const ADMINISTRATION_AGREEMENTS_QUERY_KEY = 'administration-agreements';

--- a/apps/dashboard/src/constants/queryKeys.js
+++ b/apps/dashboard/src/constants/queryKeys.js
@@ -9,6 +9,7 @@ export const ADMINISTRATION_SCORE_OVERVIEW_QUERY_KEY = 'administration-score-ove
 export const ADMINISTRATION_SCORE_STUDENTS_QUERY_KEY = 'administration-score-students';
 export const ADMINISTRATION_SCORE_FACETS_QUERY_KEY = 'administration-score-facets';
 export const ADMINISTRATION_TASK_SUBSCORES_QUERY_KEY = 'administration-task-subscores';
+export const ADMINISTRATION_INDIVIDUAL_REPORT_QUERY_KEY = 'administration-individual-report';
 export const ADMINISTRATION_ASSIGNEES_QUERY_KEY = 'administration-assignees';
 export const ADMINISTRATION_TASK_VARIANTS_QUERY_KEY = 'administration-task-variants';
 export const ADMINISTRATION_AGREEMENTS_QUERY_KEY = 'administration-agreements';

--- a/apps/dashboard/src/constants/queryKeys.js
+++ b/apps/dashboard/src/constants/queryKeys.js
@@ -5,6 +5,7 @@ export const ADMINISTRATION_QUERY_KEY = 'administration';
 export const ADMINISTRATION_ASSIGNMENTS_QUERY_KEY = 'administration-assignments';
 export const ADMINISTRATION_PROGRESS_QUERY_KEY = 'administration-progress';
 export const ADMINISTRATION_PROGRESS_OVERVIEW_QUERY_KEY = 'administration-progress-overview';
+export const ADMINISTRATION_SCORE_OVERVIEW_QUERY_KEY = 'administration-score-overview';
 export const ADMINISTRATION_ASSIGNEES_QUERY_KEY = 'administration-assignees';
 export const ADMINISTRATION_TASK_VARIANTS_QUERY_KEY = 'administration-task-variants';
 export const ADMINISTRATION_AGREEMENTS_QUERY_KEY = 'administration-agreements';

--- a/apps/dashboard/src/constants/queryKeys.js
+++ b/apps/dashboard/src/constants/queryKeys.js
@@ -6,6 +6,7 @@ export const ADMINISTRATION_ASSIGNMENTS_QUERY_KEY = 'administration-assignments'
 export const ADMINISTRATION_PROGRESS_QUERY_KEY = 'administration-progress';
 export const ADMINISTRATION_PROGRESS_OVERVIEW_QUERY_KEY = 'administration-progress-overview';
 export const ADMINISTRATION_SCORE_OVERVIEW_QUERY_KEY = 'administration-score-overview';
+export const ADMINISTRATION_SCORE_STUDENTS_QUERY_KEY = 'administration-score-students';
 export const ADMINISTRATION_ASSIGNEES_QUERY_KEY = 'administration-assignees';
 export const ADMINISTRATION_TASK_VARIANTS_QUERY_KEY = 'administration-task-variants';
 export const ADMINISTRATION_AGREEMENTS_QUERY_KEY = 'administration-agreements';

--- a/apps/dashboard/src/containers/StudentScoreReport/StudentScoreReport.vue
+++ b/apps/dashboard/src/containers/StudentScoreReport/StudentScoreReport.vue
@@ -37,6 +37,7 @@
             :student-first-name="studentFirstName"
             :student-grade="studentGrade"
             :task-data="taskData"
+            :report-tasks="isParentPath ? null : reportData?.tasks"
             :tasks-dictionary="tasksDictionary"
             :longitudinal-data="longitudinalData"
             :current-assignment-id="administrationId"
@@ -69,6 +70,7 @@
             :student-first-name="studentFirstName"
             :student-grade="studentGrade"
             :task-data="taskData"
+            :report-tasks="isParentPath ? null : reportData?.tasks"
             :tasks-dictionary="tasksDictionary"
             :longitudinal-data="longitudinalData"
             :expanded="expanded"
@@ -97,6 +99,7 @@ import useUserDataQuery from '@/composables/queries/useUserDataQuery';
 import useAdministrationsQuery from '@/composables/queries/useAdministrationsQuery';
 import useUserRunPageQuery from '@/composables/queries/useUserRunPageQuery';
 import useUserLongitudinalRunsQuery from '@/composables/queries/useUserLongitudinalRunsQuery';
+import useAdministrationIndividualScoreReportQuery from '@/composables/queries/useAdministrationIndividualScoreReportQuery';
 import useTasksDictionaryQuery from '@/composables/queries/useTasksDictionaryQuery';
 import usePagedPreview from '@/composables/usePagedPreview';
 import PdfExportService from '@/services/PdfExport.service';
@@ -112,6 +115,7 @@ import { getStudentDisplayName } from '@/helpers/getStudentDisplayName';
 import { formatListArray } from '@/helpers/formatListArray';
 import { getStudentExternalId } from '@/helpers/getStudentExternalId';
 import { STUDENT_SCORE_REPORT_TASK_IDS } from '@/constants/studentScoreReportTasks';
+import { SINGULAR_ORG_TYPES } from '@/constants/orgTypes';
 
 const props = defineProps({
   administrationId: { type: String, required: true },
@@ -125,6 +129,10 @@ const route = useRoute();
 
 const isPrintMode = computed(() => route.query.print !== undefined);
 
+// The parent/guardian path navigates with orgType 'family' and stays on the legacy
+// data path this PR; the administrator path (org scopes) uses the backend report endpoint.
+const isParentPath = computed(() => props.orgType === SINGULAR_ORG_TYPES.FAMILIES);
+
 const expanded = ref(false);
 const exportLoading = ref(false);
 
@@ -134,6 +142,7 @@ const isLoading = computed(
     isLoadingStudentData.value ||
     isLoadingTasksDictionary.value ||
     isLoadingTaskData.value ||
+    isLoadingReport.value ||
     isLoadingAdministrationData.value ||
     isLoadingLongitudinalData.value,
 );
@@ -150,19 +159,43 @@ const { data: administrationData, isLoading: isLoadingAdministrationData } = use
   },
 );
 
-const { data: taskData, isLoading: isLoadingTaskData } = useUserRunPageQuery(
+const { data: legacyTaskData, isLoading: isLoadingTaskData } = useUserRunPageQuery(
   props.userId,
   props.administrationId,
   props.orgType,
   props.orgId,
-  { enabled: initialized },
+  { enabled: computed(() => initialized.value && isParentPath.value) },
 );
+
+// Administrator path: server-computed individual report (scores, support level, tags,
+// subscores, per-task historical scores) — replaces the Firestore run-page + longitudinal
+// queries for org scopes.
+const { data: reportData, isLoading: isLoadingReport } = useAdministrationIndividualScoreReportQuery(
+  props.administrationId,
+  props.userId,
+  props.orgType,
+  props.orgId,
+  { enabled: computed(() => initialized.value && !isParentPath.value) },
+);
+
+// Unified task data for the container's summary/distribution computeds. Admin path maps
+// the backend tasks to the minimal { taskId(slug), scores } shape those computeds read
+// (scores present only when completed); parent path uses the legacy run data.
+const taskData = computed(() => {
+  if (!isParentPath.value) {
+    return (reportData.value?.tasks ?? []).map((task) => ({
+      taskId: task.taskSlug,
+      scores: task.completed ? task.scores : undefined,
+    }));
+  }
+  return legacyTaskData.value;
+});
 
 const { data: longitudinalData, isLoading: isLoadingLongitudinalData } = useUserLongitudinalRunsQuery(
   props.userId,
   props.orgType,
   props.orgId,
-  { enabled: initialized, select: (data) => data },
+  { enabled: computed(() => initialized.value && isParentPath.value), select: (data) => data },
 );
 
 const { data: tasksDictionary, isLoading: isLoadingTasksDictionary } = useTasksDictionaryQuery({

--- a/apps/dashboard/src/containers/StudentScoreReport/components/ScoreList/ScoreList.print.vue
+++ b/apps/dashboard/src/containers/StudentScoreReport/components/ScoreList/ScoreList.print.vue
@@ -32,9 +32,11 @@
 </template>
 
 <script setup>
+import { computed } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { ScoreCardPrint as ScoreCard } from './ScoreCard';
 import { useScoreListData } from './useScoreListData';
+import { useReportCardData } from './useReportCardData';
 import { SCORE_REPORT_NEXT_STEPS_DOCUMENT_PATH } from '@/constants/scores';
 
 const props = defineProps({
@@ -67,20 +69,41 @@ const props = defineProps({
     type: String,
     required: true,
   },
+  // Administrator path: backend-computed report tasks (retires client scoring).
+  // The parent path leaves this null and stays on the legacy `taskData` pipeline.
+  reportTasks: {
+    type: Array,
+    required: false,
+    default: null,
+  },
 });
 
 const { t } = useI18n();
 
-/**
- * Process task data into computed task data for display
- */
-const { computedTaskData, scoreValueTemplate, getTaskDescription, getTaskScoresArray } = useScoreListData({
+const legacy = useScoreListData({
   studentGrade: props.studentGrade,
   taskData: props.taskData,
   longitudinalData: props.longitudinalData,
   taskScoringVersions: props.taskScoringVersions,
   t,
 });
+const backend = useReportCardData({
+  reportTasks: () => props.reportTasks,
+  studentGrade: props.studentGrade,
+  taskScoringVersions: props.taskScoringVersions,
+  t,
+});
+
+const useBackend = computed(() => Array.isArray(props.reportTasks));
+const computedTaskData = computed(() =>
+  useBackend.value ? backend.computedTaskData.value : legacy.computedTaskData.value,
+);
+const scoreValueTemplate = (task) =>
+  useBackend.value ? backend.scoreValueTemplate.value(task) : legacy.scoreValueTemplate.value(task);
+const getTaskDescription = (task) =>
+  useBackend.value ? backend.getTaskDescription.value(task) : legacy.getTaskDescription.value(task);
+const getTaskScoresArray = (task) =>
+  useBackend.value ? backend.getTaskScoresArray.value(task) : legacy.getTaskScoresArray.value(task);
 
 /**
  * Returns the URL of the next steps document

--- a/apps/dashboard/src/containers/StudentScoreReport/components/ScoreList/ScoreList.vue
+++ b/apps/dashboard/src/containers/StudentScoreReport/components/ScoreList/ScoreList.vue
@@ -27,9 +27,11 @@
 </template>
 
 <script setup>
+import { computed } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { ScoreCardScreen as ScoreCard } from './ScoreCard';
 import { useScoreListData } from './useScoreListData';
+import { useReportCardData } from './useReportCardData';
 
 const props = defineProps({
   studentFirstName: {
@@ -64,18 +66,42 @@ const props = defineProps({
     type: String,
     required: true,
   },
+  // Administrator path: backend-computed report tasks. When present, the card data
+  // comes from the backend (retiring client scoring); the parent path leaves this
+  // null and stays on the legacy `taskData` pipeline until its own migration.
+  reportTasks: {
+    type: Array,
+    required: false,
+    default: null,
+  },
 });
 
 const { t } = useI18n();
 
-// Use the shared composable
-const { computedTaskData, scoreValueTemplate, getTaskDescription, getTaskScoresArray } = useScoreListData({
+const legacy = useScoreListData({
   studentGrade: props.studentGrade,
   taskData: props.taskData,
   longitudinalData: props.longitudinalData,
   taskScoringVersions: props.taskScoringVersions,
   t,
 });
+const backend = useReportCardData({
+  reportTasks: () => props.reportTasks,
+  studentGrade: props.studentGrade,
+  taskScoringVersions: props.taskScoringVersions,
+  t,
+});
+
+const useBackend = computed(() => Array.isArray(props.reportTasks));
+const computedTaskData = computed(() =>
+  useBackend.value ? backend.computedTaskData.value : legacy.computedTaskData.value,
+);
+const scoreValueTemplate = (task) =>
+  useBackend.value ? backend.scoreValueTemplate.value(task) : legacy.scoreValueTemplate.value(task);
+const getTaskDescription = (task) =>
+  useBackend.value ? backend.getTaskDescription.value(task) : legacy.getTaskDescription.value(task);
+const getTaskScoresArray = (task) =>
+  useBackend.value ? backend.getTaskScoresArray.value(task) : legacy.getTaskScoresArray.value(task);
 </script>
 
 <style scoped>

--- a/apps/dashboard/src/containers/StudentScoreReport/components/ScoreList/useReportCardData.js
+++ b/apps/dashboard/src/containers/StudentScoreReport/components/ScoreList/useReportCardData.js
@@ -1,0 +1,199 @@
+import { computed, toValue } from 'vue';
+import _lowerCase from 'lodash/lowerCase';
+import ScoreReportService from '@/services/ScoreReport.service';
+import {
+  rawOnlyTasks,
+  taskDisplayNames,
+  getRawScoreRange,
+  tasksToDisplayPercentCorrect,
+  PA_SUBTASK_I18N_KEYS,
+} from '@/helpers/reports';
+import { getStudentGradeLevel } from '@/helpers/getStudentGradeLevel';
+import { SCORE_TYPES, SCORE_SUPPORT_LEVEL_COLORS } from '@/constants/scores';
+import { TAG_SEVERITIES } from '@/constants/tags';
+
+/**
+ * useReportCardData composable
+ *
+ * Backend-sourced counterpart to `useScoreListData`. Builds the exact ScoreCard
+ * prop contract (`computedTaskData` + the `scoreValueTemplate` / `getTaskDescription`
+ * / `getTaskScoresArray` helpers) from the individual-student-report endpoint's
+ * already-computed per-task values, retiring the client-side scoring pipeline
+ * (`processTaskScores` / `getScoreValue` / `getDialColor`) for this path.
+ *
+ * The backend is the source of truth: score values come from `task.scores`, the
+ * dial color from `task.supportLevel`, the longitudinal series from
+ * `task.historicalScores` (already in the LongitudinalChart input shape), and the
+ * reliability/type tags are derived from the backend `optional` / `reliable` /
+ * `engagementFlags`.
+ *
+ * NOTE: the report endpoint carries subscores only for PA and phonics, so the
+ * letter card's per-letter breakdown (upper/lower/sounds + "to work on") is not
+ * reproduced here — its card shows the primary scores only. Tracked as a gap.
+ *
+ * @param {Object} params
+ * @param {import('vue').MaybeRefOrGetter<Array>} params.reportTasks – Backend report tasks.
+ * @param {import('vue').MaybeRefOrGetter<String>} params.studentGrade – Student grade.
+ * @param {Object} params.taskScoringVersions – Map of task slug → scoring version.
+ * @param {Function} params.t – i18n translate function.
+ */
+export function useReportCardData(params) {
+  const { reportTasks, studentGrade, taskScoringVersions = {}, t } = params;
+
+  const i18n = { t };
+  const gradeLevel = getStudentGradeLevel(studentGrade);
+
+  // The frontend owns the dial color for each backend support-level enum.
+  const SUPPORT_LEVEL_DIAL_COLOR = {
+    achievedSkill: SCORE_SUPPORT_LEVEL_COLORS.ABOVE,
+    developingSkill: SCORE_SUPPORT_LEVEL_COLORS.SOME,
+    needsExtraSupport: SCORE_SUPPORT_LEVEL_COLORS.BELOW,
+  };
+
+  // Which score type the card surfaces (mirrors ScoreReport.service.getScoreToDisplay).
+  const getScoreToDisplay = (slug, grade) => {
+    if (rawOnlyTasks.includes(slug)) return SCORE_TYPES.RAW_SCORE;
+    if (['phonics', 'letter', 'letter-es', 'letter-en-ca'].includes(slug)) return SCORE_TYPES.PERCENTILE_SCORE;
+    return toValue(grade) >= 6 ? SCORE_TYPES.STANDARD_SCORE : SCORE_TYPES.PERCENTILE_SCORE;
+  };
+
+  // Type + reliability tags, derived from backend flags (mirrors the service's createTaskTags).
+  const buildTags = (optional, reliable, engagementFlags) => [
+    {
+      icon: 'pi pi-info-circle',
+      label: 'Type',
+      value: t(optional ? 'scoreReports.optional' : 'scoreReports.required'),
+      severity: TAG_SEVERITIES.INFO,
+      tooltip: t(optional ? 'scoreReports.optionalTagText' : 'scoreReports.requiredTagText'),
+    },
+    {
+      value: t(reliable === false ? 'scoreReports.unreliable' : 'scoreReports.reliable'),
+      label: 'Reliability',
+      icon: reliable === false ? 'pi pi-times' : 'pi pi-check',
+      severity: reliable === false ? TAG_SEVERITIES.DANGER : TAG_SEVERITIES.SUCCESS,
+      tooltip:
+        reliable === false
+          ? engagementFlags?.length
+            ? `${t('scoreReports.unreliableTagTextFlags')}: \n\n${engagementFlags.map((flag) => _lowerCase(flag)).join(', ')}`
+            : t('scoreReports.unreliableTagText')
+          : t('scoreReports.reliableTagText'),
+    },
+  ];
+
+  const round = (value) => (value == null ? null : Math.round(value));
+
+  const buildEntry = (task) => {
+    const slug = task.taskSlug;
+    const grade = gradeLevel;
+    const useSpanishNorms = (slug === 'swr-es' || slug === 'sre-es') && taskScoringVersions[slug] >= 1;
+    // Optional tasks render a neutral dial (matching legacy getDialColor, which returns no
+    // color for optional tasks) even though the backend classifies a completed optional task.
+    const dialColor = task.optional
+      ? undefined
+      : (SUPPORT_LEVEL_DIAL_COLOR[task.supportLevel] ?? SCORE_SUPPORT_LEVEL_COLORS.ASSESSED);
+    const rawRange = getRawScoreRange(slug);
+
+    const scoresForTask = {
+      standardScore: {
+        name: t('scoreReports.standardScore'),
+        value: round(task.scores?.standardScore),
+        min: 0,
+        max: 180,
+        supportColor: dialColor,
+      },
+      rawScore: {
+        name: t('scoreReports.rawScore'),
+        value: round(task.scores?.rawScore),
+        min: rawRange?.min,
+        max: rawRange?.max,
+        supportColor: dialColor,
+      },
+      percentileScore: {
+        name:
+          tasksToDisplayPercentCorrect.includes(slug) && !useSpanishNorms
+            ? t('scoreReports.percentCorrect')
+            : t('scoreReports.percentileScore'),
+        value: round(task.scores?.percentile),
+        min: 0,
+        max: slug.includes('letter') ? 100 : 99,
+        supportColor: dialColor,
+      },
+    };
+
+    // Phonics renders its subscores via `score.subscores` on the displayed score.
+    if (slug === 'phonics' && task.subscores) {
+      scoresForTask.percentileScore.subscores = Object.fromEntries(
+        Object.entries(task.subscores).map(([key, value]) => [key, `${value.correct}/${value.attempted}`]),
+      );
+    }
+
+    // Score-breakdown rows: standard, percentile (grade < 6 only), raw — the order the
+    // legacy createScoresArray sorts to. Letter/PA granular rows are a known gap.
+    const scoresArray = [
+      [
+        scoresForTask.standardScore.name,
+        scoresForTask.standardScore.value,
+        scoresForTask.standardScore.min,
+        scoresForTask.standardScore.max,
+      ],
+    ];
+    if (grade < 6) {
+      scoresArray.push([
+        scoresForTask.percentileScore.name,
+        scoresForTask.percentileScore.value,
+        scoresForTask.percentileScore.min,
+        scoresForTask.percentileScore.max,
+      ]);
+    }
+    scoresArray.push([
+      scoresForTask.rawScore.name,
+      scoresForTask.rawScore.value,
+      scoresForTask.rawScore.min,
+      scoresForTask.rawScore.max,
+    ]);
+    if (slug === 'pa' && task.skillsToWorkOn) {
+      const skills = task.skillsToWorkOn.map((key) => t(PA_SUBTASK_I18N_KEYS[key] ?? key));
+      scoresArray.push([t('scoreReports.skillsToWorkOn'), skills.join(', ') || t('scoreReports.none')]);
+    }
+
+    return {
+      taskId: slug,
+      scoreToDisplay: getScoreToDisplay(slug, grade),
+      ...scoresForTask,
+      tags: buildTags(task.optional, task.reliable, task.engagementFlags),
+      scores: task.scores,
+      // Already in the LongitudinalChart input shape ({ date, scores, administrationId }).
+      historicalScores: task.historicalScores ?? [],
+      scoresArray,
+    };
+  };
+
+  const computedTaskData = computed(() => {
+    const tasks = toValue(reportTasks) ?? [];
+    return tasks
+      .filter((task) => task.scores?.rawScore != null && !['vocab', 'cva'].includes(task.taskSlug))
+      .map(buildEntry)
+      .sort((a, b) => (taskDisplayNames[a.taskId]?.order ?? 99) - (taskDisplayNames[b.taskId]?.order ?? 99));
+  });
+
+  const scoreValueTemplate = computed(() => (task) => {
+    const appendPercentageTo = ['phonics', 'letter', 'letter-es', 'letter-en-ca'];
+    if (appendPercentageTo.includes(task.taskId)) {
+      const value = task[task.scoreToDisplay].value;
+      return value == null ? '' : value + '%';
+    }
+    return task.scoreToDisplay === SCORE_TYPES.PERCENTILE_SCORE
+      ? ScoreReportService.getPercentileSuffixTemplate(task.percentileScore.value, i18n)
+      : undefined;
+  });
+
+  // Reuse the service's text builders; they read the per-score `.value` fields we
+  // populated from the backend, so no client re-scoring is involved.
+  const getTaskDescription = computed(
+    () => (task) => ScoreReportService.getScoreDescription(task, gradeLevel, i18n, taskScoringVersions[task.taskId]),
+  );
+
+  const getTaskScoresArray = computed(() => (task) => ScoreReportService.getScoresArrayForTask(task));
+
+  return { computedTaskData, scoreValueTemplate, getTaskDescription, getTaskScoresArray };
+}

--- a/apps/dashboard/src/containers/StudentScoreReport/components/ScoreList/useReportCardData.test.js
+++ b/apps/dashboard/src/containers/StudentScoreReport/components/ScoreList/useReportCardData.test.js
@@ -1,0 +1,111 @@
+import { describe, it, expect } from 'vitest';
+import { useReportCardData } from './useReportCardData';
+import { SCORE_SUPPORT_LEVEL_COLORS } from '@/constants/scores';
+
+// Pass-through translator so assertions can match i18n keys directly.
+const t = (key) => key;
+
+const makeTask = (overrides = {}) => ({
+  taskId: '11111111-1111-1111-1111-111111111111',
+  taskSlug: 'swr',
+  taskName: 'Word',
+  orderIndex: 0,
+  scores: { rawScore: 500, percentile: 50, standardScore: 100 },
+  supportLevel: 'achievedSkill',
+  reliable: true,
+  optional: false,
+  completed: true,
+  engagementFlags: [],
+  tags: [],
+  historicalScores: [],
+  ...overrides,
+});
+
+const cards = (tasks, grade = '3', taskScoringVersions = {}) =>
+  useReportCardData({ reportTasks: tasks, studentGrade: grade, taskScoringVersions, t }).computedTaskData.value;
+
+describe('useReportCardData', () => {
+  it('builds the displayed score from backend values with the support-level color', () => {
+    const [card] = cards([makeTask()], '3');
+    expect(card.taskId).toBe('swr');
+    expect(card.scoreToDisplay).toBe('percentileScore'); // grade < 6, normed
+    expect(card.rawScore.value).toBe(500);
+    expect(card.percentileScore.value).toBe(50);
+    expect(card.standardScore.value).toBe(100);
+    expect(card.percentileScore.supportColor).toBe(SCORE_SUPPORT_LEVEL_COLORS.ABOVE);
+  });
+
+  it('surfaces the standard score for grade >= 6', () => {
+    const [card] = cards([makeTask()], '8');
+    expect(card.scoreToDisplay).toBe('standardScore');
+  });
+
+  it('renders a neutral dial (no color) for optional tasks', () => {
+    const [card] = cards([makeTask({ optional: true })], '3');
+    expect(card.percentileScore.supportColor).toBeUndefined();
+  });
+
+  it('builds type + reliability tags from the backend flags (engagementFlags as an array)', () => {
+    const [reliable] = cards([makeTask()], '3');
+    expect(reliable.tags).toHaveLength(2);
+    expect(reliable.tags[0].value).toBe('scoreReports.required');
+    expect(reliable.tags[1].value).toBe('scoreReports.reliable');
+
+    const [unreliable] = cards([makeTask({ reliable: false, engagementFlags: ['responseTimeTooFast'] })], '3');
+    expect(unreliable.tags[1].value).toBe('scoreReports.unreliable');
+    expect(unreliable.tags[1].tooltip).toContain('response time too fast');
+  });
+
+  it('includes the percentile breakdown row only for grade < 6', () => {
+    const [underSix] = cards([makeTask()], '3');
+    const namesUnder = underSix.scoresArray.map((row) => row[0]);
+    expect(namesUnder).toContain('scoreReports.percentileScore');
+
+    const [overSix] = cards([makeTask()], '8');
+    const namesOver = overSix.scoresArray.map((row) => row[0]);
+    expect(namesOver).not.toContain('scoreReports.percentileScore');
+  });
+
+  it('formats phonics subscores onto the displayed score as correct/attempted strings', () => {
+    const task = makeTask({
+      taskSlug: 'phonics',
+      subscores: { cvc: { correct: 15, attempted: 19, percentCorrect: 78.9 } },
+    });
+    const [card] = cards([task], '3');
+    expect(card.percentileScore.subscores).toEqual({ cvc: '15/19' });
+  });
+
+  it('adds a PA skills-to-work-on row from the backend skillsToWorkOn', () => {
+    const task = makeTask({ taskSlug: 'pa', skillsToWorkOn: ['FSM'] });
+    const [card] = cards([task], '3');
+    const skillsRow = card.scoresArray.find((row) => row[0] === 'scoreReports.skillsToWorkOn');
+    expect(skillsRow).toBeDefined();
+  });
+
+  it('excludes vocab/cva and tasks without a raw score', () => {
+    const result = cards(
+      [
+        makeTask({ taskSlug: 'swr' }),
+        makeTask({ taskSlug: 'vocab' }),
+        makeTask({ taskSlug: 'cva' }),
+        makeTask({ taskSlug: 'sre', scores: { rawScore: null, percentile: null, standardScore: null } }),
+      ],
+      '3',
+    );
+    expect(result.map((c) => c.taskId)).toEqual(['swr']);
+  });
+
+  it('scoreValueTemplate appends % for phonics/letter and blanks a null value', () => {
+    const { computedTaskData, scoreValueTemplate } = useReportCardData({
+      reportTasks: [makeTask({ taskSlug: 'phonics', scores: { rawScore: 10, percentile: 80, standardScore: null } })],
+      studentGrade: '3',
+      taskScoringVersions: {},
+      t,
+    });
+    const [phonics] = computedTaskData.value;
+    expect(scoreValueTemplate.value(phonics)).toBe('80%');
+
+    const nullPercentile = { ...phonics, percentileScore: { ...phonics.percentileScore, value: null } };
+    expect(scoreValueTemplate.value(nullPercentile)).toBe('');
+  });
+});

--- a/apps/dashboard/src/pages/ScoreReport.vue
+++ b/apps/dashboard/src/pages/ScoreReport.vue
@@ -58,11 +58,7 @@
                   <div v-for="taskId of sortedAndFilteredTaskIds" :key="taskId" style="width: 33%">
                     <div class="distribution-overview-wrapper">
                       <DistributionChartOverview
-                        :runs="
-                          props.orgType === 'district'
-                            ? aggregatedDistrictSupportCategories[taskId]
-                            : computeAssignmentAndRunData.runsByTaskId[taskId]
-                        "
+                        :support-level-counts="scoreOverviewBySlug[taskId]"
                         :initialized="initialized"
                         :task-id="taskId"
                         :org-type="props.orgType"
@@ -427,6 +423,7 @@ import { getDynamicRouterPath } from '@/helpers/getDynamicRouterPath';
 import useUserType from '@/composables/useUserType';
 import useUserClaimsQuery from '@/composables/queries/useUserClaimsQuery';
 import useAdministrationsQuery from '@/composables/queries/useAdministrationsQuery';
+import useAdministrationScoreOverviewQuery from '@/composables/queries/useAdministrationScoreOverviewQuery';
 import useOrgQuery from '@/composables/queries/useOrgQuery';
 import useDistrictSchoolsQuery from '@/composables/queries/useDistrictSchoolsQuery';
 import useAdministrationAssignmentsQuery from '@/composables/queries/useAdministrationAssignmentsQuery';
@@ -515,6 +512,25 @@ const {
 } = useDistrictSupportCategoriesQuery(props.orgId, props.administrationId, {
   enabled: computed(() => initialized.value && props.orgType === 'district'),
 });
+
+// Server-computed support-level distributions per task: the source of the "at a glance"
+// chart VALUES, scoped to this org/class/group. Keyed by task slug to match the slug-based
+// `sortedAndFilteredTaskIds` the template iterates.
+//
+// NOTE (incremental): only the chart values move to the backend here. Which tasks show a
+// chart (`sortedAndFilteredTaskIds`) and the district loading / empty-state still derive
+// from the Firestore `useAdministrationAssignmentsQuery` / `useDistrictSupportCategoriesQuery`,
+// which also feed the table + subscore tables. They're unified onto the backend in the final
+// score-report cleanup PR once those components are migrated.
+const { data: scoreOverviewData } = useAdministrationScoreOverviewQuery(
+  props.administrationId,
+  props.orgType,
+  props.orgId,
+  { enabled: initialized },
+);
+const scoreOverviewBySlug = computed(() =>
+  Object.fromEntries((scoreOverviewData.value?.tasks ?? []).map((task) => [task.taskSlug, task.supportLevels])),
+);
 
 const getScoringVersions = computed(() => {
   if (!administrationData.value?.assessments) return {};

--- a/apps/dashboard/src/pages/ScoreReport.vue
+++ b/apps/dashboard/src/pages/ScoreReport.vue
@@ -424,6 +424,7 @@ import useUserType from '@/composables/useUserType';
 import useUserClaimsQuery from '@/composables/queries/useUserClaimsQuery';
 import useAdministrationsQuery from '@/composables/queries/useAdministrationsQuery';
 import useAdministrationScoreOverviewQuery from '@/composables/queries/useAdministrationScoreOverviewQuery';
+import useAdministrationScoreStudentsQuery from '@/composables/queries/useAdministrationScoreStudentsQuery';
 import useOrgQuery from '@/composables/queries/useOrgQuery';
 import useDistrictSchoolsQuery from '@/composables/queries/useDistrictSchoolsQuery';
 import useAdministrationAssignmentsQuery from '@/composables/queries/useAdministrationAssignmentsQuery';
@@ -851,7 +852,12 @@ const assignedNormedTaskIds = computed(() => assignedTaskIds.value.filter((id) =
 // Return a faded color if assessment is not reliable
 function returnColorByReliability(assessment, rawScore, support_level, tag_color) {
   if (assessment.reliable !== undefined && !assessment.reliable && assessment.engagementFlags !== undefined) {
-    const engagementFlagExists = Object.keys(assessment.engagementFlags).some((flag) =>
+    // engagementFlags may arrive as an array (backend / normalized rows) or a legacy
+    // Firestore object map (raw assessment) — normalize before reading.
+    const engagementFlags = Array.isArray(assessment.engagementFlags)
+      ? assessment.engagementFlags
+      : Object.keys(assessment.engagementFlags ?? {});
+    const engagementFlagExists = engagementFlags.some((flag) =>
       includedValidityFlags[assessment.taskId]?.includes(flag),
     );
     if (support_level === 'Optional') {
@@ -1102,7 +1108,11 @@ const computeAssignmentAndRunData = computed(() => {
           optional: isOptional,
           supportLevel: support_level,
           reliable: assessment.reliable,
-          engagementFlags: assessment.engagementFlags ?? [],
+          // engagementFlags is normalized to an array of flag-name strings (matching the
+          // backend score shape); legacy Firestore data carries it as an object map.
+          engagementFlags: Array.isArray(assessment.engagementFlags)
+            ? assessment.engagementFlags
+            : Object.keys(assessment.engagementFlags ?? {}),
           tagColor: tagColor,
           percentile: percentile,
           percentileString: percentileString,
@@ -1367,13 +1377,118 @@ const computeAssignmentAndRunData = computed(() => {
   }
 });
 
+// --- Backend per-student scores (the score-report table's core score source) ---
+// The table's core per-task scores (rawScore / percentile / standardScore / supportLevel
+// + reliability) come from the backend; the frontend owns presentation (color per level,
+// number formatting). The per-task "special" fields (percentCorrect, gradeEstimate, ROAM
+// fr/fc, …) and the CSV/PDF export still derive from `computeAssignmentAndRunData` — a
+// deferred follow-up. There is no student table at district scope, so the query is off there.
+const { data: studentScoresData } = useAdministrationScoreStudentsQuery(
+  props.administrationId,
+  props.orgType,
+  props.orgId,
+  { enabled: computed(() => initialized.value && props.orgType !== 'district') },
+);
+
+// The frontend owns the color for each backend support-level enum (`reliable: false` plus a
+// recognized engagement flag fades the color). The backend is the source of truth for the
+// level itself; `optional` / `null` levels keep the client-derived cell.
+const SUPPORT_LEVEL_DISPLAY = {
+  needsExtraSupport: { label: 'Needs Extra Support', color: SCORE_SUPPORT_LEVEL_COLORS.BELOW, faded: '#d6b8c7' },
+  developingSkill: { label: 'Developing Skill', color: SCORE_SUPPORT_LEVEL_COLORS.SOME, faded: '#e8dbb5' },
+  achievedSkill: { label: 'Achieved Skill', color: SCORE_SUPPORT_LEVEL_COLORS.ABOVE, faded: '#c0d9bd' },
+};
+
+// Non-normed tasks whose columns show task-specific values (percent correct, grade estimate,
+// correct/incorrect difference, raw-only) rather than the normed percentile/standard/raw the
+// backend overlay supplies. listStudents maps their `percentile`/`rawScore` to task-specific
+// numbers, so these keep their client-computed cells entirely (deferred follow-up).
+const SPECIAL_TASK_SLUGS = new Set([
+  ...tasksToDisplayPercentCorrect,
+  ...tasksToDisplayTotalCorrect,
+  ...tasksToDisplayGradeEstimate,
+  ...tasksToDisplayCorrectIncorrectDifference,
+  ...rawOnlyTasks,
+]);
+
+// Backend scores re-keyed: userId → { taskSlug → entry }. The table columns are slug-based,
+// while the response keys `scores` by task UUID.
+const backendScoresByUser = computed(() => {
+  const data = studentScoresData.value;
+  if (!data) return {};
+  const slugByUuid = Object.fromEntries(data.tasks.map((task) => [task.taskId, task.taskSlug]));
+  const byUser = {};
+  for (const row of data.students) {
+    const slugScores = {};
+    for (const [taskUuid, entry] of Object.entries(row.scores)) {
+      slugScores[slugByUuid[taskUuid] ?? taskUuid] = entry;
+    }
+    byUser[row.user.userId] = slugScores;
+  }
+  return byUser;
+});
+
+/**
+ * Overlay the backend per-student core scores onto the client-computed table rows.
+ *
+ * For each task the backend scores, the numeric fields (rawScore / percentile /
+ * standardScore) and the support-level classification + color are taken from the backend;
+ * the frontend formats them. Fields the backend leaves null (e.g. percentile for non-normed
+ * tasks) and the per-task "special" fields keep the client value, so the special-task
+ * columns and the CSV/PDF export are unaffected (deferred follow-up).
+ */
+const tableDataWithBackendScores = computed(() => {
+  const clientRows = computeAssignmentAndRunData.value.assignmentTableData;
+  const byUser = backendScoresByUser.value;
+  if (!clientRows.length || Object.keys(byUser).length === 0) return clientRows;
+
+  return clientRows.map((row) => {
+    const backendScores = byUser[row.user.userId];
+    if (!backendScores) return row;
+
+    const mergedScores = {};
+    for (const [slug, clientScore] of Object.entries(row.scores)) {
+      const entry = backendScores[slug];
+      // Special (non-normed) tasks keep their client-computed cell: listStudents maps their
+      // `percentile`/`rawScore` to task-specific values that don't belong in the normed
+      // columns, and those cells + the CSV export stay client-side (deferred follow-up).
+      if (!entry || SPECIAL_TASK_SLUGS.has(slug)) {
+        mergedScores[slug] = clientScore;
+        continue;
+      }
+
+      const merged = { ...clientScore };
+      if (entry.rawScore != null) merged.rawScore = entry.rawScore;
+      // Only the numeric `percentile` (the table cell) comes from the backend; keep the
+      // client's `percentileString`, which carries the >99 / <1 display cap the CSV export uses.
+      if (entry.percentile != null) merged.percentile = entry.percentile;
+      if (entry.standardScore != null) merged.standardScore = entry.standardScore;
+      if (entry.reliable != null) merged.reliable = entry.reliable;
+      if (entry.engagementFlags) merged.engagementFlags = entry.engagementFlags;
+
+      const levelInfo = entry.supportLevel ? SUPPORT_LEVEL_DISPLAY[entry.supportLevel] : null;
+      if (levelInfo) {
+        merged.supportLevel = levelInfo.label;
+        const faded =
+          entry.reliable === false &&
+          (entry.engagementFlags ?? []).some((flag) => includedValidityFlags[slug]?.includes(flag));
+        merged.tagColor = faded ? levelInfo.faded : levelInfo.color;
+      }
+
+      mergedScores[slug] = merged;
+    }
+
+    return { ...row, scores: mergedScores };
+  });
+});
+
 // This composable manages the data which is passed into the FilterBar component slot for filtering
 const filteredTableData = ref([]);
 
 watch(
-  computeAssignmentAndRunData,
+  tableDataWithBackendScores,
   (newValue) => {
-    filteredTableData.value = newValue.assignmentTableData;
+    filteredTableData.value = newValue;
   },
   { immediate: true, deep: true },
 );
@@ -1502,12 +1617,10 @@ const createExportData = ({ rows, includeProgress = false }) => {
 
       // Add reliability information
       if (score.reliable !== undefined && !score.reliable && score.engagementFlags !== undefined) {
-        const engagementFlags = Object.keys(score.engagementFlags);
+        const engagementFlags = score.engagementFlags;
         if (engagementFlags.length > 0) {
           if (includedValidityFlags[taskId]) {
-            const filteredFlags = Object.keys(score.engagementFlags).filter((flag) =>
-              includedValidityFlags[taskId].includes(flag),
-            );
+            const filteredFlags = score.engagementFlags.filter((flag) => includedValidityFlags[taskId].includes(flag));
             tableRow[`${taskName} - Reliability`] =
               filteredFlags.length === 0 ? 'Unreliable' : `Unreliable: ${filteredFlags.map(_lowerCase).join(', ')}`;
           } else {

--- a/apps/dashboard/src/pages/ScoreReport.vue
+++ b/apps/dashboard/src/pages/ScoreReport.vue
@@ -315,7 +315,9 @@
           <div class="text-sm font-light text-gray-600 uppercase">Loading Task Reports</div>
         </div>
         <template v-if="!isLoadingAssignments && !isLoadingTasksDictionary && !isLoadingDistrictSupportCategories">
-          <PvTabs v-model:value="activeTabIndex">
+          <!-- lazy: only the active tab's TaskReport mounts, so subscore tables fetch on demand
+               (one cached request per opened tab) instead of all firing on report open. -->
+          <PvTabs v-model:value="activeTabIndex" lazy>
             <PvTabList>
               <PvTab v-for="(taskId, i) in sortedAndFilteredSubscoreTaskIds" :key="taskId" :value="i" class="text-base">
                 {{ tasksDictionary[taskId]?.nameSimple ?? taskId }}
@@ -327,11 +329,11 @@
                 <div :id="'tab-view-' + taskId">
                   <TaskReport
                     v-if="taskId"
-                    :computed-table-data="computeAssignmentAndRunData.assignmentTableData"
                     :task-id="taskId"
                     :initialized="initialized"
                     :administration-id="administrationId"
                     :facets="facetsByTask[taskId]"
+                    :task-uuid="taskUuidBySlug[taskId]"
                     :org-type="orgType"
                     :org-id="orgId"
                     :org-info="orgData"
@@ -544,6 +546,16 @@ const { data: scoreFacetsData } = useAdministrationScoreFacetsQuery(
 const facetsByTask = computed(() =>
   Object.fromEntries((scoreFacetsData.value?.tasks ?? []).map((task) => [task.taskSlug, task])),
 );
+
+// Slug → task UUID, from the backend report task metadata. The subscores endpoint
+// is keyed by UUID; the report iterates tasks by slug. Merged from the facets and
+// students responses so every scored task resolves regardless of which loaded first.
+const taskUuidBySlug = computed(() => {
+  const map = {};
+  for (const task of scoreFacetsData.value?.tasks ?? []) map[task.taskSlug] = task.taskId;
+  for (const task of studentScoresData.value?.tasks ?? []) map[task.taskSlug] = task.taskId;
+  return map;
+});
 
 const getScoringVersions = computed(() => {
   if (!administrationData.value?.assessments) return {};

--- a/apps/dashboard/src/pages/ScoreReport.vue
+++ b/apps/dashboard/src/pages/ScoreReport.vue
@@ -331,11 +331,7 @@
                     :task-id="taskId"
                     :initialized="initialized"
                     :administration-id="administrationId"
-                    :runs="
-                      orgType === 'district'
-                        ? aggregatedDistrictSupportCategories?.[taskId]
-                        : computeAssignmentAndRunData.runsByTaskId?.[taskId]
-                    "
+                    :facets="facetsByTask[taskId]"
                     :org-type="orgType"
                     :org-id="orgId"
                     :org-info="orgData"
@@ -425,6 +421,7 @@ import useUserClaimsQuery from '@/composables/queries/useUserClaimsQuery';
 import useAdministrationsQuery from '@/composables/queries/useAdministrationsQuery';
 import useAdministrationScoreOverviewQuery from '@/composables/queries/useAdministrationScoreOverviewQuery';
 import useAdministrationScoreStudentsQuery from '@/composables/queries/useAdministrationScoreStudentsQuery';
+import useAdministrationScoreFacetsQuery from '@/composables/queries/useAdministrationScoreFacetsQuery';
 import useOrgQuery from '@/composables/queries/useOrgQuery';
 import useDistrictSchoolsQuery from '@/composables/queries/useDistrictSchoolsQuery';
 import useAdministrationAssignmentsQuery from '@/composables/queries/useAdministrationAssignmentsQuery';
@@ -531,6 +528,21 @@ const { data: scoreOverviewData } = useAdministrationScoreOverviewQuery(
 );
 const scoreOverviewBySlug = computed(() =>
   Object.fromEntries((scoreOverviewData.value?.tasks ?? []).map((task) => [task.taskSlug, task.supportLevels])),
+);
+
+// Server-computed distribution facets per task (support-level + score bins, faceted by
+// grade and school) — the source for the per-task TaskReport distribution charts at ALL
+// scopes. This replaces both the client-side facet binning (non-district) and the Firestore
+// `aggregatedDistrictSupportCategories` feed (district); the charts no longer distinguish
+// scope. School facets are populated at district scope only (empty arrays elsewhere).
+const { data: scoreFacetsData } = useAdministrationScoreFacetsQuery(
+  props.administrationId,
+  props.orgType,
+  props.orgId,
+  { enabled: initialized },
+);
+const facetsByTask = computed(() =>
+  Object.fromEntries((scoreFacetsData.value?.tasks ?? []).map((task) => [task.taskSlug, task])),
 );
 
 const getScoringVersions = computed(() => {


### PR DESCRIPTION
## Summary

This PR cuts the **administrator path** of the individual student report over to the backend `getIndividualStudentReport` endpoint — the fifth slice of the score-report frontend migration. The score cards now **adopt the backend's computed values directly** (score values, support level, tags, subscores, per-task historical trend), retiring the client-side scoring pipeline (`processTaskScores` / `getScoreValue` / `getDialColor`) for this path.

The `StudentScoreReport` container is reached by two routes: the **administrator** path (org scopes, this PR) and the **parent** path (`orgType: 'family'`, a separate endpoint). The parent path stays on its legacy data path here and is migrated in the follow-on PR.

> Stacked on `enh/score-report-subscores` → `facets` → `students` → `overview`. Merge bottom-up.

## Changes

- **`useAdministrationIndividualScoreReportQuery`** (new) — non-paginated composable for `getIndividualStudentReport` (token + scope + userId gating, envelope unwrap, structured errors, pinned retry). Unit test.
- **`useReportCardData`** (new) — builds the `ScoreCard` contract from the backend's computed per-task values: scores from `task.scores`, dial color from a frontend `supportLevel → color` map, type/reliability tags from `optional`/`reliable`/`engagementFlags`, longitudinal from `task.historicalScores` (already in the chart's input shape). Reuses the service's text builders (`getScoreDescription`, `getPercentileSuffixTemplate`) fed by backend values — no client re-scoring.
- **`ScoreList` / `ScoreList.print`** — branch on a new `reportTasks` prop (present → backend cards; null → legacy). `ScoreCard` is unchanged.
- **`StudentScoreReport` container** — `isParentPath = orgType === 'family'`; gates the legacy run-page + longitudinal queries to the parent path, adds the report query for the admin path, passes `:report-tasks`, and feeds a unified `taskData` to its summary/distribution computeds.

## Parity notes / gaps (for QA)

- **Cards can't render in CI sandbox** — needs a manual spot-check vs the current admin report across task families (swr/sre/pa/phonics/letter/roam), screen + print/PDF.
- **Letter card detail** (upper/lower/sounds + "to work on") is not in the endpoint (`subscores` is PA/phonics only) — that card shows primary scores only. Flagged for a backend decision.
- **Kept legacy** for both paths: `useUserDataQuery` (grade + PDF IDs) and `useAdministrationsQuery` (name/date + `scoringVersions`) — the report endpoint doesn't carry those. Retiring them is out of scope.

## Review fixes applied

- **Optional-task dial color preserved.** Completed optional tasks render a neutral dial (matching legacy `getDialColor`, which returns no color for optional tasks) rather than coloring them by the backend's classification.
- **Null displayed score guarded.** A phonics/letter card with a null percentile renders a blank value instead of `"null%"`.
- **`useReportCardData` unit test added** covering score selection, `scoreToDisplay` branching, the optional-neutral-dial, tags, the grade<6 percentile row, phonics subscores, PA skills, the include/exclude filter, and `scoreValueTemplate`.

## Testing

- Composable unit test (key, single-request unwrap, gating, error, retry) + `useReportCardData` unit test. `prettier --check` and `@vue/compiler-sfc` compile pass.
- ⚠️ Manual scoring-display QA required before merge (see gaps above), plus confirm the parent path (`orgType: 'family'`) is visually unchanged.



> [!NOTE]
> **Cross-fork stacking.** Because intermediate branches live only on `richford`, a `yeatmanlab/roar-dashboard` PR cannot use one as its base — every PR in this series targets `project/backend-refactor`, and they are reviewed/merged **bottom-up** so each shows only its own slice once its parent merges.

> [!IMPORTANT]
> **Merge order:** stacked on `enh/score-report-subscores` (#1982) — merge #1982 first; until it lands, this PR's diff sits on top of that branch's commits.

Resolves #1965
Part of #1958