### PR TITLE
Add GET /v1/users/:id/memberships (requester-scoped)

### DIFF
--- a/apps/backend/src/controllers/users.controller.test.ts
+++ b/apps/backend/src/controllers/users.controller.test.ts
@@ -66,6 +66,7 @@ describe('UsersController', () => {
   const mockGetUserAdministrations = vi.fn();
   const mockGetUserAdministration = vi.fn();
   const mockListUserAdministrationAgreements = vi.fn();
+  const mockListUserMemberships = vi.fn();
   const mockGetGuardianStudentReport = vi.fn();
   const mockAuthContext = AuthContextFactory.build({ userId: 'user-123', isSuperAdmin: false });
 
@@ -78,6 +79,7 @@ describe('UsersController', () => {
     mockUserService.create = mockCreate;
     mockUserService.update = mockUpdate;
     mockUserService.recordUserAgreement = mockRecordUserAgreement;
+    mockUserService.listUserMemberships = mockListUserMemberships;
     vi.mocked(UserService).mockReturnValue(mockUserService);
 
     // Setup the mock AdministrationService
@@ -538,6 +540,45 @@ describe('UsersController', () => {
       const { UsersController: Controller } = await import('./users.controller');
 
       await expect(Controller.update(superAdminContext, targetUserId, validBody)).rejects.toThrow('Unexpected error');
+    });
+  });
+
+  describe('listUserMemberships', () => {
+    const classMembership = {
+      entityType: 'class' as const,
+      entityId: 'class-A',
+      role: 'student' as const,
+      schoolId: 'school-A',
+      districtId: 'district-1',
+    };
+    const familyMembership = { entityType: 'family' as const, entityId: 'fam-1', role: 'child' as const };
+    const schoolMembership = { entityType: 'school' as const, entityId: 'school-A', role: 'administrator' as const };
+
+    it('returns 200 with the membership items, preserving schoolId/districtId on class rows', async () => {
+      mockListUserMemberships.mockResolvedValue([classMembership, familyMembership, schoolMembership]);
+
+      const { UsersController: Controller } = await import('./users.controller');
+      const result = await Controller.listUserMemberships(mockAuthContext, 'student-1');
+
+      const data = expectOkResponse(result);
+      // Deep equality confirms the transform preserves the class parent IDs and the
+      // family / org role shapes unchanged.
+      expect(data.items).toEqual([classMembership, familyMembership, schoolMembership]);
+      expect(mockListUserMemberships).toHaveBeenCalledWith(mockAuthContext, 'student-1');
+    });
+
+    it('maps a FORBIDDEN ApiError to a 403 response', async () => {
+      const error = new ApiError(ApiErrorMessage.FORBIDDEN, {
+        statusCode: StatusCodes.FORBIDDEN,
+        code: ApiErrorCode.AUTH_FORBIDDEN,
+      });
+      mockListUserMemberships.mockRejectedValue(error);
+
+      const { UsersController: Controller } = await import('./users.controller');
+      const result = await Controller.listUserMemberships(mockAuthContext, 'student-1');
+
+      const errorBody = expectErrorResponse(result, StatusCodes.FORBIDDEN);
+      expect(errorBody.code).toBe(ApiErrorCode.AUTH_FORBIDDEN);
     });
   });
 

--- a/apps/backend/src/controllers/users.controller.ts
+++ b/apps/backend/src/controllers/users.controller.ts
@@ -1,5 +1,6 @@
 import type { AuthContext } from '../types/auth-context';
 import type { User } from '../db/schema';
+import type { UserMembershipDetail } from '../repositories/user.repository';
 import type {
   UserResponse,
   CreateUserRequestBody,
@@ -9,6 +10,7 @@ import type {
   AdministrationsListQuery,
   AdministrationAgreementsListQuery,
   UserAdministrationAgreement,
+  UserMembershipResponse,
 } from '@roar-platform/api-contract';
 import { StatusCodes } from 'http-status-codes';
 import { UserService } from '../services/user';
@@ -81,6 +83,44 @@ function toUserAdministrationAgreement(item: AgreementWithSignedStatus): UserAdm
   return {
     ...toAgreementItem(item),
     signed: item.signed,
+  };
+}
+
+/**
+ * Map a service-layer membership into the API response shape.
+ *
+ * `UserMembershipDetail` is a discriminated union on `entityType`, so the branches
+ * narrow `role` (org/class roles vs. family roles) and surface the parent
+ * `schoolId` / `districtId` only on class memberships.
+ *
+ * @param membership - Service result for a single active membership
+ * @returns The API-formatted membership
+ */
+function toUserMembershipResponse(membership: UserMembershipDetail): UserMembershipResponse {
+  if (membership.entityType === 'class') {
+    // Parent IDs are present on full-access reads (self / super admin / guardian) and
+    // omitted on the scoped supervisory path — include them only when provided.
+    return {
+      entityType: 'class',
+      entityId: membership.entityId,
+      role: membership.role,
+      ...(membership.schoolId !== undefined ? { schoolId: membership.schoolId } : {}),
+      ...(membership.districtId !== undefined ? { districtId: membership.districtId } : {}),
+    };
+  }
+
+  if (membership.entityType === 'family') {
+    return {
+      entityType: 'family',
+      entityId: membership.entityId,
+      role: membership.role,
+    };
+  }
+
+  return {
+    entityType: membership.entityType,
+    entityId: membership.entityId,
+    role: membership.role,
   };
 }
 
@@ -363,6 +403,39 @@ export const UsersController = {
         return toErrorResponse(error, [
           StatusCodes.NOT_FOUND,
           StatusCodes.FORBIDDEN,
+          StatusCodes.INTERNAL_SERVER_ERROR,
+        ]);
+      }
+      throw error;
+    }
+  },
+
+  /**
+   * List a user's active entity memberships, scoped to the requester's access.
+   *
+   * Delegates authorization and row scoping to UserService; transforms the
+   * service result into the unpaginated API response.
+   *
+   * @param authContext - Requesting user's authentication context.
+   * @param userId - UUID of the user whose memberships to list.
+   */
+  listUserMemberships: async (authContext: AuthContext, userId: string) => {
+    try {
+      const memberships = await userService.listUserMemberships(authContext, userId);
+      return {
+        status: StatusCodes.OK as const,
+        body: {
+          data: {
+            items: memberships.map(toUserMembershipResponse),
+          },
+        },
+      };
+    } catch (error) {
+      if (error instanceof ApiError) {
+        return toErrorResponse(error, [
+          StatusCodes.UNAUTHORIZED,
+          StatusCodes.FORBIDDEN,
+          StatusCodes.NOT_FOUND,
           StatusCodes.INTERNAL_SERVER_ERROR,
         ]);
       }

--- a/apps/backend/src/repositories/user.repository.ts
+++ b/apps/backend/src/repositories/user.repository.ts
@@ -7,9 +7,29 @@ import { CoreDbClient } from '../db/clients';
 import type { CoreTransaction } from '../db/clients';
 import type * as CoreDbSchema from '../db/schema/core';
 import { UserRole } from '../enums/user-role.enum';
+import type { UserFamilyRole } from '../enums/user-family-role.enum';
 import { BaseRepository } from './base.repository';
 import { isEnrollmentActive, isActiveInFamily } from './utils/enrollment.utils';
 import { logger } from '../logger';
+
+/**
+ * Org types supported by the FGA model. Only `district` and `school` map to FGA
+ * object types today; other org types (national, state, local, department) are not
+ * yet used in ROAR and are skipped (logged) so a user gets a safe denial rather
+ * than a false grant.
+ */
+const FGA_SUPPORTED_ORG_TYPES: ReadonlySet<string> = new Set([EntityType.DISTRICT, EntityType.SCHOOL]);
+
+/**
+ * A single active entity membership of a user, enriched for the memberships read
+ * endpoint: each row carries the member's `role`, and class rows carry the parent
+ * `schoolId` / `districtId` (a student has no school-level row of their own — their
+ * school is the parent of their class).
+ */
+export type UserMembershipDetail =
+  | { entityType: 'district' | 'school' | 'group'; entityId: string; role: UserRole }
+  | { entityType: 'class'; entityId: string; role: UserRole; schoolId?: string; districtId?: string }
+  | { entityType: 'family'; entityId: string; role: UserFamilyRole };
 
 /**
  * User Repository
@@ -80,7 +100,6 @@ export class UserRepository extends BaseRepository<User, typeof users> {
     // FGA model today. Other org types (national, state, local, department) are not yet
     // used in ROAR — log a warning and skip them so the user gets a safe denial rather
     // than a false grant.
-    const FGA_SUPPORTED_ORG_TYPES: ReadonlySet<string> = new Set([EntityType.DISTRICT, EntityType.SCHOOL]);
     const orgMemberships: { entityType: EntityType; entityId: string }[] = [];
     for (const row of orgRows) {
       if (FGA_SUPPORTED_ORG_TYPES.has(row.orgType)) {
@@ -100,6 +119,81 @@ export class UserRepository extends BaseRepository<User, typeof users> {
       ...classRows.map((r) => ({ entityType: EntityType.CLASS, entityId: r.entityId })),
       ...groupRows.map((r) => ({ entityType: EntityType.GROUP, entityId: r.entityId })),
       ...familyRows.map((r) => ({ entityType: EntityType.FAMILY, entityId: r.entityId })),
+    ];
+  }
+
+  /**
+   * Get a user's active entity memberships, enriched for the memberships read endpoint.
+   *
+   * Like {@link getUserEntityMemberships}, but additionally returns each membership's
+   * `role` and, for class memberships, the parent `schoolId` / `districtId` (read off
+   * the `classes` row). Active-only: enrollment/membership windows must currently be
+   * open. Unsupported org types are skipped (logged), same as `getUserEntityMemberships`.
+   *
+   * @param userId - The user whose memberships to look up
+   * @returns Array of detailed memberships across orgs, classes, groups, and families
+   */
+  async getUserMembershipsDetailed(userId: string): Promise<UserMembershipDetail[]> {
+    const [orgRows, classRows, groupRows, familyRows] = await Promise.all([
+      this.db
+        .select({ entityId: userOrgs.orgId, role: userOrgs.role, orgType: orgs.orgType })
+        .from(userOrgs)
+        .innerJoin(orgs, eq(userOrgs.orgId, orgs.id))
+        .where(and(eq(userOrgs.userId, userId), isEnrollmentActive(userOrgs))),
+      this.db
+        .select({
+          entityId: userClasses.classId,
+          role: userClasses.role,
+          schoolId: classes.schoolId,
+          districtId: classes.districtId,
+        })
+        .from(userClasses)
+        .innerJoin(classes, eq(userClasses.classId, classes.id))
+        .where(and(eq(userClasses.userId, userId), isEnrollmentActive(userClasses))),
+      this.db
+        .select({ entityId: userGroups.groupId, role: userGroups.role })
+        .from(userGroups)
+        .where(and(eq(userGroups.userId, userId), isEnrollmentActive(userGroups))),
+      this.db
+        .select({ entityId: userFamilies.familyId, role: userFamilies.role })
+        .from(userFamilies)
+        .where(and(eq(userFamilies.userId, userId), isActiveInFamily(userFamilies))),
+    ]);
+
+    const orgMemberships: UserMembershipDetail[] = [];
+    for (const row of orgRows) {
+      if (FGA_SUPPORTED_ORG_TYPES.has(row.orgType)) {
+        // Safe: filtered to 'district' | 'school', which TypeScript can't infer statically.
+        orgMemberships.push({
+          entityType: row.orgType as 'district' | 'school',
+          entityId: row.entityId,
+          role: row.role,
+        });
+      } else {
+        logger.warn(
+          { userId, orgId: row.entityId, orgType: row.orgType },
+          'Skipping org membership with unsupported FGA org type',
+        );
+      }
+    }
+
+    return [
+      ...orgMemberships,
+      ...classRows.map(
+        (r): UserMembershipDetail => ({
+          entityType: EntityType.CLASS,
+          entityId: r.entityId,
+          role: r.role,
+          schoolId: r.schoolId,
+          districtId: r.districtId,
+        }),
+      ),
+      ...groupRows.map(
+        (r): UserMembershipDetail => ({ entityType: EntityType.GROUP, entityId: r.entityId, role: r.role }),
+      ),
+      ...familyRows.map(
+        (r): UserMembershipDetail => ({ entityType: EntityType.FAMILY, entityId: r.entityId, role: r.role }),
+      ),
     ];
   }
 

--- a/apps/backend/src/routes/users.integration.test.ts
+++ b/apps/backend/src/routes/users.integration.test.ts
@@ -3361,3 +3361,165 @@ describe('POST /v1/users/anonymous', () => {
     expect(allTuples).toHaveLength(0);
   });
 });
+
+// ═══════════════════════════════════════════════════════════════════════════
+// GET /v1/users/:userId/memberships
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('GET /v1/users/:userId/memberships', () => {
+  type MembershipItem = {
+    entityType: string;
+    entityId: string;
+    role?: string;
+    schoolId?: string;
+    districtId?: string;
+  };
+
+  // A student enrolled in a class in school A AND a class in school B, who is also
+  // a child in a family — exercises cross-school scoping and family-row visibility.
+  let crossSchoolChild: Awaited<ReturnType<typeof UserFactory.create>>;
+  let childParent: Awaited<ReturnType<typeof UserFactory.create>>;
+  let otherParent: Awaited<ReturnType<typeof UserFactory.create>>;
+  let childFamilyId: string;
+
+  beforeAll(async () => {
+    const { UserFamilyFactory } = await import('../test-support/factories/user-family.factory');
+    const { FamilyFactory } = await import('../test-support/factories/family.factory');
+    const { syncFgaTuplesFromPostgres } = await import('../test-support/fga');
+
+    crossSchoolChild = await UserFactory.create({ dob: '2015-01-01', grade: '3' });
+    await UserClassFactory.create({
+      userId: crossSchoolChild.id,
+      classId: baseFixture.classInSchoolA.id,
+      role: UserRole.STUDENT,
+    });
+    await UserClassFactory.create({
+      userId: crossSchoolChild.id,
+      classId: baseFixture.classInSchoolB.id,
+      role: UserRole.STUDENT,
+    });
+
+    const family = await FamilyFactory.create();
+    childFamilyId = family.id;
+    childParent = await UserFactory.create({ dob: '1985-01-01' });
+    await UserFamilyFactory.create({ userId: childParent.id, familyId: family.id, role: 'parent' });
+    await UserFamilyFactory.create({ userId: crossSchoolChild.id, familyId: family.id, role: 'child' });
+
+    // A parent of a DIFFERENT family — must not be able to read crossSchoolChild.
+    const otherFamily = await FamilyFactory.create();
+    otherParent = await UserFactory.create({ dob: '1986-01-01' });
+    await UserFamilyFactory.create({ userId: otherParent.id, familyId: otherFamily.id, role: 'parent' });
+
+    await syncFgaTuplesFromPostgres();
+  });
+
+  it('returns the full set to a guardian — both classes, the family row, and class parent IDs', async () => {
+    const res = await expectRoute('GET', `/v1/users/${crossSchoolChild.id}/memberships`)
+      .as({ id: childParent.id, authId: childParent.authId! })
+      .toReturn(StatusCodes.OK);
+
+    const items: MembershipItem[] = res.body.data.items;
+    const classA = items.find((m) => m.entityType === 'class' && m.entityId === baseFixture.classInSchoolA.id);
+    const classB = items.find((m) => m.entityType === 'class' && m.entityId === baseFixture.classInSchoolB.id);
+    const family = items.find((m) => m.entityType === 'family' && m.entityId === childFamilyId);
+
+    expect(classA).toBeDefined();
+    expect(classB).toBeDefined();
+    expect(family).toBeDefined();
+    // A guardian is entitled to the whole child, so the class parent IDs are present.
+    expect(classA?.schoolId).toBe(baseFixture.schoolA.id);
+    expect(classA?.districtId).toBe(baseFixture.district.id);
+    expect(classB?.schoolId).toBe(baseFixture.schoolB.id);
+  });
+
+  it('returns the full set to the user themselves (with class parent IDs)', async () => {
+    const res = await expectRoute('GET', `/v1/users/${crossSchoolChild.id}/memberships`)
+      .as({ id: crossSchoolChild.id, authId: crossSchoolChild.authId! })
+      .toReturn(StatusCodes.OK);
+
+    const items: MembershipItem[] = res.body.data.items;
+    const classA = items.find((m) => m.entityType === 'class' && m.entityId === baseFixture.classInSchoolA.id);
+    expect(classA?.role).toBe('student');
+    expect(classA?.schoolId).toBe(baseFixture.schoolA.id);
+    expect(classA?.districtId).toBe(baseFixture.district.id);
+    expect(items.some((m) => m.entityType === 'class' && m.entityId === baseFixture.classInSchoolB.id)).toBe(true);
+    expect(items.some((m) => m.entityType === 'family' && m.entityId === childFamilyId)).toBe(true);
+  });
+
+  it('returns the full set to a super admin', async () => {
+    const res = await expectRoute('GET', `/v1/users/${crossSchoolChild.id}/memberships`)
+      .as(tiers.superAdmin)
+      .toReturn(StatusCodes.OK);
+
+    const items: MembershipItem[] = res.body.data.items;
+    const entityIds = items.map((m) => m.entityId);
+    expect(entityIds).toContain(baseFixture.classInSchoolA.id);
+    expect(entityIds).toContain(baseFixture.classInSchoolB.id);
+    expect(entityIds).toContain(childFamilyId);
+  });
+
+  it('scopes a school-A principal to school A — no school-B class, no family row, class parent IDs stripped', async () => {
+    const res = await expectRoute('GET', `/v1/users/${crossSchoolChild.id}/memberships`)
+      .as({ id: baseFixture.schoolAPrincipal.id, authId: baseFixture.schoolAPrincipal.authId! })
+      .toReturn(StatusCodes.OK);
+
+    const items: MembershipItem[] = res.body.data.items;
+    const classA = items.find((m) => m.entityType === 'class' && m.entityId === baseFixture.classInSchoolA.id);
+
+    // Sees the school-A class they supervise...
+    expect(classA).toBeDefined();
+    // ...but parent school/district IDs are withheld: a class-scoped supervisor can list the
+    // class's users without `can_read` on the parent school, so echoing them would leak org IDs.
+    expect(classA?.schoolId).toBeUndefined();
+    expect(classA?.districtId).toBeUndefined();
+    // Never the school-B enrolment, never the family row.
+    expect(items.some((m) => m.entityType === 'class' && m.entityId === baseFixture.classInSchoolB.id)).toBe(false);
+    expect(items.some((m) => m.entityType === 'family')).toBe(false);
+  });
+
+  it('denies a parent of a different family — no cross-family leakage (403)', async () => {
+    const res = await expectRoute('GET', `/v1/users/${crossSchoolChild.id}/memberships`)
+      .as({ id: otherParent.id, authId: otherParent.authId! })
+      .toReturn(StatusCodes.FORBIDDEN);
+
+    expect(res.body.error.code).toBe(ApiErrorCode.AUTH_FORBIDDEN);
+  });
+
+  it('denies an unrelated student (403)', async () => {
+    const res = await expectRoute('GET', `/v1/users/${crossSchoolChild.id}/memberships`)
+      .as(tiers.student)
+      .toReturn(StatusCodes.FORBIDDEN);
+
+    expect(res.body.error.code).toBe(ApiErrorCode.AUTH_FORBIDDEN);
+  });
+
+  it('returns 401 when unauthenticated', async () => {
+    const res = await expectRoute('GET', `/v1/users/${crossSchoolChild.id}/memberships`)
+      .unauthenticated()
+      .toReturn(StatusCodes.UNAUTHORIZED);
+
+    expect(res.body.error.code).toBe(ApiErrorCode.AUTH_REQUIRED);
+  });
+
+  it('returns 404 for a non-existent user', async () => {
+    const res = await expectRoute('GET', '/v1/users/00000000-0000-0000-0000-000000000000/memberships')
+      .as(tiers.superAdmin)
+      .toReturn(StatusCodes.NOT_FOUND);
+
+    expect(res.body.error.code).toBe(ApiErrorCode.RESOURCE_NOT_FOUND);
+  });
+
+  it('returns 404 for a rostering-ended target user (#1742)', async () => {
+    const endedUser = await UserFactory.create({
+      dob: '2015-01-01',
+      grade: '3',
+      rosteringEnded: new Date(Date.now() - 24 * 60 * 60 * 1000),
+    });
+
+    const res = await expectRoute('GET', `/v1/users/${endedUser.id}/memberships`)
+      .as(tiers.superAdmin)
+      .toReturn(StatusCodes.NOT_FOUND);
+
+    expect(res.body.error.code).toBe(ApiErrorCode.RESOURCE_NOT_FOUND);
+  });
+});

--- a/apps/backend/src/routes/users.ts
+++ b/apps/backend/src/routes/users.ts
@@ -49,6 +49,10 @@ export function registerUserRoutes(routerInstance: Router) {
       handler: async ({ req: { user }, params: { userId, administrationId }, query }) =>
         UsersController.listUserAdministrationAgreements(user!, userId, administrationId, query),
     },
+    listUserMemberships: {
+      middleware: [AuthGuardMiddleware],
+      handler: async ({ req: { user }, params: { userId } }) => UsersController.listUserMemberships(user!, userId),
+    },
     scoreReports: {
       getGuardianStudentReport: {
         middleware: [AuthGuardMiddleware],

--- a/apps/backend/src/services/user/user.service.memberships.test.ts
+++ b/apps/backend/src/services/user/user.service.memberships.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { StatusCodes } from 'http-status-codes';
+import { UserService } from './user.service';
+import { UserFactory, AuthContextFactory } from '../../test-support/factories/user.factory';
+import { createMockUserRepository } from '../../test-support/repositories/user.repository';
+import { createMockAuthorizationService } from '../../test-support/services/authorization.service';
+import type { UserMembershipDetail } from '../../repositories/user.repository';
+import { FgaType, FgaRelation } from '../authorization/fga-constants';
+
+/**
+ * Unit tests for the requester-scoped row filtering on `listUserMemberships`.
+ *
+ * These mock FGA, so they assert the *wiring* (which relation is asked, on which
+ * objects, and which rows survive) — not the policy itself. The policy guarantee
+ * (that a school-A admin truly cannot resolve `can_list_users` on school B) needs
+ * integration tests against the real OpenFGA model.
+ */
+describe('UserService.listUserMemberships', () => {
+  let mockUserRepository: ReturnType<typeof createMockUserRepository>;
+  let mockAuthorizationService: ReturnType<typeof createMockAuthorizationService>;
+
+  // Target: a student enrolled in a class in school A and a class in school B,
+  // and a member of one family (a ROAR@Home child).
+  const classA: UserMembershipDetail = {
+    entityType: 'class',
+    entityId: 'class-A',
+    role: 'student',
+    schoolId: 'school-A',
+    districtId: 'district-1',
+  };
+  const classB: UserMembershipDetail = {
+    entityType: 'class',
+    entityId: 'class-B',
+    role: 'student',
+    schoolId: 'school-B',
+    districtId: 'district-1',
+  };
+  const family: UserMembershipDetail = { entityType: 'family', entityId: 'fam-1', role: 'child' };
+  const detailedMemberships: UserMembershipDetail[] = [classA, classB, family];
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    mockUserRepository = createMockUserRepository();
+    mockAuthorizationService = createMockAuthorizationService();
+  });
+
+  function service() {
+    return UserService({
+      userRepository: mockUserRepository,
+      authorizationService: mockAuthorizationService,
+    });
+  }
+
+  it('returns the full set for self, with no FGA filtering', async () => {
+    const authContext = AuthContextFactory.build({ userId: 'student-1', isSuperAdmin: false });
+    mockUserRepository.getById.mockResolvedValue(UserFactory.build({ id: 'student-1' }));
+    mockUserRepository.getUserMembershipsDetailed.mockResolvedValue(detailedMemberships);
+
+    const result = await service().listUserMemberships(authContext, 'student-1');
+
+    expect(result).toEqual(detailedMemberships);
+    expect(mockAuthorizationService.hasPermission).not.toHaveBeenCalled();
+    expect(mockAuthorizationService.hasAnyPermission).not.toHaveBeenCalled();
+  });
+
+  it('returns the full set for a super admin', async () => {
+    const authContext = AuthContextFactory.build({ userId: 'admin-1', isSuperAdmin: true });
+    mockUserRepository.getById.mockResolvedValue(UserFactory.build({ id: 'student-1' }));
+    mockUserRepository.getUserMembershipsDetailed.mockResolvedValue(detailedMemberships);
+
+    const result = await service().listUserMemberships(authContext, 'student-1');
+
+    expect(result).toEqual(detailedMemberships);
+    expect(mockAuthorizationService.hasPermission).not.toHaveBeenCalled();
+  });
+
+  it('returns the full set (including family rows) for a guardian of the user', async () => {
+    const authContext = AuthContextFactory.build({ userId: 'parent-1', isSuperAdmin: false });
+    mockUserRepository.getById.mockResolvedValue(UserFactory.build({ id: 'student-1' }));
+    // Gate: the target's entities include the family; the parent passes via can_list_users on it.
+    mockUserRepository.getUserEntityMemberships.mockResolvedValue([{ entityType: 'family', entityId: 'fam-1' }]);
+    mockUserRepository.getUserMembershipsDetailed.mockResolvedValue(detailedMemberships);
+    // Both the gate check and the guardian check resolve true for a parent.
+    mockAuthorizationService.hasAnyPermission.mockResolvedValue(true);
+
+    const result = await service().listUserMemberships(authContext, 'student-1');
+
+    expect(result).toEqual(detailedMemberships);
+    // The guardian check asks can_list_users on the child's family object.
+    expect(mockAuthorizationService.hasAnyPermission).toHaveBeenCalledWith('parent-1', FgaRelation.CAN_LIST_USERS, [
+      `${FgaType.FAMILY}:fam-1`,
+    ]);
+    // A guardian gets the full set without per-entity filtering.
+    expect(mockAuthorizationService.hasPermission).not.toHaveBeenCalled();
+  });
+
+  it("scopes an administrator to their reach — never another school's enrolment, never family rows", async () => {
+    const authContext = AuthContextFactory.build({ userId: 'principal-A', isSuperAdmin: false });
+    mockUserRepository.getById.mockResolvedValue(UserFactory.build({ id: 'student-1' }));
+    mockUserRepository.getUserEntityMemberships.mockResolvedValue([
+      { entityType: 'class', entityId: 'class-A' },
+      { entityType: 'class', entityId: 'class-B' },
+      { entityType: 'family', entityId: 'fam-1' },
+    ]);
+    mockUserRepository.getUserMembershipsDetailed.mockResolvedValue(detailedMemberships);
+    // Gate passes (first call) but the guardian check fails (the principal is not the parent).
+    mockAuthorizationService.hasAnyPermission.mockResolvedValueOnce(true).mockResolvedValueOnce(false);
+    // Per-entity: the principal can list users only in school A's class.
+    mockAuthorizationService.hasPermission.mockImplementation(
+      async (_userId, _relation, object) => object === `${FgaType.CLASS}:class-A`,
+    );
+
+    const result = await service().listUserMemberships(authContext, 'student-1');
+
+    // The school-A class survives, but its parent school/district IDs are stripped on the
+    // supervisory path (the principal can list the class's users but not read the school).
+    expect(result).toEqual([{ entityType: 'class', entityId: 'class-A', role: 'student' }]);
+    expect(result[0]).not.toHaveProperty('schoolId');
+    expect(result[0]).not.toHaveProperty('districtId');
+    // The school-B enrolment and the family row are filtered out entirely.
+    expect(result).not.toContainEqual(classB);
+    expect(result).not.toContainEqual(family);
+  });
+
+  it('propagates 403 from the access gate without fetching memberships', async () => {
+    const authContext = AuthContextFactory.build({ userId: 'stranger-1', isSuperAdmin: false });
+    mockUserRepository.getById.mockResolvedValue(UserFactory.build({ id: 'student-1' }));
+    mockUserRepository.getUserEntityMemberships.mockResolvedValue([{ entityType: 'class', entityId: 'class-A' }]);
+    mockAuthorizationService.hasAnyPermission.mockResolvedValue(false); // gate denies
+
+    await expect(service().listUserMemberships(authContext, 'student-1')).rejects.toMatchObject({
+      statusCode: StatusCodes.FORBIDDEN,
+    });
+    expect(mockUserRepository.getUserMembershipsDetailed).not.toHaveBeenCalled();
+  });
+
+  it('propagates 404 when the target user does not exist', async () => {
+    const authContext = AuthContextFactory.build({ userId: 'admin-1', isSuperAdmin: true });
+    mockUserRepository.getById.mockResolvedValue(null);
+
+    await expect(service().listUserMemberships(authContext, 'missing')).rejects.toMatchObject({
+      statusCode: StatusCodes.NOT_FOUND,
+    });
+  });
+});

--- a/apps/backend/src/services/user/user.service.ts
+++ b/apps/backend/src/services/user/user.service.ts
@@ -16,6 +16,7 @@ import { ApiError } from '../../errors/api-error';
 import { isUniqueViolation, isForeignKeyViolation, unwrapDrizzleError } from '../../errors';
 import { logger } from '../../logger';
 import { UserRepository } from '../../repositories/user.repository';
+import type { UserMembershipDetail } from '../../repositories/user.repository';
 import { UserAgreementRepository } from '../../repositories/user-agreement.repository';
 import { AgreementVersionRepository } from '../../repositories/agreement-version.repository';
 import { AgreementRepository } from '../../repositories/agreement.repository';
@@ -1574,9 +1575,104 @@ export function UserService({
     }
   }
 
+  /**
+   * List a user's active entity memberships, scoped to the requester's access.
+   *
+   * Authorization is two-layered:
+   * 1. Gate — {@link verifyUserAccess} (404-before-403, super-admin bypass, self, or
+   *    `can_list_users` on any of the target's entities; rostering-ended target → 404).
+   * 2. Row filter — the rows returned are scoped to what the requester may see of this
+   *    user:
+   *    - super admin / self / guardian (a parent with `can_list_users` on one of the
+   *      target's families) receive the full set, including family memberships;
+   *    - any other authorized requester (an administrator or educator) receives only the
+   *      entities they can `can_list_users`, checked per the target's own membership
+   *      entities, and class rows are returned without their parent school/district IDs
+   *      (the requester may list a class's users without being able to read its parent
+   *      school). Family memberships are dropped on this path — a supervisory requester
+   *      holds no family relation — so families surface only to self / guardian / super admin.
+   *
+   * Example: a principal of school A requesting a student enrolled in schools A and B
+   * receives the school-A class memberships only, never the school-B ones.
+   *
+   * @param authContext - Requesting user's authentication context
+   * @param targetUserId - UUID of the user whose memberships to list
+   * @returns The target's active memberships visible to the requester
+   * @throws {ApiError} NOT_FOUND if the user does not exist or is rostering-ended
+   * @throws {ApiError} FORBIDDEN if the requester cannot access the user
+   * @throws {ApiError} INTERNAL_SERVER_ERROR if a database or FGA query fails
+   */
+  async function listUserMemberships(authContext: AuthContext, targetUserId: string): Promise<UserMembershipDetail[]> {
+    const { userId, isSuperAdmin } = authContext;
+
+    try {
+      // 1. Gate: existence + base access. Throws 404 (not found / rostering-ended) or 403.
+      await verifyUserAccess(authContext, targetUserId);
+
+      // 2. Fetch the target's active memberships (role + class parent IDs).
+      const memberships = await userRepository.getUserMembershipsDetailed(targetUserId);
+
+      // 3. Full set for callers entitled to the whole user: super admin, the user
+      //    themselves, and a guardian (parent) of the user.
+      if (isSuperAdmin || userId === targetUserId) {
+        return memberships;
+      }
+
+      const familyObjects = memberships
+        .filter((m) => m.entityType === EntityType.FAMILY)
+        .map((m) => `${FgaType.FAMILY}:${m.entityId}`);
+
+      const isGuardian =
+        familyObjects.length > 0 &&
+        (await authorizationService.hasAnyPermission(userId, FgaRelation.CAN_LIST_USERS, familyObjects));
+
+      if (isGuardian) {
+        return memberships;
+      }
+
+      // 4. Supervisory path (administrator or educator): scope rows to the requester's
+      //    reach. Check `can_list_users` per the target's own (small, bounded) membership
+      //    entities and keep only those that pass — so a school-A admin sees the user's
+      //    school-A enrolment but never their school-B one. Family rows are never visible
+      //    here: a supervisory requester has no `can_list_users` on a family.
+      const allowed = await Promise.all(
+        memberships.map((m) =>
+          authorizationService.hasPermission(
+            userId,
+            FgaRelation.CAN_LIST_USERS,
+            `${ENTITY_TYPE_TO_FGA_TYPE[m.entityType]}:${m.entityId}`,
+          ),
+        ),
+      );
+
+      // Strip the parent school/district IDs from surviving class rows on this path. A
+      // requester can hold `can_list_users` on a class (e.g. a teacher rostered on it)
+      // without holding `can_read` on the parent school, so echoing those IDs would
+      // disclose org identifiers they can't otherwise read. The parent IDs are only
+      // needed by the homepage, which takes the full-set path above.
+      return memberships
+        .filter((_, index) => allowed[index] === true)
+        .map((m) =>
+          m.entityType === 'class' ? { entityType: 'class' as const, entityId: m.entityId, role: m.role } : m,
+        );
+    } catch (error) {
+      if (error instanceof ApiError) throw error;
+
+      logger.error({ err: error, context: { userId, targetUserId } }, 'Failed to list user memberships');
+
+      throw new ApiError(ApiErrorMessage.INTERNAL_SERVER_ERROR, {
+        statusCode: StatusCodes.INTERNAL_SERVER_ERROR,
+        code: ApiErrorCode.DATABASE_QUERY_FAILED,
+        context: { userId, targetUserId },
+        cause: error,
+      });
+    }
+  }
+
   return {
     findByAuthId,
     getById,
+    listUserMemberships,
     create,
     update,
     recordUserAgreement,

--- a/apps/backend/src/test-support/repositories/user.repository.ts
+++ b/apps/backend/src/test-support/repositories/user.repository.ts
@@ -13,6 +13,7 @@ export function createMockUserRepository(): MockedObject<UserRepository> {
     ...createMockBaseRepositoryMethods(),
     findByAuthId: vi.fn(),
     getUserEntityMemberships: vi.fn(),
+    getUserMembershipsDetailed: vi.fn(),
     hasPlatformAdminRole: vi.fn(),
     findClassParentSchool: vi.fn(),
     createWithMemberships: vi.fn(),

--- a/apps/backend/src/test-support/services/user.service.ts
+++ b/apps/backend/src/test-support/services/user.service.ts
@@ -10,6 +10,7 @@ export function createMockUserService(): MockedObject<ReturnType<typeof UserServ
   return {
     findByAuthId: vi.fn(),
     getById: vi.fn(),
+    listUserMemberships: vi.fn(),
     create: vi.fn(),
     update: vi.fn(),
     recordUserAgreement: vi.fn(),

--- a/packages/api-contract/src/v1/users/contract.ts
+++ b/packages/api-contract/src/v1/users/contract.ts
@@ -8,6 +8,7 @@ import {
   UpdateUserRequestBodySchema,
   RecordUserAgreementRequestBodySchema,
   RecordUserAgreementResponseSchema,
+  UserMembershipsResponseSchema,
 } from './schema';
 
 import {
@@ -211,6 +212,31 @@ export const UsersContract = c.router(
         'Use ?locale=<bcp47> to select the current version returned per agreement (defaults to en-US). ' +
         'Returns 403 if the requester does not have access to the administration for the specified user. ' +
         'Returns 404 if the specified user or administration does not exist, or the specified user lacks access to it.',
+    },
+    listUserMemberships: {
+      method: 'GET',
+      path: '/:userId/memberships',
+      pathParams: z.object({
+        userId: z.string().uuid(),
+      }),
+      responses: {
+        200: SuccessEnvelopeSchema(UserMembershipsResponseSchema),
+        401: ErrorEnvelopeSchema,
+        403: ErrorEnvelopeSchema,
+        404: ErrorEnvelopeSchema,
+        500: ErrorEnvelopeSchema,
+      },
+      strictStatusCodes: true,
+      summary: "List a user's active entity memberships",
+      description:
+        "Returns the specified user's active (current) org, class, group, and family memberships, each with the " +
+        "member's role. Class memberships can also include the parent schoolId and districtId so a caller can resolve " +
+        "the user's current school(s) without a separate lookup. Results are scoped to the requester's access: " +
+        'self, super admins, and a guardian of the user receive the full set (including family memberships and the ' +
+        'class parent IDs); a supervisory requester (administrator or educator) receives only the entities within ' +
+        'their reach, with class rows stripped of the parent school/district IDs, and no family memberships. ' +
+        'Returns 403 if the requester cannot access the specified user. ' +
+        'Returns 404 if the specified user does not exist.',
     },
     // Nest guardian / longitudinal score report sub-router under /users
     scoreReports: GuardianStudentReportContract,

--- a/packages/api-contract/src/v1/users/schema.ts
+++ b/packages/api-contract/src/v1/users/schema.ts
@@ -82,6 +82,64 @@ const FamilyMembershipSchema = z.object({
 export const UserMembershipSchema = z.union([OrgMembershipSchema, FamilyMembershipSchema]);
 export type UserMembership = z.infer<typeof UserMembershipSchema>;
 
+/**
+ * Response membership shapes for `GET /users/:userId/memberships`.
+ *
+ * Distinct from the create-body `UserMembershipSchema` above: this read shape
+ * carries the member's `role`, and class rows can additionally carry the parent
+ * `schoolId` / `districtId` so a consumer can resolve a student's current
+ * school(s) without a separate lookup (a student has no school-level membership
+ * row of their own — their school is the parent of their class).
+ *
+ * The parent `schoolId` / `districtId` are **optional**: they are returned only on
+ * full-access reads (self, super admin, or a guardian of the user), which is where
+ * the homepage use case lives. A scoped supervisory requester (administrator or
+ * educator) may hold `can_list_users` on a class without `can_read` on its parent
+ * school, so the parent IDs are omitted on that path to avoid disclosing org
+ * identifiers they cannot otherwise read.
+ *
+ * v1 returns **active (current) memberships only**; enrollment dates are omitted.
+ * A future `?status=active|all` toggle would reintroduce them.
+ */
+const OrgGroupMembershipResponseSchema = z.object({
+  entityType: z.enum(['district', 'school', 'group']),
+  entityId: z.string().uuid(),
+  role: UserRoleSchema,
+});
+
+const ClassMembershipResponseSchema = z.object({
+  entityType: z.literal('class'),
+  entityId: z.string().uuid(),
+  role: UserRoleSchema,
+  schoolId: z.string().uuid().optional(),
+  districtId: z.string().uuid().optional(),
+});
+
+const FamilyMembershipResponseSchema = z.object({
+  entityType: z.literal('family'),
+  entityId: z.string().uuid(),
+  role: UserFamilyRoleSchema,
+});
+
+export const UserMembershipResponseSchema = z.union([
+  OrgGroupMembershipResponseSchema,
+  ClassMembershipResponseSchema,
+  FamilyMembershipResponseSchema,
+]);
+export type UserMembershipResponse = z.infer<typeof UserMembershipResponseSchema>;
+
+/**
+ * Response body payload for `GET /users/:userId/memberships`.
+ *
+ * Unpaginated: a user's active membership set is small and bounded (students sit
+ * at the leaves of the org hierarchy, admins at the top), so there is nothing to
+ * page through.
+ */
+export const UserMembershipsResponseSchema = z.object({
+  items: z.array(UserMembershipResponseSchema),
+});
+export type UserMembershipsResponse = z.infer<typeof UserMembershipsResponseSchema>;
+
 const CreateUserIdentifiersSchema = z.object({
   stateId: z.string().optional(),
   pid: z.string().optional(),


### PR DESCRIPTION
## Summary

This PR adds `GET /v1/users/:userId/memberships`, a read endpoint that returns a user's active org, class, group, and family memberships — the **backend half** of moving the participant homepage off its last Firestore read. Nothing on the API exposed a user's associations before (`/me` returns only the caller's own families; `GET /users/:id` carries no memberships), so the dashboard had no way to resolve a participant's current school/class from the backend.

> ⚠️ **Security-sensitive authorization change — please review the row-scoping logic line-by-line and rely on integration tests, not the FGA-mocked unit tests, for the policy guarantee.** Per `culture-leverage-ai.md`, requester-scoped filtering is exactly the kind of access-control code that can look right but be subtly wrong.

## What it returns

`{ data: { items: UserMembership[] } }` — the user's **active** linking-table rows only. Unpaginated: the set is small and bounded (admins sit at the top of their org hierarchy, students at the leaves), so there is nothing to page through.

- All four entity types, each with its `role`. Class rows can carry the parent `schoolId` / `districtId` (both notNull on `classes`) so a caller can resolve a student's current school(s) without a second lookup — a student has no school-level membership row of their own. These parent IDs are returned only on **full-access** reads (self / super-admin / guardian); a scoped supervisory requester receives the class row without them (see Authorization).
- **Literal rows, not a hierarchy traversal.** A principal returns their one school `user_orgs` row, not the school's classes; a student returns their class rows, not their (ancestor) school. This keeps the response bounded.
- v1 has **no query params** and returns active memberships only. A future `?status=active|all` is an additive change if history is ever needed.

## Authorization (please verify each)

Two layers in `UserService.listUserMemberships`:

1. **Gate** — reuses `verifyUserAccess` unchanged: 404-before-403, super-admin bypass, self fast-path, else `can_list_users` on any of the target's entities. Rostering-ended targets return 404.
2. **Requester-scoped row filter** — the rows returned are scoped to what the requester may see of this user:
   - **super-admin / self / guardian** (a parent holding `can_list_users` on one of the target's families) → the **full** set, including family rows.
   - **administrator / educator** → only the entities the requester can `can_list_users`, checked with one `hasPermission` per the target's **own** (small, bounded) membership entities — so a school-A admin sees the student's school-A class but **never** their school-B class, and **never** family rows (a supervisory requester holds no family relation). Surviving class rows are returned **without** their parent `schoolId` / `districtId`: a requester can hold `can_list_users` on a class (e.g. a teacher rostered on it) without `can_read` on the parent school, so echoing those IDs would leak org identifiers they can't otherwise read.

Three things to confirm in review:

1. Super-admin bypass and the self fast-path are checked before any FGA call.
2. The guardian short-circuit returns the full set (the parent is entitled to the whole child); the per-entity filter is reached only for the administrator path.
3. The per-entity check iterates the **target's** memberships (bounded), not the requester's accessible set (which for a district admin could be the whole district) — see `performance-avoid-quadratic`.

## Layers

- **Contract** (`packages/api-contract/src/v1/users`): new `UserMembershipResponseSchema` / `UserMembershipsResponseSchema` and the `listUserMemberships` route. The shared create-body `UserMembershipSchema` is **not** modified.
- **Repository**: `getUserMembershipsDetailed` (role + class parent IDs, active-only). The `FGA_SUPPORTED_ORG_TYPES` set is hoisted to module scope and shared with the existing `getUserEntityMemberships` (no behaviour change).
- **Service**: `listUserMemberships` (gate + filter).
- **Controller** + **route**: transform (discriminated-union → API shape) and handler.

## Testing

- **Unit tests added** — service (`user.service.memberships.test.ts`): self / super-admin / guardian full-set, administrator scoping (cross-school **and** family-row denial), 403-gate propagation, 404. Controller: 200 transform (class `schoolId`/`districtId` preserved) and 403 mapping. These **mock FGA**, so they assert the wiring — which relation is asked, on which objects, and which rows survive — not the policy.
- **Integration tests added** against the real OpenFGA model in `apps/backend/src/routes/users.integration.test.ts` (`GET /v1/users/:userId/memberships`): guardian full set incl. family + class parent IDs; self; super-admin; **school-A principal scoped** to the school-A class with the school-B enrolment, the family row, and the class parent IDs all withheld; cross-family parent denied (403); unrelated student (403); unauthenticated (401); non-existent and rostering-ended (404). These exercise the policy end-to-end through FGA (not mocked). The authoring sandbox can't stand up OpenFGA, so they weren't executed there — run against the seeded local stack / CI before merge.
- `check-types` and `prettier --check` pass for all changed files. (A pre-existing, unrelated set of `@roar-platform/assessment-schema/roar-letter|roar-sre` type errors appears only because that sibling package's build artifact is stale in this checkout; it reproduces on the base commit with these changes stashed, and CI builds packages in dependency order.)

## Review

An independent review pass flagged that returning class `schoolId` / `districtId` to a requester who can list a class's users but cannot read its parent school (e.g. a class-rostered teacher) would leak org identifiers — `school.can_read` has no `from child_class` path in the FGA model. Fixed in this PR by scoping the parent IDs to the full-access paths (self / super-admin / guardian) and omitting them on the supervisory path; covered by the updated service unit test. (Other review notes — a second membership fetch shared with the gate, and a possible `batchCheck` micro-optimization — were assessed as acceptable for the bounded membership set and left as-is.)

## Out of scope

- The **frontend** cutover (HomeParticipant reading `useUserMembershipsQuery`, `GameTabs` sourcing `schools.current`/`classes.current`) — a separate follow-on PR that depends on this one.
- `?status=all` (historical memberships) — additive, deferred until a consumer needs it.



> [!NOTE]
> **Cross-fork stacking.** Because intermediate branches live only on `richford`, a `yeatmanlab/roar-dashboard` PR cannot use one as its base — every PR in this series targets `project/backend-refactor`, and they are reviewed/merged **bottom-up** so each shows only its own slice once its parent merges.

> [!IMPORTANT]
> **Merge order:** first in its stack — targets `project/backend-refactor` directly.

Resolves #1973
Part of #1958