### PR TITLE
Participant home: read profile from GET /users/:id off Firestore

### DIFF
--- a/apps/backend/src/controllers/users.controller.test.ts
+++ b/apps/backend/src/controllers/users.controller.test.ts
@@ -66,6 +66,7 @@ describe('UsersController', () => {
   const mockGetUserAdministrations = vi.fn();
   const mockGetUserAdministration = vi.fn();
   const mockListUserAdministrationAgreements = vi.fn();
+  const mockListUserMemberships = vi.fn();
   const mockGetGuardianStudentReport = vi.fn();
   const mockAuthContext = AuthContextFactory.build({ userId: 'user-123', isSuperAdmin: false });
 
@@ -78,6 +79,7 @@ describe('UsersController', () => {
     mockUserService.create = mockCreate;
     mockUserService.update = mockUpdate;
     mockUserService.recordUserAgreement = mockRecordUserAgreement;
+    mockUserService.listUserMemberships = mockListUserMemberships;
     vi.mocked(UserService).mockReturnValue(mockUserService);
 
     // Setup the mock AdministrationService
@@ -538,6 +540,45 @@ describe('UsersController', () => {
       const { UsersController: Controller } = await import('./users.controller');
 
       await expect(Controller.update(superAdminContext, targetUserId, validBody)).rejects.toThrow('Unexpected error');
+    });
+  });
+
+  describe('listUserMemberships', () => {
+    const classMembership = {
+      entityType: 'class' as const,
+      entityId: 'class-A',
+      role: 'student' as const,
+      schoolId: 'school-A',
+      districtId: 'district-1',
+    };
+    const familyMembership = { entityType: 'family' as const, entityId: 'fam-1', role: 'child' as const };
+    const schoolMembership = { entityType: 'school' as const, entityId: 'school-A', role: 'administrator' as const };
+
+    it('returns 200 with the membership items, preserving schoolId/districtId on class rows', async () => {
+      mockListUserMemberships.mockResolvedValue([classMembership, familyMembership, schoolMembership]);
+
+      const { UsersController: Controller } = await import('./users.controller');
+      const result = await Controller.listUserMemberships(mockAuthContext, 'student-1');
+
+      const data = expectOkResponse(result);
+      // Deep equality confirms the transform preserves the class parent IDs and the
+      // family / org role shapes unchanged.
+      expect(data.items).toEqual([classMembership, familyMembership, schoolMembership]);
+      expect(mockListUserMemberships).toHaveBeenCalledWith(mockAuthContext, 'student-1');
+    });
+
+    it('maps a FORBIDDEN ApiError to a 403 response', async () => {
+      const error = new ApiError(ApiErrorMessage.FORBIDDEN, {
+        statusCode: StatusCodes.FORBIDDEN,
+        code: ApiErrorCode.AUTH_FORBIDDEN,
+      });
+      mockListUserMemberships.mockRejectedValue(error);
+
+      const { UsersController: Controller } = await import('./users.controller');
+      const result = await Controller.listUserMemberships(mockAuthContext, 'student-1');
+
+      const errorBody = expectErrorResponse(result, StatusCodes.FORBIDDEN);
+      expect(errorBody.code).toBe(ApiErrorCode.AUTH_FORBIDDEN);
     });
   });
 

--- a/apps/backend/src/controllers/users.controller.ts
+++ b/apps/backend/src/controllers/users.controller.ts
@@ -1,5 +1,6 @@
 import type { AuthContext } from '../types/auth-context';
 import type { User } from '../db/schema';
+import type { UserMembershipDetail } from '../repositories/user.repository';
 import type {
   UserResponse,
   CreateUserRequestBody,
@@ -9,6 +10,7 @@ import type {
   AdministrationsListQuery,
   AdministrationAgreementsListQuery,
   UserAdministrationAgreement,
+  UserMembershipResponse,
 } from '@roar-platform/api-contract';
 import { StatusCodes } from 'http-status-codes';
 import { UserService } from '../services/user';
@@ -81,6 +83,44 @@ function toUserAdministrationAgreement(item: AgreementWithSignedStatus): UserAdm
   return {
     ...toAgreementItem(item),
     signed: item.signed,
+  };
+}
+
+/**
+ * Map a service-layer membership into the API response shape.
+ *
+ * `UserMembershipDetail` is a discriminated union on `entityType`, so the branches
+ * narrow `role` (org/class roles vs. family roles) and surface the parent
+ * `schoolId` / `districtId` only on class memberships.
+ *
+ * @param membership - Service result for a single active membership
+ * @returns The API-formatted membership
+ */
+function toUserMembershipResponse(membership: UserMembershipDetail): UserMembershipResponse {
+  if (membership.entityType === 'class') {
+    // Parent IDs are present on full-access reads (self / super admin / guardian) and
+    // omitted on the scoped supervisory path — include them only when provided.
+    return {
+      entityType: 'class',
+      entityId: membership.entityId,
+      role: membership.role,
+      ...(membership.schoolId !== undefined ? { schoolId: membership.schoolId } : {}),
+      ...(membership.districtId !== undefined ? { districtId: membership.districtId } : {}),
+    };
+  }
+
+  if (membership.entityType === 'family') {
+    return {
+      entityType: 'family',
+      entityId: membership.entityId,
+      role: membership.role,
+    };
+  }
+
+  return {
+    entityType: membership.entityType,
+    entityId: membership.entityId,
+    role: membership.role,
   };
 }
 
@@ -363,6 +403,39 @@ export const UsersController = {
         return toErrorResponse(error, [
           StatusCodes.NOT_FOUND,
           StatusCodes.FORBIDDEN,
+          StatusCodes.INTERNAL_SERVER_ERROR,
+        ]);
+      }
+      throw error;
+    }
+  },
+
+  /**
+   * List a user's active entity memberships, scoped to the requester's access.
+   *
+   * Delegates authorization and row scoping to UserService; transforms the
+   * service result into the unpaginated API response.
+   *
+   * @param authContext - Requesting user's authentication context.
+   * @param userId - UUID of the user whose memberships to list.
+   */
+  listUserMemberships: async (authContext: AuthContext, userId: string) => {
+    try {
+      const memberships = await userService.listUserMemberships(authContext, userId);
+      return {
+        status: StatusCodes.OK as const,
+        body: {
+          data: {
+            items: memberships.map(toUserMembershipResponse),
+          },
+        },
+      };
+    } catch (error) {
+      if (error instanceof ApiError) {
+        return toErrorResponse(error, [
+          StatusCodes.UNAUTHORIZED,
+          StatusCodes.FORBIDDEN,
+          StatusCodes.NOT_FOUND,
           StatusCodes.INTERNAL_SERVER_ERROR,
         ]);
       }

--- a/apps/backend/src/repositories/user.repository.ts
+++ b/apps/backend/src/repositories/user.repository.ts
@@ -7,9 +7,29 @@ import { CoreDbClient } from '../db/clients';
 import type { CoreTransaction } from '../db/clients';
 import type * as CoreDbSchema from '../db/schema/core';
 import { UserRole } from '../enums/user-role.enum';
+import type { UserFamilyRole } from '../enums/user-family-role.enum';
 import { BaseRepository } from './base.repository';
 import { isEnrollmentActive, isActiveInFamily } from './utils/enrollment.utils';
 import { logger } from '../logger';
+
+/**
+ * Org types supported by the FGA model. Only `district` and `school` map to FGA
+ * object types today; other org types (national, state, local, department) are not
+ * yet used in ROAR and are skipped (logged) so a user gets a safe denial rather
+ * than a false grant.
+ */
+const FGA_SUPPORTED_ORG_TYPES: ReadonlySet<string> = new Set([EntityType.DISTRICT, EntityType.SCHOOL]);
+
+/**
+ * A single active entity membership of a user, enriched for the memberships read
+ * endpoint: each row carries the member's `role`, and class rows carry the parent
+ * `schoolId` / `districtId` (a student has no school-level row of their own — their
+ * school is the parent of their class).
+ */
+export type UserMembershipDetail =
+  | { entityType: 'district' | 'school' | 'group'; entityId: string; role: UserRole }
+  | { entityType: 'class'; entityId: string; role: UserRole; schoolId?: string; districtId?: string }
+  | { entityType: 'family'; entityId: string; role: UserFamilyRole };
 
 /**
  * User Repository
@@ -80,7 +100,6 @@ export class UserRepository extends BaseRepository<User, typeof users> {
     // FGA model today. Other org types (national, state, local, department) are not yet
     // used in ROAR — log a warning and skip them so the user gets a safe denial rather
     // than a false grant.
-    const FGA_SUPPORTED_ORG_TYPES: ReadonlySet<string> = new Set([EntityType.DISTRICT, EntityType.SCHOOL]);
     const orgMemberships: { entityType: EntityType; entityId: string }[] = [];
     for (const row of orgRows) {
       if (FGA_SUPPORTED_ORG_TYPES.has(row.orgType)) {
@@ -100,6 +119,81 @@ export class UserRepository extends BaseRepository<User, typeof users> {
       ...classRows.map((r) => ({ entityType: EntityType.CLASS, entityId: r.entityId })),
       ...groupRows.map((r) => ({ entityType: EntityType.GROUP, entityId: r.entityId })),
       ...familyRows.map((r) => ({ entityType: EntityType.FAMILY, entityId: r.entityId })),
+    ];
+  }
+
+  /**
+   * Get a user's active entity memberships, enriched for the memberships read endpoint.
+   *
+   * Like {@link getUserEntityMemberships}, but additionally returns each membership's
+   * `role` and, for class memberships, the parent `schoolId` / `districtId` (read off
+   * the `classes` row). Active-only: enrollment/membership windows must currently be
+   * open. Unsupported org types are skipped (logged), same as `getUserEntityMemberships`.
+   *
+   * @param userId - The user whose memberships to look up
+   * @returns Array of detailed memberships across orgs, classes, groups, and families
+   */
+  async getUserMembershipsDetailed(userId: string): Promise<UserMembershipDetail[]> {
+    const [orgRows, classRows, groupRows, familyRows] = await Promise.all([
+      this.db
+        .select({ entityId: userOrgs.orgId, role: userOrgs.role, orgType: orgs.orgType })
+        .from(userOrgs)
+        .innerJoin(orgs, eq(userOrgs.orgId, orgs.id))
+        .where(and(eq(userOrgs.userId, userId), isEnrollmentActive(userOrgs))),
+      this.db
+        .select({
+          entityId: userClasses.classId,
+          role: userClasses.role,
+          schoolId: classes.schoolId,
+          districtId: classes.districtId,
+        })
+        .from(userClasses)
+        .innerJoin(classes, eq(userClasses.classId, classes.id))
+        .where(and(eq(userClasses.userId, userId), isEnrollmentActive(userClasses))),
+      this.db
+        .select({ entityId: userGroups.groupId, role: userGroups.role })
+        .from(userGroups)
+        .where(and(eq(userGroups.userId, userId), isEnrollmentActive(userGroups))),
+      this.db
+        .select({ entityId: userFamilies.familyId, role: userFamilies.role })
+        .from(userFamilies)
+        .where(and(eq(userFamilies.userId, userId), isActiveInFamily(userFamilies))),
+    ]);
+
+    const orgMemberships: UserMembershipDetail[] = [];
+    for (const row of orgRows) {
+      if (FGA_SUPPORTED_ORG_TYPES.has(row.orgType)) {
+        // Safe: filtered to 'district' | 'school', which TypeScript can't infer statically.
+        orgMemberships.push({
+          entityType: row.orgType as 'district' | 'school',
+          entityId: row.entityId,
+          role: row.role,
+        });
+      } else {
+        logger.warn(
+          { userId, orgId: row.entityId, orgType: row.orgType },
+          'Skipping org membership with unsupported FGA org type',
+        );
+      }
+    }
+
+    return [
+      ...orgMemberships,
+      ...classRows.map(
+        (r): UserMembershipDetail => ({
+          entityType: EntityType.CLASS,
+          entityId: r.entityId,
+          role: r.role,
+          schoolId: r.schoolId,
+          districtId: r.districtId,
+        }),
+      ),
+      ...groupRows.map(
+        (r): UserMembershipDetail => ({ entityType: EntityType.GROUP, entityId: r.entityId, role: r.role }),
+      ),
+      ...familyRows.map(
+        (r): UserMembershipDetail => ({ entityType: EntityType.FAMILY, entityId: r.entityId, role: r.role }),
+      ),
     ];
   }
 

--- a/apps/backend/src/routes/users.integration.test.ts
+++ b/apps/backend/src/routes/users.integration.test.ts
@@ -3361,3 +3361,165 @@ describe('POST /v1/users/anonymous', () => {
     expect(allTuples).toHaveLength(0);
   });
 });
+
+// ═══════════════════════════════════════════════════════════════════════════
+// GET /v1/users/:userId/memberships
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('GET /v1/users/:userId/memberships', () => {
+  type MembershipItem = {
+    entityType: string;
+    entityId: string;
+    role?: string;
+    schoolId?: string;
+    districtId?: string;
+  };
+
+  // A student enrolled in a class in school A AND a class in school B, who is also
+  // a child in a family — exercises cross-school scoping and family-row visibility.
+  let crossSchoolChild: Awaited<ReturnType<typeof UserFactory.create>>;
+  let childParent: Awaited<ReturnType<typeof UserFactory.create>>;
+  let otherParent: Awaited<ReturnType<typeof UserFactory.create>>;
+  let childFamilyId: string;
+
+  beforeAll(async () => {
+    const { UserFamilyFactory } = await import('../test-support/factories/user-family.factory');
+    const { FamilyFactory } = await import('../test-support/factories/family.factory');
+    const { syncFgaTuplesFromPostgres } = await import('../test-support/fga');
+
+    crossSchoolChild = await UserFactory.create({ dob: '2015-01-01', grade: '3' });
+    await UserClassFactory.create({
+      userId: crossSchoolChild.id,
+      classId: baseFixture.classInSchoolA.id,
+      role: UserRole.STUDENT,
+    });
+    await UserClassFactory.create({
+      userId: crossSchoolChild.id,
+      classId: baseFixture.classInSchoolB.id,
+      role: UserRole.STUDENT,
+    });
+
+    const family = await FamilyFactory.create();
+    childFamilyId = family.id;
+    childParent = await UserFactory.create({ dob: '1985-01-01' });
+    await UserFamilyFactory.create({ userId: childParent.id, familyId: family.id, role: 'parent' });
+    await UserFamilyFactory.create({ userId: crossSchoolChild.id, familyId: family.id, role: 'child' });
+
+    // A parent of a DIFFERENT family — must not be able to read crossSchoolChild.
+    const otherFamily = await FamilyFactory.create();
+    otherParent = await UserFactory.create({ dob: '1986-01-01' });
+    await UserFamilyFactory.create({ userId: otherParent.id, familyId: otherFamily.id, role: 'parent' });
+
+    await syncFgaTuplesFromPostgres();
+  });
+
+  it('returns the full set to a guardian — both classes, the family row, and class parent IDs', async () => {
+    const res = await expectRoute('GET', `/v1/users/${crossSchoolChild.id}/memberships`)
+      .as({ id: childParent.id, authId: childParent.authId! })
+      .toReturn(StatusCodes.OK);
+
+    const items: MembershipItem[] = res.body.data.items;
+    const classA = items.find((m) => m.entityType === 'class' && m.entityId === baseFixture.classInSchoolA.id);
+    const classB = items.find((m) => m.entityType === 'class' && m.entityId === baseFixture.classInSchoolB.id);
+    const family = items.find((m) => m.entityType === 'family' && m.entityId === childFamilyId);
+
+    expect(classA).toBeDefined();
+    expect(classB).toBeDefined();
+    expect(family).toBeDefined();
+    // A guardian is entitled to the whole child, so the class parent IDs are present.
+    expect(classA?.schoolId).toBe(baseFixture.schoolA.id);
+    expect(classA?.districtId).toBe(baseFixture.district.id);
+    expect(classB?.schoolId).toBe(baseFixture.schoolB.id);
+  });
+
+  it('returns the full set to the user themselves (with class parent IDs)', async () => {
+    const res = await expectRoute('GET', `/v1/users/${crossSchoolChild.id}/memberships`)
+      .as({ id: crossSchoolChild.id, authId: crossSchoolChild.authId! })
+      .toReturn(StatusCodes.OK);
+
+    const items: MembershipItem[] = res.body.data.items;
+    const classA = items.find((m) => m.entityType === 'class' && m.entityId === baseFixture.classInSchoolA.id);
+    expect(classA?.role).toBe('student');
+    expect(classA?.schoolId).toBe(baseFixture.schoolA.id);
+    expect(classA?.districtId).toBe(baseFixture.district.id);
+    expect(items.some((m) => m.entityType === 'class' && m.entityId === baseFixture.classInSchoolB.id)).toBe(true);
+    expect(items.some((m) => m.entityType === 'family' && m.entityId === childFamilyId)).toBe(true);
+  });
+
+  it('returns the full set to a super admin', async () => {
+    const res = await expectRoute('GET', `/v1/users/${crossSchoolChild.id}/memberships`)
+      .as(tiers.superAdmin)
+      .toReturn(StatusCodes.OK);
+
+    const items: MembershipItem[] = res.body.data.items;
+    const entityIds = items.map((m) => m.entityId);
+    expect(entityIds).toContain(baseFixture.classInSchoolA.id);
+    expect(entityIds).toContain(baseFixture.classInSchoolB.id);
+    expect(entityIds).toContain(childFamilyId);
+  });
+
+  it('scopes a school-A principal to school A — no school-B class, no family row, class parent IDs stripped', async () => {
+    const res = await expectRoute('GET', `/v1/users/${crossSchoolChild.id}/memberships`)
+      .as({ id: baseFixture.schoolAPrincipal.id, authId: baseFixture.schoolAPrincipal.authId! })
+      .toReturn(StatusCodes.OK);
+
+    const items: MembershipItem[] = res.body.data.items;
+    const classA = items.find((m) => m.entityType === 'class' && m.entityId === baseFixture.classInSchoolA.id);
+
+    // Sees the school-A class they supervise...
+    expect(classA).toBeDefined();
+    // ...but parent school/district IDs are withheld: a class-scoped supervisor can list the
+    // class's users without `can_read` on the parent school, so echoing them would leak org IDs.
+    expect(classA?.schoolId).toBeUndefined();
+    expect(classA?.districtId).toBeUndefined();
+    // Never the school-B enrolment, never the family row.
+    expect(items.some((m) => m.entityType === 'class' && m.entityId === baseFixture.classInSchoolB.id)).toBe(false);
+    expect(items.some((m) => m.entityType === 'family')).toBe(false);
+  });
+
+  it('denies a parent of a different family — no cross-family leakage (403)', async () => {
+    const res = await expectRoute('GET', `/v1/users/${crossSchoolChild.id}/memberships`)
+      .as({ id: otherParent.id, authId: otherParent.authId! })
+      .toReturn(StatusCodes.FORBIDDEN);
+
+    expect(res.body.error.code).toBe(ApiErrorCode.AUTH_FORBIDDEN);
+  });
+
+  it('denies an unrelated student (403)', async () => {
+    const res = await expectRoute('GET', `/v1/users/${crossSchoolChild.id}/memberships`)
+      .as(tiers.student)
+      .toReturn(StatusCodes.FORBIDDEN);
+
+    expect(res.body.error.code).toBe(ApiErrorCode.AUTH_FORBIDDEN);
+  });
+
+  it('returns 401 when unauthenticated', async () => {
+    const res = await expectRoute('GET', `/v1/users/${crossSchoolChild.id}/memberships`)
+      .unauthenticated()
+      .toReturn(StatusCodes.UNAUTHORIZED);
+
+    expect(res.body.error.code).toBe(ApiErrorCode.AUTH_REQUIRED);
+  });
+
+  it('returns 404 for a non-existent user', async () => {
+    const res = await expectRoute('GET', '/v1/users/00000000-0000-0000-0000-000000000000/memberships')
+      .as(tiers.superAdmin)
+      .toReturn(StatusCodes.NOT_FOUND);
+
+    expect(res.body.error.code).toBe(ApiErrorCode.RESOURCE_NOT_FOUND);
+  });
+
+  it('returns 404 for a rostering-ended target user (#1742)', async () => {
+    const endedUser = await UserFactory.create({
+      dob: '2015-01-01',
+      grade: '3',
+      rosteringEnded: new Date(Date.now() - 24 * 60 * 60 * 1000),
+    });
+
+    const res = await expectRoute('GET', `/v1/users/${endedUser.id}/memberships`)
+      .as(tiers.superAdmin)
+      .toReturn(StatusCodes.NOT_FOUND);
+
+    expect(res.body.error.code).toBe(ApiErrorCode.RESOURCE_NOT_FOUND);
+  });
+});

--- a/apps/backend/src/routes/users.ts
+++ b/apps/backend/src/routes/users.ts
@@ -49,6 +49,10 @@ export function registerUserRoutes(routerInstance: Router) {
       handler: async ({ req: { user }, params: { userId, administrationId }, query }) =>
         UsersController.listUserAdministrationAgreements(user!, userId, administrationId, query),
     },
+    listUserMemberships: {
+      middleware: [AuthGuardMiddleware],
+      handler: async ({ req: { user }, params: { userId } }) => UsersController.listUserMemberships(user!, userId),
+    },
     scoreReports: {
       getGuardianStudentReport: {
         middleware: [AuthGuardMiddleware],

--- a/apps/backend/src/services/user/user.service.memberships.test.ts
+++ b/apps/backend/src/services/user/user.service.memberships.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { StatusCodes } from 'http-status-codes';
+import { UserService } from './user.service';
+import { UserFactory, AuthContextFactory } from '../../test-support/factories/user.factory';
+import { createMockUserRepository } from '../../test-support/repositories/user.repository';
+import { createMockAuthorizationService } from '../../test-support/services/authorization.service';
+import type { UserMembershipDetail } from '../../repositories/user.repository';
+import { FgaType, FgaRelation } from '../authorization/fga-constants';
+
+/**
+ * Unit tests for the requester-scoped row filtering on `listUserMemberships`.
+ *
+ * These mock FGA, so they assert the *wiring* (which relation is asked, on which
+ * objects, and which rows survive) — not the policy itself. The policy guarantee
+ * (that a school-A admin truly cannot resolve `can_list_users` on school B) needs
+ * integration tests against the real OpenFGA model.
+ */
+describe('UserService.listUserMemberships', () => {
+  let mockUserRepository: ReturnType<typeof createMockUserRepository>;
+  let mockAuthorizationService: ReturnType<typeof createMockAuthorizationService>;
+
+  // Target: a student enrolled in a class in school A and a class in school B,
+  // and a member of one family (a ROAR@Home child).
+  const classA: UserMembershipDetail = {
+    entityType: 'class',
+    entityId: 'class-A',
+    role: 'student',
+    schoolId: 'school-A',
+    districtId: 'district-1',
+  };
+  const classB: UserMembershipDetail = {
+    entityType: 'class',
+    entityId: 'class-B',
+    role: 'student',
+    schoolId: 'school-B',
+    districtId: 'district-1',
+  };
+  const family: UserMembershipDetail = { entityType: 'family', entityId: 'fam-1', role: 'child' };
+  const detailedMemberships: UserMembershipDetail[] = [classA, classB, family];
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    mockUserRepository = createMockUserRepository();
+    mockAuthorizationService = createMockAuthorizationService();
+  });
+
+  function service() {
+    return UserService({
+      userRepository: mockUserRepository,
+      authorizationService: mockAuthorizationService,
+    });
+  }
+
+  it('returns the full set for self, with no FGA filtering', async () => {
+    const authContext = AuthContextFactory.build({ userId: 'student-1', isSuperAdmin: false });
+    mockUserRepository.getById.mockResolvedValue(UserFactory.build({ id: 'student-1' }));
+    mockUserRepository.getUserMembershipsDetailed.mockResolvedValue(detailedMemberships);
+
+    const result = await service().listUserMemberships(authContext, 'student-1');
+
+    expect(result).toEqual(detailedMemberships);
+    expect(mockAuthorizationService.hasPermission).not.toHaveBeenCalled();
+    expect(mockAuthorizationService.hasAnyPermission).not.toHaveBeenCalled();
+  });
+
+  it('returns the full set for a super admin', async () => {
+    const authContext = AuthContextFactory.build({ userId: 'admin-1', isSuperAdmin: true });
+    mockUserRepository.getById.mockResolvedValue(UserFactory.build({ id: 'student-1' }));
+    mockUserRepository.getUserMembershipsDetailed.mockResolvedValue(detailedMemberships);
+
+    const result = await service().listUserMemberships(authContext, 'student-1');
+
+    expect(result).toEqual(detailedMemberships);
+    expect(mockAuthorizationService.hasPermission).not.toHaveBeenCalled();
+  });
+
+  it('returns the full set (including family rows) for a guardian of the user', async () => {
+    const authContext = AuthContextFactory.build({ userId: 'parent-1', isSuperAdmin: false });
+    mockUserRepository.getById.mockResolvedValue(UserFactory.build({ id: 'student-1' }));
+    // Gate: the target's entities include the family; the parent passes via can_list_users on it.
+    mockUserRepository.getUserEntityMemberships.mockResolvedValue([{ entityType: 'family', entityId: 'fam-1' }]);
+    mockUserRepository.getUserMembershipsDetailed.mockResolvedValue(detailedMemberships);
+    // Both the gate check and the guardian check resolve true for a parent.
+    mockAuthorizationService.hasAnyPermission.mockResolvedValue(true);
+
+    const result = await service().listUserMemberships(authContext, 'student-1');
+
+    expect(result).toEqual(detailedMemberships);
+    // The guardian check asks can_list_users on the child's family object.
+    expect(mockAuthorizationService.hasAnyPermission).toHaveBeenCalledWith('parent-1', FgaRelation.CAN_LIST_USERS, [
+      `${FgaType.FAMILY}:fam-1`,
+    ]);
+    // A guardian gets the full set without per-entity filtering.
+    expect(mockAuthorizationService.hasPermission).not.toHaveBeenCalled();
+  });
+
+  it("scopes an administrator to their reach — never another school's enrolment, never family rows", async () => {
+    const authContext = AuthContextFactory.build({ userId: 'principal-A', isSuperAdmin: false });
+    mockUserRepository.getById.mockResolvedValue(UserFactory.build({ id: 'student-1' }));
+    mockUserRepository.getUserEntityMemberships.mockResolvedValue([
+      { entityType: 'class', entityId: 'class-A' },
+      { entityType: 'class', entityId: 'class-B' },
+      { entityType: 'family', entityId: 'fam-1' },
+    ]);
+    mockUserRepository.getUserMembershipsDetailed.mockResolvedValue(detailedMemberships);
+    // Gate passes (first call) but the guardian check fails (the principal is not the parent).
+    mockAuthorizationService.hasAnyPermission.mockResolvedValueOnce(true).mockResolvedValueOnce(false);
+    // Per-entity: the principal can list users only in school A's class.
+    mockAuthorizationService.hasPermission.mockImplementation(
+      async (_userId, _relation, object) => object === `${FgaType.CLASS}:class-A`,
+    );
+
+    const result = await service().listUserMemberships(authContext, 'student-1');
+
+    // The school-A class survives, but its parent school/district IDs are stripped on the
+    // supervisory path (the principal can list the class's users but not read the school).
+    expect(result).toEqual([{ entityType: 'class', entityId: 'class-A', role: 'student' }]);
+    expect(result[0]).not.toHaveProperty('schoolId');
+    expect(result[0]).not.toHaveProperty('districtId');
+    // The school-B enrolment and the family row are filtered out entirely.
+    expect(result).not.toContainEqual(classB);
+    expect(result).not.toContainEqual(family);
+  });
+
+  it('propagates 403 from the access gate without fetching memberships', async () => {
+    const authContext = AuthContextFactory.build({ userId: 'stranger-1', isSuperAdmin: false });
+    mockUserRepository.getById.mockResolvedValue(UserFactory.build({ id: 'student-1' }));
+    mockUserRepository.getUserEntityMemberships.mockResolvedValue([{ entityType: 'class', entityId: 'class-A' }]);
+    mockAuthorizationService.hasAnyPermission.mockResolvedValue(false); // gate denies
+
+    await expect(service().listUserMemberships(authContext, 'student-1')).rejects.toMatchObject({
+      statusCode: StatusCodes.FORBIDDEN,
+    });
+    expect(mockUserRepository.getUserMembershipsDetailed).not.toHaveBeenCalled();
+  });
+
+  it('propagates 404 when the target user does not exist', async () => {
+    const authContext = AuthContextFactory.build({ userId: 'admin-1', isSuperAdmin: true });
+    mockUserRepository.getById.mockResolvedValue(null);
+
+    await expect(service().listUserMemberships(authContext, 'missing')).rejects.toMatchObject({
+      statusCode: StatusCodes.NOT_FOUND,
+    });
+  });
+});

--- a/apps/backend/src/services/user/user.service.ts
+++ b/apps/backend/src/services/user/user.service.ts
@@ -16,6 +16,7 @@ import { ApiError } from '../../errors/api-error';
 import { isUniqueViolation, isForeignKeyViolation, unwrapDrizzleError } from '../../errors';
 import { logger } from '../../logger';
 import { UserRepository } from '../../repositories/user.repository';
+import type { UserMembershipDetail } from '../../repositories/user.repository';
 import { UserAgreementRepository } from '../../repositories/user-agreement.repository';
 import { AgreementVersionRepository } from '../../repositories/agreement-version.repository';
 import { AgreementRepository } from '../../repositories/agreement.repository';
@@ -1574,9 +1575,104 @@ export function UserService({
     }
   }
 
+  /**
+   * List a user's active entity memberships, scoped to the requester's access.
+   *
+   * Authorization is two-layered:
+   * 1. Gate — {@link verifyUserAccess} (404-before-403, super-admin bypass, self, or
+   *    `can_list_users` on any of the target's entities; rostering-ended target → 404).
+   * 2. Row filter — the rows returned are scoped to what the requester may see of this
+   *    user:
+   *    - super admin / self / guardian (a parent with `can_list_users` on one of the
+   *      target's families) receive the full set, including family memberships;
+   *    - any other authorized requester (an administrator or educator) receives only the
+   *      entities they can `can_list_users`, checked per the target's own membership
+   *      entities, and class rows are returned without their parent school/district IDs
+   *      (the requester may list a class's users without being able to read its parent
+   *      school). Family memberships are dropped on this path — a supervisory requester
+   *      holds no family relation — so families surface only to self / guardian / super admin.
+   *
+   * Example: a principal of school A requesting a student enrolled in schools A and B
+   * receives the school-A class memberships only, never the school-B ones.
+   *
+   * @param authContext - Requesting user's authentication context
+   * @param targetUserId - UUID of the user whose memberships to list
+   * @returns The target's active memberships visible to the requester
+   * @throws {ApiError} NOT_FOUND if the user does not exist or is rostering-ended
+   * @throws {ApiError} FORBIDDEN if the requester cannot access the user
+   * @throws {ApiError} INTERNAL_SERVER_ERROR if a database or FGA query fails
+   */
+  async function listUserMemberships(authContext: AuthContext, targetUserId: string): Promise<UserMembershipDetail[]> {
+    const { userId, isSuperAdmin } = authContext;
+
+    try {
+      // 1. Gate: existence + base access. Throws 404 (not found / rostering-ended) or 403.
+      await verifyUserAccess(authContext, targetUserId);
+
+      // 2. Fetch the target's active memberships (role + class parent IDs).
+      const memberships = await userRepository.getUserMembershipsDetailed(targetUserId);
+
+      // 3. Full set for callers entitled to the whole user: super admin, the user
+      //    themselves, and a guardian (parent) of the user.
+      if (isSuperAdmin || userId === targetUserId) {
+        return memberships;
+      }
+
+      const familyObjects = memberships
+        .filter((m) => m.entityType === EntityType.FAMILY)
+        .map((m) => `${FgaType.FAMILY}:${m.entityId}`);
+
+      const isGuardian =
+        familyObjects.length > 0 &&
+        (await authorizationService.hasAnyPermission(userId, FgaRelation.CAN_LIST_USERS, familyObjects));
+
+      if (isGuardian) {
+        return memberships;
+      }
+
+      // 4. Supervisory path (administrator or educator): scope rows to the requester's
+      //    reach. Check `can_list_users` per the target's own (small, bounded) membership
+      //    entities and keep only those that pass — so a school-A admin sees the user's
+      //    school-A enrolment but never their school-B one. Family rows are never visible
+      //    here: a supervisory requester has no `can_list_users` on a family.
+      const allowed = await Promise.all(
+        memberships.map((m) =>
+          authorizationService.hasPermission(
+            userId,
+            FgaRelation.CAN_LIST_USERS,
+            `${ENTITY_TYPE_TO_FGA_TYPE[m.entityType]}:${m.entityId}`,
+          ),
+        ),
+      );
+
+      // Strip the parent school/district IDs from surviving class rows on this path. A
+      // requester can hold `can_list_users` on a class (e.g. a teacher rostered on it)
+      // without holding `can_read` on the parent school, so echoing those IDs would
+      // disclose org identifiers they can't otherwise read. The parent IDs are only
+      // needed by the homepage, which takes the full-set path above.
+      return memberships
+        .filter((_, index) => allowed[index] === true)
+        .map((m) =>
+          m.entityType === 'class' ? { entityType: 'class' as const, entityId: m.entityId, role: m.role } : m,
+        );
+    } catch (error) {
+      if (error instanceof ApiError) throw error;
+
+      logger.error({ err: error, context: { userId, targetUserId } }, 'Failed to list user memberships');
+
+      throw new ApiError(ApiErrorMessage.INTERNAL_SERVER_ERROR, {
+        statusCode: StatusCodes.INTERNAL_SERVER_ERROR,
+        code: ApiErrorCode.DATABASE_QUERY_FAILED,
+        context: { userId, targetUserId },
+        cause: error,
+      });
+    }
+  }
+
   return {
     findByAuthId,
     getById,
+    listUserMemberships,
     create,
     update,
     recordUserAgreement,

--- a/apps/backend/src/test-support/repositories/user.repository.ts
+++ b/apps/backend/src/test-support/repositories/user.repository.ts
@@ -13,6 +13,7 @@ export function createMockUserRepository(): MockedObject<UserRepository> {
     ...createMockBaseRepositoryMethods(),
     findByAuthId: vi.fn(),
     getUserEntityMemberships: vi.fn(),
+    getUserMembershipsDetailed: vi.fn(),
     hasPlatformAdminRole: vi.fn(),
     findClassParentSchool: vi.fn(),
     createWithMemberships: vi.fn(),

--- a/apps/backend/src/test-support/services/user.service.ts
+++ b/apps/backend/src/test-support/services/user.service.ts
@@ -10,6 +10,7 @@ export function createMockUserService(): MockedObject<ReturnType<typeof UserServ
   return {
     findByAuthId: vi.fn(),
     getById: vi.fn(),
+    listUserMemberships: vi.fn(),
     create: vi.fn(),
     update: vi.fn(),
     recordUserAgreement: vi.fn(),

--- a/apps/dashboard/src/composables/queries/useUserMembershipsQuery.js
+++ b/apps/dashboard/src/composables/queries/useUserMembershipsQuery.js
@@ -1,0 +1,67 @@
+import { toValue } from 'vue';
+import { useQuery } from '@tanstack/vue-query';
+import { StatusCodes } from 'http-status-codes';
+import { getRoarApiClient } from '@/clients/roar-api';
+import { useAuthStore } from '@/store/auth';
+import { computeQueryOverrides } from '@/helpers/computeQueryOverrides';
+import { isRosteringEndedError, isTerminalAuthError } from '@/utils/api-errors';
+import { USER_MEMBERSHIPS_QUERY_KEY } from '@/constants/queryKeys';
+
+const MAX_RETRIES = 3;
+
+/**
+ * User memberships query.
+ *
+ * Fetches a user's active org/class/group/family memberships from
+ * `GET /v1/users/:userId/memberships` and returns the flat `items` array
+ * (each `{ entityType, entityId, role, ... }`; class rows additionally carry
+ * `schoolId` / `districtId` on full-access reads). The set is small and bounded,
+ * so the endpoint is unpaginated.
+ *
+ * **Enablement.** Internally gated on `authStore.accessToken` AND a truthy
+ * resolved `userId`; callers can add conditions via `queryOptions.enabled`. The
+ * participant homepage gates it further so it only fires when a launch URL
+ * actually needs the school/class IDs.
+ *
+ * @param {import('vue').MaybeRefOrGetter<String>} userId – The target user's Postgres UUID.
+ * @param {Object|undefined} queryOptions – Optional TanStack query options.
+ * @returns {import('@tanstack/vue-query').UseQueryReturnType} The query result resolving to the memberships array.
+ */
+const useUserMembershipsQuery = (userId = undefined, queryOptions = undefined) => {
+  const authStore = useAuthStore();
+  const conditions = [() => Boolean(authStore.accessToken), () => Boolean(toValue(userId))];
+  const { isQueryEnabled, options } = computeQueryOverrides(conditions, queryOptions);
+
+  return useQuery({
+    queryKey: [USER_MEMBERSHIPS_QUERY_KEY, userId],
+    queryFn: async () => {
+      const client = getRoarApiClient();
+      const result = await client.users.listUserMemberships({ params: { userId: toValue(userId) } });
+
+      if (result.status !== StatusCodes.OK) {
+        // Non-200 ts-rest results are surfaced as thrown errors so TanStack routes
+        // them through `error`. The thrown shape carries the ts-rest response so
+        // downstream error handlers can introspect it.
+        const error = new Error(`Failed to fetch user memberships with status ${result.status}`);
+        error.status = result.status;
+        error.body = result.body;
+        throw error;
+      }
+
+      return result.body.data.items;
+    },
+    ...options,
+    enabled: isQueryEnabled,
+    // Terminal auth errors and rostering-ended are not transient; retrying delays
+    // the user-facing error UX. Placed after `...options` so a caller-supplied
+    // `retry` can't silently override the policy.
+    retry: (failureCount, error) => {
+      if (isRosteringEndedError(error) || isTerminalAuthError(error)) {
+        return false;
+      }
+      return failureCount < MAX_RETRIES;
+    },
+  });
+};
+
+export default useUserMembershipsQuery;

--- a/apps/dashboard/src/composables/queries/useUserMembershipsQuery.test.js
+++ b/apps/dashboard/src/composables/queries/useUserMembershipsQuery.test.js
@@ -1,0 +1,179 @@
+import { ref, nextTick, isRef, isReadonly } from 'vue';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { createTestingPinia } from '@pinia/testing';
+import * as VueQuery from '@tanstack/vue-query';
+import { nanoid } from 'nanoid';
+import { StatusCodes } from 'http-status-codes';
+import { withSetup } from '@/test-support/withSetup.js';
+import { useAuthStore } from '@/store/auth';
+import useUserMembershipsQuery from './useUserMembershipsQuery';
+import { USER_MEMBERSHIPS_QUERY_KEY } from '@/constants/queryKeys';
+
+const mockListUserMemberships = vi.fn();
+
+vi.mock('@/clients/roar-api', () => ({
+  getRoarApiClient: () => ({
+    users: { listUserMemberships: mockListUserMemberships },
+  }),
+}));
+
+vi.mock('@tanstack/vue-query', async (getModule) => {
+  const original = await getModule();
+  return {
+    ...original,
+    useQuery: vi.fn().mockImplementation(original.useQuery),
+  };
+});
+
+const SAMPLE_ITEMS = [
+  { entityType: 'class', entityId: 'class-1', role: 'student', schoolId: 'school-1', districtId: 'district-1' },
+];
+
+describe('useUserMembershipsQuery', () => {
+  let piniaInstance;
+  let queryClient;
+
+  beforeEach(() => {
+    piniaInstance = createTestingPinia();
+    queryClient = new VueQuery.QueryClient({ defaultOptions: { queries: { retry: false } } });
+    mockListUserMemberships.mockReset();
+    mockListUserMemberships.mockResolvedValue({
+      status: StatusCodes.OK,
+      body: { data: { items: SAMPLE_ITEMS } },
+    });
+  });
+
+  afterEach(() => {
+    queryClient?.clear();
+    vi.clearAllMocks();
+  });
+
+  it('calls useQuery with the membership query key and a gated, readonly enabled', () => {
+    const userId = nanoid();
+    const authStore = useAuthStore(piniaInstance);
+    authStore.accessToken = 'test-token';
+
+    vi.spyOn(VueQuery, 'useQuery');
+
+    withSetup(() => useUserMembershipsQuery(userId), {
+      plugins: [[VueQuery.VueQueryPlugin, { queryClient }]],
+    });
+
+    const call = vi.mocked(VueQuery.useQuery).mock.calls[0][0];
+    expect(call.queryKey[0]).toBe(USER_MEMBERSHIPS_QUERY_KEY);
+    expect(call.queryKey[1]).toBe(userId);
+    expect(call.queryFn).toBeInstanceOf(Function);
+    expect(isRef(call.enabled)).toBe(true);
+    expect(isReadonly(call.enabled)).toBe(true);
+    expect(call.enabled.value).toBe(true);
+  });
+
+  it('fetches the memberships and returns the items array', async () => {
+    const userId = nanoid();
+    const authStore = useAuthStore(piniaInstance);
+    authStore.accessToken = 'test-token';
+
+    vi.spyOn(VueQuery, 'useQuery');
+
+    withSetup(() => useUserMembershipsQuery(userId), {
+      plugins: [[VueQuery.VueQueryPlugin, { queryClient }]],
+    });
+
+    const { queryFn } = vi.mocked(VueQuery.useQuery).mock.calls[0][0];
+    const items = await queryFn();
+
+    expect(mockListUserMemberships).toHaveBeenCalledWith({ params: { userId } });
+    expect(items).toEqual(SAMPLE_ITEMS);
+  });
+
+  it('throws when the API returns a non-200 status', async () => {
+    mockListUserMemberships.mockResolvedValue({ status: StatusCodes.FORBIDDEN, body: {} });
+
+    const authStore = useAuthStore(piniaInstance);
+    authStore.accessToken = 'test-token';
+
+    vi.spyOn(VueQuery, 'useQuery');
+
+    withSetup(() => useUserMembershipsQuery(nanoid()), {
+      plugins: [[VueQuery.VueQueryPlugin, { queryClient }]],
+    });
+
+    const { queryFn } = vi.mocked(VueQuery.useQuery).mock.calls[0][0];
+    await expect(queryFn()).rejects.toThrow(/status 403/);
+  });
+
+  it('unwraps a reactive userId and stays disabled until it is present', async () => {
+    const userId = ref(null);
+    const authStore = useAuthStore(piniaInstance);
+    authStore.accessToken = 'test-token';
+
+    withSetup(() => useUserMembershipsQuery(userId), {
+      plugins: [[VueQuery.VueQueryPlugin, { queryClient }]],
+    });
+
+    const call = vi.mocked(VueQuery.useQuery).mock.calls[0][0];
+    expect(call.enabled.value).toBe(false);
+
+    userId.value = nanoid();
+    await nextTick();
+
+    expect(call.enabled.value).toBe(true);
+  });
+
+  it('stays disabled until the access token is available', async () => {
+    const authStore = useAuthStore(piniaInstance);
+    authStore.accessToken = null;
+
+    withSetup(() => useUserMembershipsQuery(nanoid()), {
+      plugins: [[VueQuery.VueQueryPlugin, { queryClient }]],
+    });
+
+    const call = vi.mocked(VueQuery.useQuery).mock.calls[0][0];
+    expect(call.enabled.value).toBe(false);
+
+    authStore.accessToken = 'test-token';
+    await nextTick();
+
+    expect(call.enabled.value).toBe(true);
+  });
+
+  it('AND-s a caller-supplied enabled condition with the internal gate', async () => {
+    const authStore = useAuthStore(piniaInstance);
+    authStore.accessToken = 'test-token';
+    const callerEnabled = ref(false);
+
+    withSetup(() => useUserMembershipsQuery(nanoid(), { enabled: callerEnabled }), {
+      plugins: [[VueQuery.VueQueryPlugin, { queryClient }]],
+    });
+
+    const call = vi.mocked(VueQuery.useQuery).mock.calls[0][0];
+    // The internal token+userId gate is satisfied, so the caller's `false` is what withholds it.
+    expect(call.enabled.value).toBe(false);
+
+    callerEnabled.value = true;
+    await nextTick();
+
+    expect(call.enabled.value).toBe(true);
+  });
+
+  it('does not retry terminal auth / rostering-ended errors but retries transient ones up to 3x', () => {
+    const authStore = useAuthStore(piniaInstance);
+    authStore.accessToken = 'test-token';
+
+    let retryFn;
+    vi.spyOn(VueQuery, 'useQuery').mockImplementation((options) => {
+      retryFn = options.retry;
+      return { data: { value: null }, error: { value: null } };
+    });
+
+    withSetup(() => useUserMembershipsQuery(nanoid()), {
+      plugins: [[VueQuery.VueQueryPlugin, { queryClient }]],
+    });
+
+    expect(retryFn(0, { body: { error: { code: 'auth/token-expired' } } })).toBe(false);
+    expect(retryFn(0, { body: { error: { code: 'auth/rostering-ended' } } })).toBe(false);
+    const networkError = new Error('network down');
+    expect(retryFn(2, networkError)).toBe(true);
+    expect(retryFn(3, networkError)).toBe(false);
+  });
+});

--- a/apps/dashboard/src/composables/queries/useUserStudentDataQuery.js
+++ b/apps/dashboard/src/composables/queries/useUserStudentDataQuery.js
@@ -1,4 +1,4 @@
-import { computed } from 'vue';
+import { computed, toValue } from 'vue';
 import { useQuery } from '@tanstack/vue-query';
 import { storeToRefs } from 'pinia';
 import { StatusCodes } from 'http-status-codes';
@@ -23,15 +23,19 @@ const MAX_RETRIES = 3;
  * **Enablement.** Internally gated on `authStore.accessToken` AND a truthy resolved `uid`;
  * callers can add conditions via `queryOptions.enabled`.
  *
- * @param {String|undefined} userId – If passed, return the studentData for that user; otherwise
- *                                    the current authenticated user.
+ * @param {import('vue').MaybeRefOrGetter<String>|undefined} userId – If passed (value, ref, or getter),
+ *                                    return the studentData for that user; otherwise the current
+ *                                    authenticated user.
  * @param {QueryOptions|undefined} queryOptions – Optional TanStack query options.
  * @returns {UseQueryResult} The TanStack query result (the user's `studentData`).
  */
 const useUserStudentDataQuery = (userId = undefined, queryOptions = undefined) => {
   const authStore = useAuthStore();
   const { roarUid } = storeToRefs(authStore);
-  const uid = computed(() => userId || roarUid.value);
+  // `toValue` unwraps a ref/getter (so a reactive caller arg tracks correctly) and passes a
+  // plain value through unchanged (existing callers pass a static id). Falls back to the
+  // current user's `roarUid` only when no id is supplied.
+  const uid = computed(() => toValue(userId) || roarUid.value);
 
   // Gate internally on the access token so the query never fires before auth is ready, then on
   // the resolved uid. Caller conditions arrive via queryOptions.enabled and are AND'ed in.

--- a/apps/dashboard/src/constants/queryKeys.js
+++ b/apps/dashboard/src/constants/queryKeys.js
@@ -39,5 +39,6 @@ export const USER_ASSIGNMENTS_QUERY_KEY = 'user-assignments';
 export const MULTIPLE_USER_ASSIGNMENTS_QUERY_KEY = 'multiple-user-assignments';
 export const USER_CLAIMS_QUERY_KEY = 'user-claims';
 export const USER_STUDENT_DATA_QUERY_KEY = 'user-student';
+export const USER_MEMBERSHIPS_QUERY_KEY = 'user-memberships';
 export const USER_RUN_PAGE_QUERY_KEY = 'user-run-page';
 export const USER_LONGITUDINAL_RUNS_QUERY_KEY = 'user-longitudinal-runs';

--- a/apps/dashboard/src/helpers/participantGames.js
+++ b/apps/dashboard/src/helpers/participantGames.js
@@ -12,6 +12,27 @@
 import { findTaskByIdOrSlug } from '@/helpers/taskIdentifiers';
 
 /**
+ * Whether a game's external launch URL needs the participant's org membership
+ * IDs (`schoolId` / `classId`).
+ *
+ * Mirrors the generic-external branch of `GameTabs.externalLinksByTask`: a task
+ * with an external URL that is neither `qualtrics` (needs only `assessmentPid`)
+ * nor `mefs` (needs only age, derived from `dob`) builds its URL with
+ * `schoolId` / `classId`. The participant homepage uses this to fetch the
+ * memberships read **only** when such a task is present — internal-only
+ * administrations make no extra call.
+ *
+ * @param {Object} game – A game object from {@link mapAdministrationTasksToGames}.
+ * @returns {boolean} True when the game's launch URL needs org membership IDs.
+ */
+export function gameNeedsOrgMemberships(game) {
+  const hasExternalUrl = Boolean(game?.taskData?.variantURL || game?.taskData?.taskURL);
+  if (!hasExternalUrl) return false;
+  const taskId = String(game?.taskId ?? '');
+  return !taskId.includes('qualtrics') && !taskId.includes('mefs');
+}
+
+/**
  * Map a single administration task (with embedded per-student state) plus the
  * matched catalog task into a homepage game object.
  *

--- a/apps/dashboard/src/helpers/participantGames.test.js
+++ b/apps/dashboard/src/helpers/participantGames.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { mapAdministrationTasksToGames } from './participantGames';
+import { mapAdministrationTasksToGames, gameNeedsOrgMemberships } from './participantGames';
 
 const TASK_SWR = {
   id: '00000000-0000-0000-0000-000000000001',
@@ -25,6 +25,38 @@ const makeTask = (overrides = {}) => ({
   optional: false,
   progress: { startedOn: null, completedOn: null, allowRetake: false },
   ...overrides,
+});
+
+describe('gameNeedsOrgMemberships', () => {
+  const externalGame = (taskId, urlField = 'taskURL') => ({
+    taskId,
+    taskData: { [urlField]: 'https://example.com/launch' },
+  });
+
+  it('returns true for a generic external task (taskURL)', () => {
+    expect(gameNeedsOrgMemberships(externalGame('swr'))).toBe(true);
+  });
+
+  it('returns true for a generic external task (variantURL)', () => {
+    expect(gameNeedsOrgMemberships(externalGame('swr', 'variantURL'))).toBe(true);
+  });
+
+  it('returns false for a qualtrics external task (needs only assessmentPid)', () => {
+    expect(gameNeedsOrgMemberships(externalGame('survey-qualtrics'))).toBe(false);
+  });
+
+  it('returns false for a mefs external task (needs only age, derived from dob)', () => {
+    expect(gameNeedsOrgMemberships(externalGame('mefs'))).toBe(false);
+  });
+
+  it('returns false for an internal task with no external URL', () => {
+    expect(gameNeedsOrgMemberships({ taskId: 'swr', taskData: {} })).toBe(false);
+  });
+
+  it('returns false for a nullish or shapeless game', () => {
+    expect(gameNeedsOrgMemberships(undefined)).toBe(false);
+    expect(gameNeedsOrgMemberships({})).toBe(false);
+  });
 });
 
 describe('mapAdministrationTasksToGames', () => {

--- a/apps/dashboard/src/pages/HomeParticipant.vue
+++ b/apps/dashboard/src/pages/HomeParticipant.vue
@@ -79,17 +79,17 @@
         <ParticipantSidebar :total-games="totalGames" :completed-games="completeGames" :student-info="studentInfo" />
         <Transition name="fade" mode="out-in">
           <GameTabs
-            v-if="canShowAssessments && showOptionalAssessments && userData"
+            v-if="canShowAssessments && showOptionalAssessments && participantData"
             :games="optionalAssessments"
             :sequential="isSequential"
-            :user-data="userData"
+            :user-data="participantData"
             :launch-id="launchId"
           />
           <GameTabs
-            v-else-if="canShowAssessments && requiredAssessments && userData"
+            v-else-if="canShowAssessments && requiredAssessments && participantData"
             :games="requiredAssessments"
             :sequential="isSequential"
-            :user-data="userData"
+            :user-data="participantData"
             :launch-id="launchId"
           />
         </Transition>
@@ -118,7 +118,8 @@ import PvToggleSwitch from 'primevue/toggleswitch';
 import { useAuthStore } from '@/store/auth';
 import { useGameStore } from '@/store/game';
 import useMeQuery from '@/composables/queries/useMeQuery';
-import useUserDataQuery from '@/composables/queries/useUserDataQuery';
+import useUserStudentDataQuery from '@/composables/queries/useUserStudentDataQuery';
+import useUserMembershipsQuery from '@/composables/queries/useUserMembershipsQuery';
 import useUserAdministrationsQuery from '@/composables/queries/useUserAdministrationsQuery';
 import useUserAdministrationAgreementsQuery from '@/composables/queries/useUserAdministrationAgreementsQuery';
 import useAgreementVersionContentQuery from '@/composables/queries/useAgreementVersionContentQuery';
@@ -130,7 +131,7 @@ import GameTabs from '@/components/GameTabs.vue';
 import ParticipantSidebar from '@/components/ParticipantSidebar.vue';
 import { AppMessageState, MESSAGE_STATE_TYPES } from '@/components/AppMessageState';
 import AppSpinner from '@/components/AppSpinner.vue';
-import { mapAdministrationTasksToGames } from '@/helpers/participantGames';
+import { mapAdministrationTasksToGames, gameNeedsOrgMemberships } from '@/helpers/participantGames';
 import { resolveConsentRequirement, CONSENT_REQUIREMENT_STATUS } from '@/helpers/resolveConsentRequirement';
 import { USER_ADMINISTRATION_AGREEMENTS_QUERY_KEY } from '@/constants/queryKeys';
 
@@ -187,25 +188,30 @@ const getOptionLabel = computed(() => {
 const gameStore = useGameStore();
 const { selectedAdmin } = storeToRefs(gameStore);
 
+// Resolve the participant's ROAR (Postgres) user ID from the backend `/me`
+// endpoint. This is the identity the backend user, administrations, and
+// agreements endpoints expect — NOT the Firebase `roarUid`.
+//
+// NOTE: In proxy-launch mode (`props.launchId` set), `me.id` is the launching
+// user's ID, not the participant's. Resolving the participant's UUID for the
+// proxy path is handled by the separate proxy-launch change; the standard
+// student homepage path is unaffected.
+const { data: me } = useMeQuery({ enabled: initialized });
+const userId = computed(() => me.value?.id);
+
+// Participant profile from the backend (`GET /users/:id` → `mapUser`), replacing
+// the Firestore user-doc read — the last Firestore read on this page. Pass the
+// resolved Postgres `userId` (not `props.launchId`) and gate on it:
+// `useUserStudentDataQuery` falls back to the Firestore `roarUid` for a falsy
+// arg, which the backend would 404 on, so the query stays disabled until the
+// Postgres id is known.
 const {
   isLoading: isLoadingUserData,
   isFetching: isFetchingUserData,
   data: userData,
-} = useUserDataQuery(props.launchId, {
-  enabled: initialized,
+} = useUserStudentDataQuery(userId, {
+  enabled: computed(() => initialized.value && Boolean(userId.value)),
 });
-
-// Resolve the student's ROAR (Postgres) user ID from the backend `/me` endpoint,
-// the same way the Task players do. This is the identity the new
-// `GET /users/:userId/administrations` endpoint expects — NOT the Firebase
-// `roarUid`.
-//
-// NOTE: In proxy-launch mode (`props.launchId` set), `me.id` is the launching
-// user's ID, not the participant's. Resolving the participant's UUID from the
-// launch record is not yet implemented (mirrors the documented limitation in
-// the Task players). The standard student homepage path is unaffected.
-const { data: me } = useMeQuery({ enabled: initialized });
-const userId = computed(() => me.value?.id);
 
 const {
   isLoading: isLoadingAssignments,
@@ -436,6 +442,49 @@ const requiredAssessments = computed(() => {
 
 const optionalAssessments = computed(() => {
   return _filter(assessments.value, (assessment) => assessment.optional);
+});
+
+// The participant's org memberships are needed only to build external launch URLs
+// for generic external tasks (not internal players, qualtrics, or mefs). Fetch the
+// memberships read on demand — gated on such a task being present in the selected
+// administration — so the common internal-only homepage makes no extra backend call.
+const needsOrgMembershipsForLaunch = computed(() => assessments.value.some(gameNeedsOrgMemberships));
+
+const { data: memberships } = useUserMembershipsQuery(userId, {
+  enabled: computed(() => initialized.value && Boolean(userId.value) && needsOrgMembershipsForLaunch.value),
+});
+
+// The data object passed to GameTabs: the backend user profile (`mapUser`) plus the
+// three fields GameTabs reads that the user response doesn't carry — `birthMonth` /
+// `birthYear` (derived from `studentData.dob`) and the current school / class IDs
+// (from the memberships read; a student's school is the parent of their class). This
+// reassembles the legacy `userData` shape from backend sources so `mapUser` and
+// GameTabs stay unchanged.
+const participantData = computed(() => {
+  if (!userData.value) return null;
+
+  // `dob` is an ISO calendar date (`YYYY-MM-DD`) from the backend; split it rather than
+  // parsing via `new Date()` to avoid an off-by-one in negative-UTC timezones.
+  const dob = userData.value.studentData?.dob ?? '';
+  const [birthYear, birthMonth] = dob.split('-');
+
+  const rows = memberships.value ?? [];
+  const classRows = rows.filter((membership) => membership.entityType === 'class');
+  const currentClassIds = [...new Set(classRows.map((membership) => membership.entityId))];
+  const currentSchoolIds = [
+    ...new Set([
+      ...classRows.map((membership) => membership.schoolId).filter(Boolean),
+      ...rows.filter((membership) => membership.entityType === 'school').map((membership) => membership.entityId),
+    ]),
+  ];
+
+  return {
+    ...userData.value,
+    birthYear: birthYear ? Number(birthYear) : undefined,
+    birthMonth: birthMonth ? Number(birthMonth) : undefined,
+    schools: { current: currentSchoolIds },
+    classes: { current: currentClassIds },
+  };
 });
 
 // Hard gate for the assessment list: the student may only reach the games once

--- a/packages/api-contract/src/v1/users/contract.ts
+++ b/packages/api-contract/src/v1/users/contract.ts
@@ -8,6 +8,7 @@ import {
   UpdateUserRequestBodySchema,
   RecordUserAgreementRequestBodySchema,
   RecordUserAgreementResponseSchema,
+  UserMembershipsResponseSchema,
 } from './schema';
 
 import {
@@ -211,6 +212,31 @@ export const UsersContract = c.router(
         'Use ?locale=<bcp47> to select the current version returned per agreement (defaults to en-US). ' +
         'Returns 403 if the requester does not have access to the administration for the specified user. ' +
         'Returns 404 if the specified user or administration does not exist, or the specified user lacks access to it.',
+    },
+    listUserMemberships: {
+      method: 'GET',
+      path: '/:userId/memberships',
+      pathParams: z.object({
+        userId: z.string().uuid(),
+      }),
+      responses: {
+        200: SuccessEnvelopeSchema(UserMembershipsResponseSchema),
+        401: ErrorEnvelopeSchema,
+        403: ErrorEnvelopeSchema,
+        404: ErrorEnvelopeSchema,
+        500: ErrorEnvelopeSchema,
+      },
+      strictStatusCodes: true,
+      summary: "List a user's active entity memberships",
+      description:
+        "Returns the specified user's active (current) org, class, group, and family memberships, each with the " +
+        "member's role. Class memberships can also include the parent schoolId and districtId so a caller can resolve " +
+        "the user's current school(s) without a separate lookup. Results are scoped to the requester's access: " +
+        'self, super admins, and a guardian of the user receive the full set (including family memberships and the ' +
+        'class parent IDs); a supervisory requester (administrator or educator) receives only the entities within ' +
+        'their reach, with class rows stripped of the parent school/district IDs, and no family memberships. ' +
+        'Returns 403 if the requester cannot access the specified user. ' +
+        'Returns 404 if the specified user does not exist.',
     },
     // Nest guardian / longitudinal score report sub-router under /users
     scoreReports: GuardianStudentReportContract,

--- a/packages/api-contract/src/v1/users/schema.ts
+++ b/packages/api-contract/src/v1/users/schema.ts
@@ -82,6 +82,64 @@ const FamilyMembershipSchema = z.object({
 export const UserMembershipSchema = z.union([OrgMembershipSchema, FamilyMembershipSchema]);
 export type UserMembership = z.infer<typeof UserMembershipSchema>;
 
+/**
+ * Response membership shapes for `GET /users/:userId/memberships`.
+ *
+ * Distinct from the create-body `UserMembershipSchema` above: this read shape
+ * carries the member's `role`, and class rows can additionally carry the parent
+ * `schoolId` / `districtId` so a consumer can resolve a student's current
+ * school(s) without a separate lookup (a student has no school-level membership
+ * row of their own — their school is the parent of their class).
+ *
+ * The parent `schoolId` / `districtId` are **optional**: they are returned only on
+ * full-access reads (self, super admin, or a guardian of the user), which is where
+ * the homepage use case lives. A scoped supervisory requester (administrator or
+ * educator) may hold `can_list_users` on a class without `can_read` on its parent
+ * school, so the parent IDs are omitted on that path to avoid disclosing org
+ * identifiers they cannot otherwise read.
+ *
+ * v1 returns **active (current) memberships only**; enrollment dates are omitted.
+ * A future `?status=active|all` toggle would reintroduce them.
+ */
+const OrgGroupMembershipResponseSchema = z.object({
+  entityType: z.enum(['district', 'school', 'group']),
+  entityId: z.string().uuid(),
+  role: UserRoleSchema,
+});
+
+const ClassMembershipResponseSchema = z.object({
+  entityType: z.literal('class'),
+  entityId: z.string().uuid(),
+  role: UserRoleSchema,
+  schoolId: z.string().uuid().optional(),
+  districtId: z.string().uuid().optional(),
+});
+
+const FamilyMembershipResponseSchema = z.object({
+  entityType: z.literal('family'),
+  entityId: z.string().uuid(),
+  role: UserFamilyRoleSchema,
+});
+
+export const UserMembershipResponseSchema = z.union([
+  OrgGroupMembershipResponseSchema,
+  ClassMembershipResponseSchema,
+  FamilyMembershipResponseSchema,
+]);
+export type UserMembershipResponse = z.infer<typeof UserMembershipResponseSchema>;
+
+/**
+ * Response body payload for `GET /users/:userId/memberships`.
+ *
+ * Unpaginated: a user's active membership set is small and bounded (students sit
+ * at the leaves of the org hierarchy, admins at the top), so there is nothing to
+ * page through.
+ */
+export const UserMembershipsResponseSchema = z.object({
+  items: z.array(UserMembershipResponseSchema),
+});
+export type UserMembershipsResponse = z.infer<typeof UserMembershipsResponseSchema>;
+
 const CreateUserIdentifiersSchema = z.object({
   stateId: z.string().optional(),
   pid: z.string().optional(),


### PR DESCRIPTION
## Summary

This PR moves the participant homepage off its **last Firestore read**. `HomeParticipant.vue` resolved the participant's profile from Firestore via `useUserDataQuery`; it now reads the backend `GET /v1/users/:id` (`useUserStudentDataQuery` → `mapUser`), and sources the two fields the user response doesn't carry from elsewhere — `birthMonth`/`birthYear` from `dob`, and `schools.current`/`classes.current` from the new memberships endpoint.

> **Depends on `enh/user-memberships-endpoint`** (`GET /v1/users/:id/memberships`). Stacked on it — merge the backend PR first.

## Why it wasn't a clean swap

`GameTabs` builds external-assessment launch URLs from `userData.birthMonth/birthYear`, `userData.schools.current`, and `userData.classes.current` — fields that lived only on the Firestore user doc and are absent from `mapUser`. A naïve swap would emit `participantAgeInMonths=NaN` and drop `schoolId`/`classId` for every student. This PR reassembles those fields from backend sources, so `mapUser` and `GameTabs` are left **unchanged**.

## Changes

- **`HomeParticipant.vue`**
  - Replaced `useUserDataQuery(props.launchId)` with `useUserStudentDataQuery(userId)`, where `userId` is the resolved `me.id` Postgres UUID. The query is gated on `userId` being present so it never fires with the Firestore `roarUid` fallback (which the backend would 404 on).
  - Added `useUserMembershipsQuery(userId)`, fetched **on demand** — enabled only when the selected administration contains a generic external task (`gameNeedsOrgMemberships`), so internal-only administrations make **no** extra call.
  - Added a `participantData` computed that merges the `mapUser` profile with `birthMonth`/`birthYear` (from `studentData.dob`) and `schools.current`/`classes.current` (distinct parent `schoolId`s of the active class rows, plus any direct school rows; class IDs from class rows). `GameTabs` now receives this; the consent gate and grade sidebar keep reading the `mapUser` `studentData`.
- **`useUserMembershipsQuery.js`** (new) — standard backend-client query composable: token + `userId` gating via `computeQueryOverrides`, envelope unwrap to `items`, structured error throw, pinned retry policy.
- **`useUserStudentDataQuery.js`** — wrapped its `userId` arg in `toValue` so a reactive ref tracks correctly (a plain value still passes through unchanged). Required because `HomeParticipant` now passes the reactive `userId`; existing callers (the Task players, which pass a static `props.launchId`) are unaffected.
- **`participantGames.js`** — added `gameNeedsOrgMemberships(game)`, which mirrors `GameTabs`' generic-external-launch branch (external URL present, not `qualtrics`, not `mefs`) and drives the on-demand enablement.
- **`queryKeys.js`** — added `USER_MEMBERSHIPS_QUERY_KEY`.

## Behavior

- Self path: the profile, age, and current school/class IDs all resolve from the backend; external launch URLs are byte-for-byte equivalent to the Firestore-sourced ones.
- Proxy-launch (resolving the **child's** profile under a parent session) rides the separate `enh/proxy-launch-frontend` change that sets `userId = launchId ?? me.id`. This PR passes whatever `userId` resolves to, so it composes with that change without further edits.
- `useUserDataQuery` is **not** deleted — it still has other importers (score report, SSO readiness, `useUserProfileQuery`).

## Testing

- **Unit tests added.** `useUserMembershipsQuery.test.js` mirrors the reference composable tests (query key, envelope unwrap to `items`, token + `userId` gating, reactive-`userId` unwrap, non-200 throw, retry policy). `participantGames.test.js` covers `gameNeedsOrgMemberships` (generic-external → true; qualtrics / mefs / no-URL / nullish → false).
- `HomeParticipant.vue` compiles (`@vue/compiler-sfc` parse + `compileScript`); `prettier --check` passes for all changed files. The page component has no component-test harness, so the testable core of the `participantData` assembly (`gameNeedsOrgMemberships`) is extracted and unit-tested; a self/proxy-launch e2e under the seeded stack remains the end-to-end coverage per `frontend-e2e-testing-pattern`. The dashboard is JS, so there is no `check-types`; lint/tests run in CI.

## Review

An independent review pass found no blockers and confirmed the `participantData` shape matches what `GameTabs` reads, the `roarUid` 404 fallback is never hit (both queries are gated on the resolved Postgres `userId`), and the `toValue` change is backward-compatible (the existing `useUserStudentDataQuery` test suite still passes). Its two SHOULD-FIX notes — missing tests for `useUserMembershipsQuery` and `gameNeedsOrgMemberships` — are addressed here (see Testing); two NITs (redundant optional chaining; documenting the `YYYY-MM-DD` `dob` assumption) are fixed.

## Out of scope

- The backend memberships endpoint (`enh/user-memberships-endpoint`, this PR's dependency).
- Proxy-launch identity wiring (`enh/proxy-launch-frontend`).
- Deleting `useUserDataQuery` (still has other consumers).



> [!NOTE]
> **Cross-fork stacking.** Because intermediate branches live only on `richford`, a `yeatmanlab/roar-dashboard` PR cannot use one as its base — every PR in this series targets `project/backend-refactor`, and they are reviewed/merged **bottom-up** so each shows only its own slice once its parent merges.

> [!IMPORTANT]
> **Merge order:** stacked on `enh/user-memberships-endpoint` (#1991) — merge #1991 first; until it lands, this PR's diff sits on top of that branch's commits.

Resolves #1974
Part of #1958