### PR TITLE
Wire can_read_child into the two administration read endpoints

### DIFF
--- a/apps/backend/src/services/administration/administration.service.test.ts
+++ b/apps/backend/src/services/administration/administration.service.test.ts
@@ -3107,6 +3107,48 @@ describe('AdministrationService', () => {
       expect(result.totalItems).toBe(2);
     });
 
+    it('returns the target child administrations for an authorized guardian (can_read_child), bypassing the requester intersection', async () => {
+      // Proxy-launch: a parent with `can_read_child` on the child's family lists the
+      // child's administrations. The parent holds no administration-level access of
+      // their own, so the admin/teacher intersection would be empty — the guardian
+      // path returns the child's full accessible set instead.
+      const child = UserFactory.build({ id: 'child-1', rosteringEnded: null });
+      mockUserRepository.getById.mockResolvedValue(child);
+
+      const childAdmins = AdministrationFactory.buildList(2);
+      mockAuthorizationService.listAccessibleObjects.mockResolvedValue(
+        childAdmins.map((a) => `administration:${a.id}`),
+      );
+      mockUserRepository.getUserEntityMemberships.mockResolvedValue([{ entityType: 'family', entityId: 'family-1' }]);
+      mockAuthorizationService.hasAnyPermission.mockResolvedValue(true);
+      mockAdministrationRepository.getByIds.mockResolvedValue({ items: childAdmins, totalItems: 2 });
+
+      const service = AdministrationService({
+        administrationRepository: mockAdministrationRepository,
+        userRepository: mockUserRepository,
+        authorizationService: mockAuthorizationService,
+      });
+
+      const result = await service.getUserAdministrations({ userId: 'parent-1', isSuperAdmin: false }, 'child-1', {
+        page: 1,
+        perPage: 25,
+        sortBy: 'createdAt',
+        sortOrder: 'desc',
+      });
+
+      // Guardianship is checked via `can_read_child` on the child's family.
+      expect(mockAuthorizationService.hasAnyPermission).toHaveBeenCalledWith('parent-1', 'can_read_child', [
+        'family:family-1',
+      ]);
+      // Only the target's accessible-objects lookup runs — no requester intersection.
+      expect(mockAuthorizationService.listAccessibleObjects).toHaveBeenCalledTimes(1);
+      expect(mockAdministrationRepository.getByIds).toHaveBeenCalledWith(
+        childAdmins.map((a) => a.id),
+        expect.objectContaining({ page: 1, perPage: 25 }),
+      );
+      expect(result.items).toHaveLength(2);
+    });
+
     it('throws 404 when a rostering-ended user requests their own administrations (#1742 defense-in-depth)', async () => {
       // The auth guard (#1735) blocks rostering-ended users end-to-end, but
       // the service-layer check runs BEFORE the `requesterUserId === userId`
@@ -5295,6 +5337,47 @@ describe('AdministrationService', () => {
       const unsignedItem = result.items.find((i) => i.agreement.id === 'agreement-unsigned');
       expect(signedItem!.signed).toBe(true);
       expect(unsignedItem!.signed).toBe(false);
+    });
+
+    it('allows an authorized guardian (can_read_child) to read the target child agreements', async () => {
+      // Proxy-launch consent gate: a parent with `can_read_child` on the child's
+      // family reads the child's per-administration agreements. The guardian has no
+      // administration-level `can_read`, so the guardian path must be accepted in
+      // place of the admin/teacher fallback.
+      const child = UserFactory.build({ id: 'child-1', isSuperAdmin: false });
+      const mockAdmin = AdministrationFactory.build({ id: 'admin-123' });
+      const mockAgreementRepo = createMockAgreementRepository();
+
+      mockUserRepository.getById.mockResolvedValue(child);
+      mockAdministrationRepository.getById.mockResolvedValue(mockAdmin);
+      mockAuthorizationService.requirePermission.mockResolvedValue(undefined);
+      mockUserRepository.getUserEntityMemberships.mockResolvedValue([{ entityType: 'family', entityId: 'family-1' }]);
+      mockAuthorizationService.hasAnyPermission.mockResolvedValue(true);
+      mockAdministrationRepository.getAgreementsByAdministrationId.mockResolvedValue({
+        items: [buildAgreementItem('agreement-1')],
+        totalItems: 1,
+      });
+      mockAgreementRepo.getSignedAgreementIds.mockResolvedValue(new Set());
+
+      const service = AdministrationService({
+        administrationRepository: mockAdministrationRepository,
+        userRepository: mockUserRepository,
+        authorizationService: mockAuthorizationService,
+        agreementRepository: mockAgreementRepo,
+      });
+
+      const result = await service.listUserAdministrationAgreements(
+        { userId: 'parent-1', isSuperAdmin: false },
+        'child-1',
+        'admin-123',
+        defaultOptions,
+      );
+
+      // Guardianship is checked via `can_read_child` on the child's family.
+      expect(mockAuthorizationService.hasAnyPermission).toHaveBeenCalledWith('parent-1', 'can_read_child', [
+        'family:family-1',
+      ]);
+      expect(result.totalItems).toBe(1);
     });
 
     it('allows a self-read (requester === target) with a single requirePermission call', async () => {

--- a/apps/backend/src/services/administration/administration.service.ts
+++ b/apps/backend/src/services/administration/administration.service.ts
@@ -16,6 +16,7 @@ import { StatusCodes } from 'http-status-codes';
 import type { Administration, User } from '../../db/schema';
 import { AuthorizationService } from '../authorization/authorization.service';
 import { FgaType, FgaRelation } from '../authorization/fga-constants';
+import { EntityType } from '../../types/entity-type';
 import { extractFgaObjectId } from '../authorization/helpers/extract-fga-object-id.helper';
 import { collectStreamedFgaObjects } from '../authorization/helpers/collect-streamed-fga-objects.helper';
 import {
@@ -1009,6 +1010,31 @@ export function AdministrationService({
   }
 
   /**
+   * Whether the requester is an authorized guardian of the target user — i.e. holds
+   * `can_read_child` on any family the target belongs to. Mirrors the parent-consent
+   * check in `UserService.recordUserAgreement` (which uses `can_consent_for_child`).
+   *
+   * Non-throwing on purpose: callers combine it with the existing self / super-admin /
+   * admin-teacher access paths, so it returns a boolean rather than throwing FORBIDDEN.
+   *
+   * @param requesterUserId - The authenticated requester (e.g. the launching parent)
+   * @param targetUserId - The user whose data is being accessed (e.g. the child)
+   * @returns true when the requester holds `can_read_child` on a shared family
+   */
+  async function hasGuardianReadAccess(requesterUserId: string, targetUserId: string): Promise<boolean> {
+    const targetMemberships = await userRepository.getUserEntityMemberships(targetUserId);
+    const familyObjects = targetMemberships
+      .filter((membership) => membership.entityType === EntityType.FAMILY)
+      .map((membership) => `${FgaType.FAMILY}:${membership.entityId}`);
+
+    if (familyObjects.length === 0) {
+      return false;
+    }
+
+    return authorizationService.hasAnyPermission(requesterUserId, FgaRelation.CAN_READ_CHILD, familyObjects);
+  }
+
+  /**
    * List administrations accessible to a requester and target user with pagination, sorting, and optional embeds.
    *
    * super_admin users have unrestricted access to all administrations.
@@ -1088,6 +1114,12 @@ export function AdministrationService({
       let result: PaginatedResult<Administration>;
 
       if (isSuperAdmin) {
+        result = await administrationRepository.getByIds(targetUserAdminIds, queryParams);
+      } else if (await hasGuardianReadAccess(requesterUserId, userId)) {
+        // Authorized guardians (can_read_child) see all of the target child's
+        // administrations, bypassing the admin/teacher shared-access intersection
+        // below — a guardian holds no administration-level access of their own, so
+        // the intersection would always be empty.
         result = await administrationRepository.getByIds(targetUserAdminIds, queryParams);
       } else {
         const requesterUserAdmins = await authorizationService.listAccessibleObjects(
@@ -1516,11 +1548,19 @@ export function AdministrationService({
           { requesterUserId, userId, administrationId },
           'Requester attempting cross-user administration agreements access',
         );
-        await authorizationService.requirePermission(
-          requesterUserId,
-          FgaRelation.CAN_READ,
-          `${FgaType.ADMINISTRATION}:${administrationId}`,
-        );
+        // Authorized guardians (can_read_child on the target's family) may read their
+        // child's per-administration consent agreements. A guardian holds no
+        // administration-level access, so check the guardian path first and otherwise
+        // require can_read on the administration (the admin/teacher path), which throws
+        // FORBIDDEN for everyone else.
+        const isGuardian = await hasGuardianReadAccess(requesterUserId, userId);
+        if (!isGuardian) {
+          await authorizationService.requirePermission(
+            requesterUserId,
+            FgaRelation.CAN_READ,
+            `${FgaType.ADMINISTRATION}:${administrationId}`,
+          );
+        }
       }
 
       const queryParams = {


### PR DESCRIPTION
## Summary

This PR wires the FGA `can_read_child` relation into the two administration **read** endpoints a parent hits when proxy-launching their child, so the child's homepage and consent gate resolve under a parent session instead of `403`-ing. It is a service-layer authorization change only — no contract, route, controller, or schema changes.

> ⚠️ **This is a security-sensitive authorization change. Please review the three points below line-by-line and rely on the integration tests, not the (FGA-mocked) unit tests, for the policy guarantee.**

## What was missing

`getUserAdministrations` and `listUserAdministrationAgreements` authorized only super-admin, self, or an admin/teacher whose accessible-administration set intersects the target's. A parent reading their own child is none of those, so the proxy-launch homepage and consent gate returned `403`. Run creation (`can_create_run_for_child`) and parent consent recording (`can_consent_for_child`) were already authorized; only these two reads were not.

## Changes

- **`hasGuardianReadAccess(requesterUserId, targetUserId)`** — a new private, **non-throwing** helper in `administration.service.ts`. It reads the target user's entity memberships, keeps the `family` ones, and asks FGA whether the requester has `can_read_child` on any of those family objects (`hasAnyPermission`). It returns a boolean (rather than throwing) so callers can fall through to other authorization paths. This mirrors the parent block already in `user.service.recordUserAgreement`.
- **`getUserAdministrations`** — in the non-super-admin / non-self branch, the guardian path is tried **before** the existing admin/teacher intersection fallback. When the requester is an authorized guardian, the target child's administrations are returned directly (by IDs), bypassing the requester-intersection logic that exists for admins/teachers.
- **`listUserAdministrationAgreements`** — inside the existing `!isSuperAdmin && requesterUserId !== userId` block, an authorized guardian is accepted in place of the administration-level `can_read` requirement.

## Authorization behavior (please verify each)

1. **Super-admin bypass is unchanged and still checked first.** The guardian path lives only in the non-super-admin, non-self branch.
2. **404-before-403 ordering is preserved.** `listUserAdministrationAgreements` still verifies the child and the administration exist before the guardian check runs.
3. **Correct FGA relation and object.** Access is `can_read_child` on `family:<id>` for each family the **child** belongs to — not an administration-scoped relation, and keyed to the child's family, not the requester's.

## Why the guardian sees the child's data, not their own (embed scoping)

`getUserAdministrations` resolves embeds after the authorization decision. Stats are gated to super-admins only (a guardian never receives them). The tasks embed is fetched unfiltered (its `userId` argument is only error-logging context), and per-student task state is attached **keyed to the target user** (the child). So the guardian path returns the child's administrations and the child's per-task state. Confirm this in review against the embed-resolution code.

## Testing

- **Unit tests added** for both endpoints (guardian-allowed). These mock FGA, so they assert the **wiring**: that `hasAnyPermission` is called with `('<requester>', 'can_read_child', ['family:<childFamily>'])`, that the self/admin paths are not taken, and that the child's data is returned.
- ⚠️ **Integration tests against the real OpenFGA model are still required and were not run in the authoring environment.** Before merge, please add/verify integration coverage for: (a) a guardian with `can_read_child` on the child's family is **allowed** on both endpoints; (b) a user **without** that relation, and a guardian of a **different** family, are **denied** (`403`); (c) the super-admin, self, and admin/teacher paths are unaffected.
- Lint, format, and `check-types` were run for the changed backend files.

## Out of scope

- `recordUserAgreement` (already authorizes parents via `can_consent_for_child`).
- The dependent **frontend** proxy-launch cutover (`enh/proxy-launch-frontend`), which builds on this PR.



> [!NOTE]
> **Cross-fork stacking.** Because intermediate branches live only on `richford`, a `yeatmanlab/roar-dashboard` PR cannot use one as its base — every PR in this series targets `project/backend-refactor`, and they are reviewed/merged **bottom-up** so each shows only its own slice once its parent merges.

> [!IMPORTANT]
> **Merge order:** first in its stack — targets `project/backend-refactor` directly.

Resolves #1975
Part of #1958