### PR TITLE
`fix` Pin Chrome Version in Assessment e2e Tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -493,12 +493,27 @@ jobs:
         env:
           ASSESSMENT_NAME: ${{ matrix.assessment }}
 
+      # Pin Chrome so every machine in the parallel run reports an identical browserVersion.
+      # Bare ubuntu-latest runners drift the Chrome version as GitHub updates them (e.g. 149 vs
+      # 150), which makes Cypress Cloud refuse to group the parallel machines ("we do not
+      # parallelize tests across different environments"). This job can't use a cypress/browsers
+      # container like e2e-tests / component-tests because it runs `docker compose` to bring up
+      # the assessment env (no docker-in-docker inside a job container), so it pins Chrome on the
+      # bare runner instead. Version 130 matches the cypress/browsers image the other jobs use.
+      - name: Pin Chrome version
+        id: setup-chrome
+        uses: browser-actions/setup-chrome@v1
+        with:
+          chrome-version: '130'
+
       - name: Run Cypress tests
         uses: cypress-io/github-action@v6
         with:
           install: false
           start: npm run dev:ci
-          browser: ${{ matrix.browser }}
+          # Point Cypress at the pinned binary explicitly so it doesn't fall back to the runner's
+          # (drifting) system Chrome. The matrix still labels this leg "chrome".
+          browser: ${{ steps.setup-chrome.outputs.chrome-path }}
           working-directory: apps/assessments/${{ matrix.assessment }}
           wait-on: "http://localhost:8000"
           wait-on-timeout: 120

--- a/.github/workflows/deploy-assessment.yml
+++ b/.github/workflows/deploy-assessment.yml
@@ -108,6 +108,13 @@ jobs:
     if: ${{ inputs.run-cypress }}
     needs: [deploy]
     runs-on: ubuntu-latest
+    # Pin the browser/OS via a container so every machine in the parallel run reports identical
+    # environment parameters (osName/osVersion/browserVersion) to Cypress Cloud. Bare
+    # ubuntu-latest runners drift the Chrome version across machines as GitHub updates them
+    # (e.g. 149 vs 150), which makes Cypress refuse to group them ("we do not parallelize tests
+    # across different environments"). Same pinned image as the e2e-tests job in ci.yml.
+    container:
+      image: cypress/browsers:node-20.18.0-chrome-130.0.6723.69-1-ff-131.0.3-edge-130.0.2849.52-1
     timeout-minutes: 60
     strategy:
       fail-fast: false


### PR DESCRIPTION
Bare ubuntu-latest runners drift the Chrome version across the parallel machines as GitHub updates them (e.g. 149 vs 150), so Cypress Cloud refuses to group them. Pin Chrome 130 via setup-chrome in ci.yml's e2e-assessments job (it stays on a bare runner for docker compose) and add the cypress/browsers container to deploy-assessment.yml's cypress job.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
