### PR TITLE
enh: Add variant picker to assessments in staging/dev environments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -568,10 +568,20 @@ jobs:
   # and no deployment-branch policy restricting it to `main`. If it's locked to main,
   # move these four secrets to a PR-permissive environment (e.g. assessments:preview)
   # and point this job at it instead.
+  #
+  # Fork PRs receive no repository/environment secrets from GitHub, so this job would
+  # otherwise fail at the GCP auth step with empty credentials. The `if` below skips it
+  # cleanly for forks — previews run only for same-repo branch PRs (authored by
+  # maintainers with push access), which is also the only case that can satisfy the
+  # environment's deployment-branch policy.
   preview-assessments:
     name: Preview ${{ matrix.assessment }}
     needs: [detect-assessment-changes, lint, build]
-    if: needs.detect-assessment-changes.outputs.matrix != '[]'
+    # Skip cleanly for fork PRs — GitHub withholds secrets from them, so the deploy would
+    # fail at GCP auth. Previews run only for same-repo branch PRs.
+    if: >-
+      needs.detect-assessment-changes.outputs.matrix != '[]' &&
+      github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     environment: assessments:staging
     timeout-minutes: 15

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -634,28 +634,79 @@ jobs:
           dist-path: apps/assessments/${{ matrix.assessment }}/dist
           firebase-config-path: apps/assessments/${{ matrix.assessment }}/firebase.json
 
-      - name: Comment preview URL
+      # Record this assessment's preview URL as an artifact so the single `preview-comment`
+      # fan-in job can aggregate every link into one PR comment (instead of one per assessment).
+      - name: Record preview result
         if: steps.deploy.outputs.deployment-url != ''
-        uses: actions/github-script@v7
         env:
           ASSESSMENT: ${{ matrix.assessment }}
           PREVIEW_URL: ${{ steps.deploy.outputs.deployment-url }}
+        run: |
+          mkdir -p preview-results
+          printf '%s\t%s\n' "$ASSESSMENT" "$PREVIEW_URL" > "preview-results/$ASSESSMENT.tsv"
+
+      - name: Upload preview result
+        if: steps.deploy.outputs.deployment-url != ''
+        uses: actions/upload-artifact@v4
+        with:
+          name: preview-result-${{ matrix.assessment }}
+          path: preview-results/${{ matrix.assessment }}.tsv
+          retention-days: 1
+
+  # ––––––––––––––––––––––––––––––––––––––––––––––– #
+  # Post all assessment preview links in one PR comment
+  # ––––––––––––––––––––––––––––––––––––––––––––––– #
+  #
+  # Fan-in for the preview-assessments matrix: each leg uploads its deploy URL as an
+  # artifact; this single job aggregates them into one sticky comment (hidden marker) that
+  # updates in place on every push. A single job avoids the write race that parallel matrix
+  # legs would hit editing one shared comment. always() so it still posts whatever deployed
+  # even if some legs failed; the fork / empty-matrix guards mirror the deploy job.
+  preview-comment:
+    name: Post preview links
+    needs: [detect-assessment-changes, preview-assessments]
+    if: >-
+      always() &&
+      needs.detect-assessment-changes.outputs.matrix != '[]' &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Download preview results
+        uses: actions/download-artifact@v4
+        with:
+          pattern: preview-result-*
+          path: preview-results
+          merge-multiple: true
+
+      - name: Upsert single preview comment
+        uses: actions/github-script@v7
         with:
           script: |
-            const assessment = process.env.ASSESSMENT;
-            const url = process.env.PREVIEW_URL;
-            // Hidden marker keeps one sticky comment per assessment: re-pushes update it
-            // in place, and multiple changed assessments never clobber each other.
-            const marker = `<!-- assessment-preview:${assessment} -->`;
+            const fs = require('fs');
+            const dir = 'preview-results';
+            const rows = [];
+            if (fs.existsSync(dir)) {
+              for (const file of fs.readdirSync(dir)) {
+                const [assessment, url] = fs.readFileSync(`${dir}/${file}`, 'utf8').trim().split('\t');
+                if (assessment && url) rows.push({ assessment, url });
+              }
+            }
+            // Nothing deployed (e.g. every leg failed) — don't post an empty comment.
+            if (rows.length === 0) return;
+            rows.sort((a, b) => a.assessment.localeCompare(b.assessment));
+
+            // Single hidden marker → one sticky comment, updated in place on re-push.
+            const marker = '<!-- assessment-previews -->';
             const body = [
               marker,
-              `### 🔍 Preview — \`${assessment}\``,
-              url,
+              '### 🔍 Assessment previews',
+              ...rows.map((r) => `- \`${r.assessment}\` — ${r.url}`),
               '',
-              "_Runs the default (first published) variant against the **staging** backend, reflecting " +
-                "this PR's bundle changes. Expires in 7 days (refreshed on each push). In-page variant " +
-                "selection lands with the variant-picker enhancement._",
+              "_Each runs the default (first published) variant against the **staging** backend, " +
+                "reflecting this PR's bundle changes. Expires in 7 days (refreshed on each push)._",
             ].join('\n');
+
             const comments = await github.paginate(github.rest.issues.listComments, {
               owner: context.repo.owner,
               repo: context.repo.repo,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -706,8 +706,10 @@ jobs:
               // append duplicate title cards for every preview below the list.
               ...rows.map((r) => `- \`${r.assessment}\` — [${r.url}](${r.url})`),
               '',
-              "_Each runs the default (first published) variant against the **staging** backend, " +
-                "reflecting this PR's bundle changes. Expires in 7 days (refreshed on each push)._",
+              "_Each preview opens on the default (first published) variant against the **staging** " +
+                "backend, reflecting this PR's bundle changes. Most include an in-page variant picker " +
+                "(dev/staging only) to switch between published variants. Expires in 7 days " +
+                "(refreshed on each push)._",
             ].join('\n');
 
             const comments = await github.paginate(github.rest.issues.listComments, {

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -620,7 +620,8 @@ jobs:
 
       # No github-token here on purpose: it would trigger the FirebaseExtended action's
       # own PR comment, which isn't keyed per-site and would clobber across matrix legs.
-      # We post a per-assessment sticky comment below using the deployment-url output.
+      # This leg records its deployment-url to an artifact; the separate preview-comment
+      # job aggregates all legs into a single sticky comment after the matrix completes.
       - name: Deploy preview channel
         id: deploy
         uses: ./.github/actions/deploy-firebase-hosting

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -561,11 +561,11 @@ jobs:
   # default (first published) variant; in-page variant selection lands with the
   # variant-picker enhancement (a follow-up PR).
   #
-  # Credentials come from the dedicated `assessments:preview` environment — a PR-permissive
-  # environment (all-branches deployment policy) holding the same secrets as
-  # `assessments:staging`, so the real staging-deploy environment stays branch-locked while
-  # previews can deploy from PR branches. The assessment hosting sites live under the same
-  # staging Firebase project.
+  # Credentials come from the `assessments:staging` environment, which has an all-branches
+  # deployment policy (no required reviewers), so PR branches can deploy previews directly.
+  # Staging holds only synthetic data and the assessment hosting sites live under the same
+  # staging Firebase project, so a preview channel targets the same low-risk surface as a
+  # normal staging deploy.
   #
   # Fork PRs receive no repository/environment secrets from GitHub, so this job would
   # otherwise fail at the GCP auth step with empty credentials. The `if` below skips it
@@ -581,7 +581,7 @@ jobs:
       needs.detect-assessment-changes.outputs.matrix != '[]' &&
       github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
-    environment: assessments:preview
+    environment: assessments:staging
     timeout-minutes: 15
     env:
       # Lets the Sentry webpack plugin upload source maps for the preview build — it reads

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -561,13 +561,11 @@ jobs:
   # default (first published) variant; in-page variant selection lands with the
   # variant-picker enhancement (a follow-up PR).
   #
-  # Credentials come from the `assessments:staging` environment (the assessment
-  # hosting sites live under that project; the same secrets drive
-  # deploy-assessments-staging.yml). NOTE: for previews to run on PR branches, that
-  # environment must permit non-main deployments — i.e. no "required reviewers" gate
-  # and no deployment-branch policy restricting it to `main`. If it's locked to main,
-  # move these four secrets to a PR-permissive environment (e.g. assessments:preview)
-  # and point this job at it instead.
+  # Credentials come from the dedicated `assessments:preview` environment — a PR-permissive
+  # environment (all-branches deployment policy) holding the same secrets as
+  # `assessments:staging`, so the real staging-deploy environment stays branch-locked while
+  # previews can deploy from PR branches. The assessment hosting sites live under the same
+  # staging Firebase project.
   #
   # Fork PRs receive no repository/environment secrets from GitHub, so this job would
   # otherwise fail at the GCP auth step with empty credentials. The `if` below skips it
@@ -583,8 +581,13 @@ jobs:
       needs.detect-assessment-changes.outputs.matrix != '[]' &&
       github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
-    environment: assessments:staging
+    environment: assessments:preview
     timeout-minutes: 15
+    env:
+      # Lets the Sentry webpack plugin upload source maps for the preview build — it reads
+      # SENTRY_AUTH_TOKEN from the process env during build:staging. Set at job level so it
+      # reaches the composite build-assessment action.
+      SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -702,7 +702,9 @@ jobs:
             const body = [
               marker,
               '### 🔍 Assessment previews',
-              ...rows.map((r) => `- \`${r.assessment}\` — ${r.url}`),
+              // Explicit markdown links (not naked URLs) so the unfurl-links bot doesn't
+              // append duplicate title cards for every preview below the list.
+              ...rows.map((r) => `- \`${r.assessment}\` — [${r.url}](${r.url})`),
               '',
               "_Each runs the default (first published) variant against the **staging** backend, " +
                 "reflecting this PR's bundle changes. Expires in 7 days (refreshed on each push)._",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -546,3 +546,121 @@ jobs:
           CYPRESS_PROJECT_ID: ${{ secrets.CYPRESS_PROJECT_ID }}
           COMMIT_INFO_MESSAGE: "${{ github.event.pull_request.title }} (#${{ github.event.pull_request.number }})"
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  # ––––––––––––––––––––––––––––––––––––––––––––––– #
+  # Assessment PR preview links
+  # ––––––––––––––––––––––––––––––––––––––––––––––– #
+  #
+  # For each changed assessment, build the staging bundle and deploy it to an
+  # ephemeral Firebase Hosting *preview channel* on that assessment's existing
+  # staging hosting site, then post the preview URL on the PR. The preview points
+  # at the staging backend (baked-in ROAR_API_BASE_URL) and authenticates
+  # anonymously against the staging assessment Firebase project via the site's
+  # /__/firebase/init.json — identical to the live staging assessment, just on an
+  # ephemeral channel. No Firebase apiKeys enter the workflow. Reviewers get the
+  # default (first published) variant; in-page variant selection lands with the
+  # variant-picker enhancement (a follow-up PR).
+  #
+  # Credentials come from the `assessments:staging` environment (the assessment
+  # hosting sites live under that project; the same secrets drive
+  # deploy-assessments-staging.yml). NOTE: for previews to run on PR branches, that
+  # environment must permit non-main deployments — i.e. no "required reviewers" gate
+  # and no deployment-branch policy restricting it to `main`. If it's locked to main,
+  # move these four secrets to a PR-permissive environment (e.g. assessments:preview)
+  # and point this job at it instead.
+  preview-assessments:
+    name: Preview ${{ matrix.assessment }}
+    needs: [detect-assessment-changes, lint, build]
+    if: needs.detect-assessment-changes.outputs.matrix != '[]'
+    runs-on: ubuntu-latest
+    environment: assessments:staging
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        assessment: ${{ fromJson(needs.detect-assessment-changes.outputs.matrix) }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Read hosting site name
+        id: hosting
+        run: |
+          site=$(jq -r '.roar.hosting.staging' apps/assessments/${{ matrix.assessment }}/package.json)
+          echo "site=$site" >> "$GITHUB_OUTPUT"
+
+      - name: Build assessment
+        uses: ./.github/actions/build-assessment
+        with:
+          assessment: ${{ matrix.assessment }}
+          build-script: build:staging
+          roar-api-base-url: ${{ secrets.ROAR_API_BASE_URL }}
+
+      # The assessment firebase.json hardcodes sentry_environment=production in its
+      # Report-To/CSP headers; retag it to the PR so preview Sentry events group
+      # separately from production issues. Mirrors deploy-assessment.yml.
+      - name: Set Sentry environment for preview
+        run: |
+          sed -i "s|sentry_environment=production|sentry_environment=pr-${{ github.event.pull_request.number }}|g" \
+            apps/assessments/${{ matrix.assessment }}/firebase.json
+
+      # No github-token here on purpose: it would trigger the FirebaseExtended action's
+      # own PR comment, which isn't keyed per-site and would clobber across matrix legs.
+      # We post a per-assessment sticky comment below using the deployment-url output.
+      - name: Deploy preview channel
+        id: deploy
+        uses: ./.github/actions/deploy-firebase-hosting
+        with:
+          firebase-channel: preview
+          expires: 7d
+          firebase-hosting-site: ${{ steps.hosting.outputs.site }}
+          firebase-project-id: ${{ secrets.FIREBASE_PROJECT_ID }}
+          gcp-workload-identity-provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          gcp-service-account-id: ${{ secrets.FIREBASE_HOSTING_SERVICE_ACCOUNT_ID }}
+          dist-path: apps/assessments/${{ matrix.assessment }}/dist
+          firebase-config-path: apps/assessments/${{ matrix.assessment }}/firebase.json
+
+      - name: Comment preview URL
+        if: steps.deploy.outputs.deployment-url != ''
+        uses: actions/github-script@v7
+        env:
+          ASSESSMENT: ${{ matrix.assessment }}
+          PREVIEW_URL: ${{ steps.deploy.outputs.deployment-url }}
+        with:
+          script: |
+            const assessment = process.env.ASSESSMENT;
+            const url = process.env.PREVIEW_URL;
+            // Hidden marker keeps one sticky comment per assessment: re-pushes update it
+            // in place, and multiple changed assessments never clobber each other.
+            const marker = `<!-- assessment-preview:${assessment} -->`;
+            const body = [
+              marker,
+              `### 🔍 Preview — \`${assessment}\``,
+              url,
+              '',
+              "_Runs the default (first published) variant against the **staging** backend, reflecting " +
+                "this PR's bundle changes. Expires in 7 days (refreshed on each push). In-page variant " +
+                "selection lands with the variant-picker enhancement._",
+            ].join('\n');
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+            const existing = comments.find((c) => c.body && c.body.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+            }

--- a/apps/assessments/roar-letter/eslint.config.mjs
+++ b/apps/assessments/roar-letter/eslint.config.mjs
@@ -12,6 +12,8 @@ export default [
       globals: {
         ...globals.browser,
         process: 'readonly',
+        ROAR_DB: 'readonly',
+        ROAR_API_BASE_URL: 'readonly',
       },
     },
     rules: {

--- a/apps/assessments/roar-letter/serve/serve.js
+++ b/apps/assessments/roar-letter/serve/serve.js
@@ -5,6 +5,7 @@ import { bootstrapAnonymousSession } from '@roar-platform/assessment-sdk';
 import { LETTER_LANGUAGES, PHONICS_TASK_IDS } from '@roar-platform/assessment-schema/roar-letter';
 import RoarLetter from '../src/experiment/index';
 import { getFirebaseConfig } from '../../shared/firebaseConfig';
+import { mountVariantPicker } from '../../shared/variantPicker.js';
 // Import necessary for async in the top level of the experiment script
 import 'regenerator-runtime/runtime';
 
@@ -33,9 +34,11 @@ const language = LETTER_LANGUAGES[lngParam] ?? LETTER_LANGUAGES.en;
 // Phonics is a separate task family — language doesn't affect its task ID.
 const taskId = task === 'phonics' ? PHONICS_TASK_IDS.EN : language.taskId;
 
+// App config
 const firebaseConfig = await getFirebaseConfig();
 const app = initializeApp(firebaseConfig);
 const auth = getAuth(app);
+const baseUrl = ROAR_API_BASE_URL;
 
 if (process.env.FIREBASE_AUTH_EMULATOR_HOST) {
   connectAuthEmulator(auth, `http://${process.env.FIREBASE_AUTH_EMULATOR_HOST}`, { disableWarnings: true });
@@ -50,14 +53,12 @@ onAuthStateChanged(auth, async (user) => {
       // Performs the participant-free calls and hands back the participantId and resolved variantId.
       // The variantId URL param wins; otherwise it falls back to the first published variant.
       const { participantId, variantId: resolvedVariantId } = await bootstrapAnonymousSession(
-        // eslint-disable-next-line no-undef
-        { baseUrl: ROAR_API_BASE_URL, auth: authCallbacks },
+        { baseUrl, auth: authCallbacks },
         { ...(variantId ? { variantId } : {}), taskId },
       );
 
       const ctx = {
-        // eslint-disable-next-line no-undef
-        baseUrl: ROAR_API_BASE_URL,
+        baseUrl,
         auth: authCallbacks,
         participant: { participantId },
       };
@@ -67,6 +68,17 @@ onAuthStateChanged(auth, async (user) => {
         taskVersion,
         isAnonymous: true,
       });
+
+      // Dev/staging only: mount a variant switcher so reviewers can hop between published
+      // variants without hand-editing the URL. No-op in production (guard is eliminated at build).
+      if (ROAR_DB !== 'production') {
+        mountVariantPicker({
+          baseUrl,
+          auth: authCallbacks,
+          taskId,
+          currentVariantId: resolvedVariantId,
+        });
+      }
 
       const { variantParams } = await getVariantById(resolvedVariantId);
 

--- a/apps/assessments/roar-levante-tasks/eslint.config.mjs
+++ b/apps/assessments/roar-levante-tasks/eslint.config.mjs
@@ -41,6 +41,8 @@ export default [
       globals: {
         ...globals.browser,
         process: 'readonly',
+        ROAR_DB: 'readonly',
+        ROAR_API_BASE_URL: 'readonly',
       },
     },
     rules: {

--- a/apps/assessments/roar-levante-tasks/serve/serve.js
+++ b/apps/assessments/roar-levante-tasks/serve/serve.js
@@ -4,6 +4,7 @@ import { getVariantById, initFirekitCompat } from '@roar-platform/assessment-sdk
 import { bootstrapAnonymousSession } from '@roar-platform/assessment-sdk';
 import { TaskLauncher } from '../src';
 import { getFirebaseConfig } from '../../shared/firebaseConfig.js';
+import { mountVariantPicker } from '../../shared/variantPicker.js';
 // Import necessary for async in the top level of the experiment script
 import 'regenerator-runtime/runtime';
 
@@ -35,9 +36,11 @@ const versionOverride = urlParams.get('version');
 // Task selection: variantId wins; otherwise taskId resolves to the first published variant for that task.
 const taskId = urlParams.get('task') ?? 'egma-math';
 
+// App config
 const firebaseConfig = await getFirebaseConfig();
 const app = initializeApp(firebaseConfig);
 const auth = getAuth(app);
+const baseUrl = ROAR_API_BASE_URL;
 
 if (process.env.FIREBASE_AUTH_EMULATOR_HOST) {
   connectAuthEmulator(auth, `http://${process.env.FIREBASE_AUTH_EMULATOR_HOST}`, { disableWarnings: true });
@@ -51,14 +54,12 @@ onAuthStateChanged(auth, async (user) => {
       // Provision the anonymous ROAR user (and resolve a variant) via the SDK.
       // The variantId URL param wins; otherwise falls back to the first published variant for taskId.
       const { participantId, variantId: resolvedVariantId } = await bootstrapAnonymousSession(
-        // eslint-disable-next-line no-undef
-        { baseUrl: ROAR_API_BASE_URL, auth: authCallbacks },
+        { baseUrl, auth: authCallbacks },
         { ...(variantId ? { variantId } : {}), taskId },
       );
 
       const ctx = {
-        // eslint-disable-next-line no-undef
-        baseUrl: ROAR_API_BASE_URL,
+        baseUrl,
         auth: authCallbacks,
         participant: { participantId },
       };
@@ -68,6 +69,17 @@ onAuthStateChanged(auth, async (user) => {
         taskVersion,
         isAnonymous: true,
       });
+
+      // Dev/staging only: mount a variant switcher so reviewers can hop between published
+      // variants without hand-editing the URL. No-op in production (guard is eliminated at build).
+      if (ROAR_DB !== 'production') {
+        mountVariantPicker({
+          baseUrl,
+          auth: authCallbacks,
+          taskId,
+          currentVariantId: resolvedVariantId,
+        });
+      }
 
       const { variantParams } = await getVariantById(resolvedVariantId);
 
@@ -82,7 +94,6 @@ onAuthStateChanged(auth, async (user) => {
         ...(versionOverride !== null ? { version: Number(versionOverride) } : {}),
       };
 
-      // eslint-disable-next-line no-undef
       const isDev = ROAR_DB === 'development';
       const task = new TaskLauncher(variantParams, userParams, isDev);
       task.run();

--- a/apps/assessments/roar-multichoice/eslint.config.mjs
+++ b/apps/assessments/roar-multichoice/eslint.config.mjs
@@ -12,6 +12,8 @@ export default [
       globals: {
         ...globals.browser,
         process: 'readonly',
+        ROAR_DB: 'readonly',
+        ROAR_API_BASE_URL: 'readonly',
       },
     },
     rules: {

--- a/apps/assessments/roar-multichoice/serve/serve.js
+++ b/apps/assessments/roar-multichoice/serve/serve.js
@@ -5,6 +5,7 @@ import { bootstrapAnonymousSession } from '@roar-platform/assessment-sdk';
 import { getMultichoiceTaskId } from '@roar-platform/assessment-schema/roar-multichoice';
 import RoarMultichoice from '../src/experiment/index';
 import { getFirebaseConfig } from '../../shared/firebaseConfig';
+import { mountVariantPicker } from '../../shared/variantPicker.js';
 // Import necessary for async in the top level of the experiment script
 import 'regenerator-runtime/runtime';
 
@@ -28,9 +29,11 @@ const birthMonth = urlParams.get('birthmonth') ? parseInt(urlParams.get('birthmo
 const age = urlParams.get('age') ? parseFloat(urlParams.get('age')) : null;
 const ageMonths = urlParams.get('agemonths') ? parseFloat(urlParams.get('agemonths')) : null;
 
+// App config
 const firebaseConfig = await getFirebaseConfig();
 const app = initializeApp(firebaseConfig);
 const auth = getAuth(app);
+const baseUrl = ROAR_API_BASE_URL;
 
 if (process.env.FIREBASE_AUTH_EMULATOR_HOST) {
   connectAuthEmulator(auth, `http://${process.env.FIREBASE_AUTH_EMULATOR_HOST}`, { disableWarnings: true });
@@ -44,14 +47,12 @@ onAuthStateChanged(auth, async (user) => {
       // Provision the anonymous ROAR user (and resolve a variant) via the SDK.
       // The variantId URL param wins; otherwise it falls back to the first published variant.
       const { participantId, variantId: resolvedVariantId } = await bootstrapAnonymousSession(
-        // eslint-disable-next-line no-undef
-        { baseUrl: ROAR_API_BASE_URL, auth: authCallbacks },
+        { baseUrl, auth: authCallbacks },
         { ...(variantId ? { variantId } : {}), taskId },
       );
 
       const ctx = {
-        // eslint-disable-next-line no-undef
-        baseUrl: ROAR_API_BASE_URL,
+        baseUrl,
         auth: authCallbacks,
         participant: { participantId },
       };
@@ -61,6 +62,17 @@ onAuthStateChanged(auth, async (user) => {
         taskVersion,
         isAnonymous: true,
       });
+
+      // Dev/staging only: mount a variant switcher so reviewers can hop between published
+      // variants without hand-editing the URL. No-op in production (guard is eliminated at build).
+      if (ROAR_DB !== 'production') {
+        mountVariantPicker({
+          baseUrl,
+          auth: authCallbacks,
+          taskId,
+          currentVariantId: resolvedVariantId,
+        });
+      }
 
       const { variantParams } = await getVariantById(resolvedVariantId);
 

--- a/apps/assessments/roar-pa/eslint.config.mjs
+++ b/apps/assessments/roar-pa/eslint.config.mjs
@@ -12,6 +12,8 @@ export default [
       globals: {
         ...globals.browser,
         process: 'readonly',
+        ROAR_DB: 'readonly',
+        ROAR_API_BASE_URL: 'readonly',
       },
     },
   },

--- a/apps/assessments/roar-pa/serve/serve.js
+++ b/apps/assessments/roar-pa/serve/serve.js
@@ -5,6 +5,7 @@ import { bootstrapAnonymousSession } from '@roar-platform/assessment-sdk';
 import { pa } from '@roar-platform/assessment-schema';
 import RoarPA from '../src/index';
 import { getFirebaseConfig } from '../../shared/firebaseConfig';
+import { mountVariantPicker } from '../../shared/variantPicker.js';
 import { wireScoreAdapter } from '../src/sdk/pa-firekit-facade';
 // Import necessary for async in the top level of the experiment script
 import 'regenerator-runtime/runtime';
@@ -61,6 +62,19 @@ onAuthStateChanged(auth, async (user) => {
         taskVersion,
         isAnonymous: true,
       });
+
+      // Dev/staging only: mount a variant switcher so reviewers can hop between published
+      // variants without hand-editing the URL. No-op in production (guard is eliminated at build).
+      // eslint-disable-next-line no-undef
+      if (ROAR_DB !== 'production') {
+        mountVariantPicker({
+          // eslint-disable-next-line no-undef
+          baseUrl: ROAR_API_BASE_URL,
+          auth: authCallbacks,
+          taskId: pa.PA_TASK_ID,
+          currentVariantId: resolvedVariantId,
+        });
+      }
 
       // Wire PA score computation pipeline
       wireScoreAdapter();

--- a/apps/assessments/roar-pa/serve/serve.js
+++ b/apps/assessments/roar-pa/serve/serve.js
@@ -26,13 +26,13 @@ const birthMonth = urlParams.get('birthmonth');
 const age = urlParams.get('age');
 const ageMonths = urlParams.get('agemonths');
 
+// App config
 const firebaseConfig = await getFirebaseConfig();
 const app = initializeApp(firebaseConfig);
 const auth = getAuth(app);
+const baseUrl = ROAR_API_BASE_URL;
 
-// eslint-disable-next-line no-undef
 if (process.env.FIREBASE_AUTH_EMULATOR_HOST) {
-  // eslint-disable-next-line no-undef
   connectAuthEmulator(auth, `http://${process.env.FIREBASE_AUTH_EMULATOR_HOST}`, { disableWarnings: true });
 }
 
@@ -45,14 +45,12 @@ onAuthStateChanged(auth, async (user) => {
       // Performs the participant-free calls and hands back the participantId and resolved variantId.
       // The variantId URL param wins; otherwise it falls back to the first published variant.
       const { participantId, variantId: resolvedVariantId } = await bootstrapAnonymousSession(
-        // eslint-disable-next-line no-undef
-        { baseUrl: ROAR_API_BASE_URL, auth: authCallbacks },
+        { baseUrl, auth: authCallbacks },
         { ...(variantId ? { variantId } : {}), taskId: pa.PA_TASK_ID },
       );
 
       const ctx = {
-        // eslint-disable-next-line no-undef
-        baseUrl: ROAR_API_BASE_URL,
+        baseUrl,
         auth: authCallbacks,
         participant: { participantId },
       };
@@ -65,11 +63,9 @@ onAuthStateChanged(auth, async (user) => {
 
       // Dev/staging only: mount a variant switcher so reviewers can hop between published
       // variants without hand-editing the URL. No-op in production (guard is eliminated at build).
-      // eslint-disable-next-line no-undef
       if (ROAR_DB !== 'production') {
         mountVariantPicker({
-          // eslint-disable-next-line no-undef
-          baseUrl: ROAR_API_BASE_URL,
+          baseUrl,
           auth: authCallbacks,
           taskId: pa.PA_TASK_ID,
           currentVariantId: resolvedVariantId,

--- a/apps/assessments/roar-pa/src/index.js
+++ b/apps/assessments/roar-pa/src/index.js
@@ -1,4 +1,3 @@
-// Benign comment to trigger the PR preview process -- remove later!
 import { startRun, abortRun } from '@roar-platform/assessment-sdk/compat/firekit';
 import { initConfig } from './experiment/config/config';
 import { buildExperiment } from './experiment/experiment';

--- a/apps/assessments/roar-pa/src/index.js
+++ b/apps/assessments/roar-pa/src/index.js
@@ -1,3 +1,4 @@
+// Benign comment to trigger the PR preview process -- remove later!
 import { startRun, abortRun } from '@roar-platform/assessment-sdk/compat/firekit';
 import { initConfig } from './experiment/config/config';
 import { buildExperiment } from './experiment/experiment';

--- a/apps/assessments/roar-readaloud/eslint.config.mjs
+++ b/apps/assessments/roar-readaloud/eslint.config.mjs
@@ -20,6 +20,8 @@ export default [
         ...globals.browser,
         ...globals.worker,
         process: 'readonly',
+        ROAR_DB: 'readonly',
+        ROAR_API_BASE_URL: 'readonly',
       },
     },
     rules: {

--- a/apps/assessments/roar-readaloud/serve/serve.js
+++ b/apps/assessments/roar-readaloud/serve/serve.js
@@ -5,6 +5,7 @@ import { bootstrapAnonymousSession } from '@roar-platform/assessment-sdk';
 import { READALOUD_TASK_ID } from '@roar-platform/assessment-schema/roar-readaloud';
 import ReadAloudTask from '../src/experiment/index';
 import { getFirebaseConfig } from '../../shared/firebaseConfig';
+import { mountVariantPicker } from '../../shared/variantPicker.js';
 // Import necessary for async in the top level of the experiment script
 import 'regenerator-runtime/runtime';
 
@@ -25,9 +26,11 @@ const birthMonth = urlParams.get('birthmonth') ? parseInt(urlParams.get('birthmo
 const age = urlParams.get('age') ? parseFloat(urlParams.get('age')) : null;
 const ageMonths = urlParams.get('agemonths') ? parseFloat(urlParams.get('agemonths')) : null;
 
+// App config
 const firebaseConfig = await getFirebaseConfig();
 const app = initializeApp(firebaseConfig);
 const auth = getAuth(app);
+const baseUrl = ROAR_API_BASE_URL;
 
 if (process.env.FIREBASE_AUTH_EMULATOR_HOST) {
   connectAuthEmulator(auth, `http://${process.env.FIREBASE_AUTH_EMULATOR_HOST}`, { disableWarnings: true });
@@ -41,14 +44,12 @@ onAuthStateChanged(auth, async (user) => {
       // Provision the anonymous ROAR user (and resolve a variant) via the SDK.
       // The variantId URL param wins; otherwise it falls back to the first published variant.
       const { participantId, variantId: resolvedVariantId } = await bootstrapAnonymousSession(
-        // eslint-disable-next-line no-undef
-        { baseUrl: ROAR_API_BASE_URL, auth: authCallbacks },
+        { baseUrl, auth: authCallbacks },
         { ...(variantId ? { variantId } : {}), taskId: READALOUD_TASK_ID },
       );
 
       const ctx = {
-        // eslint-disable-next-line no-undef
-        baseUrl: ROAR_API_BASE_URL,
+        baseUrl,
         auth: authCallbacks,
         participant: { participantId },
       };
@@ -58,6 +59,17 @@ onAuthStateChanged(auth, async (user) => {
         taskVersion,
         isAnonymous: true,
       });
+
+      // Dev/staging only: mount a variant switcher so reviewers can hop between published
+      // variants without hand-editing the URL. No-op in production (guard is eliminated at build).
+      if (ROAR_DB !== 'production') {
+        mountVariantPicker({
+          baseUrl,
+          auth: authCallbacks,
+          taskId: READALOUD_TASK_ID,
+          currentVariantId: resolvedVariantId,
+        });
+      }
 
       const { variantParams } = await getVariantById(resolvedVariantId);
 

--- a/apps/assessments/roar-sre/eslint.config.mjs
+++ b/apps/assessments/roar-sre/eslint.config.mjs
@@ -12,6 +12,8 @@ export default [
       globals: {
         ...globals.browser,
         process: 'readonly',
+        ROAR_DB: 'readonly',
+        ROAR_API_BASE_URL: 'readonly',
       },
     },
     rules: {

--- a/apps/assessments/roar-sre/serve/serve.js
+++ b/apps/assessments/roar-sre/serve/serve.js
@@ -5,6 +5,7 @@ import { bootstrapAnonymousSession } from '@roar-platform/assessment-sdk';
 import { SRE_LANGUAGES } from '@roar-platform/assessment-schema/roar-sre';
 import RoarSRE from '../src/index';
 import { getFirebaseConfig } from '../../shared/firebaseConfig';
+import { mountVariantPicker } from '../../shared/variantPicker.js';
 // Import necessary for async in the top level of the experiment script
 import 'regenerator-runtime/runtime';
 
@@ -30,13 +31,13 @@ const useParameterValidation = urlParams.get('useParameterValidation') === 'true
 const lngParam = urlParams.get('lng') ?? 'en';
 const language = SRE_LANGUAGES[lngParam] ?? SRE_LANGUAGES.en;
 
+// App config
 const firebaseConfig = await getFirebaseConfig();
 const app = initializeApp(firebaseConfig);
 const auth = getAuth(app);
+const baseUrl = ROAR_API_BASE_URL;
 
-// eslint-disable-next-line no-undef
 if (process.env.FIREBASE_AUTH_EMULATOR_HOST) {
-  // eslint-disable-next-line no-undef
   connectAuthEmulator(auth, `http://${process.env.FIREBASE_AUTH_EMULATOR_HOST}`, { disableWarnings: true });
 }
 
@@ -49,14 +50,12 @@ onAuthStateChanged(auth, async (user) => {
       // Performs the participant-free calls and hands back the participantId and resolved variantId.
       // The variantId URL param wins; otherwise it falls back to the first published variant.
       const { participantId, variantId: resolvedVariantId } = await bootstrapAnonymousSession(
-        // eslint-disable-next-line no-undef
-        { baseUrl: ROAR_API_BASE_URL, auth: authCallbacks },
+        { baseUrl, auth: authCallbacks },
         { ...(variantId ? { variantId } : {}), taskId: language.taskId },
       );
 
       const ctx = {
-        // eslint-disable-next-line no-undef
-        baseUrl: ROAR_API_BASE_URL,
+        baseUrl,
         auth: authCallbacks,
         participant: { participantId },
       };
@@ -66,6 +65,17 @@ onAuthStateChanged(auth, async (user) => {
         taskVersion,
         isAnonymous: true,
       });
+
+      // Dev/staging only: mount a variant switcher so reviewers can hop between published
+      // variants without hand-editing the URL. No-op in production (guard is eliminated at build).
+      if (ROAR_DB !== 'production') {
+        mountVariantPicker({
+          baseUrl,
+          auth: authCallbacks,
+          taskId: language.taskId,
+          currentVariantId: resolvedVariantId,
+        });
+      }
 
       const { variantParams } = await getVariantById(resolvedVariantId);
 

--- a/apps/assessments/roar-swr/eslint.config.mjs
+++ b/apps/assessments/roar-swr/eslint.config.mjs
@@ -12,6 +12,8 @@ export default [
       globals: {
         ...globals.browser,
         process: 'readonly',
+        ROAR_DB: 'readonly',
+        ROAR_API_BASE_URL: 'readonly',
       },
     },
     rules: {

--- a/apps/assessments/roar-swr/serve/serve.js
+++ b/apps/assessments/roar-swr/serve/serve.js
@@ -5,6 +5,7 @@ import { bootstrapAnonymousSession } from '@roar-platform/assessment-sdk';
 import { SWR_LANGUAGES } from '@roar-platform/assessment-schema/roar-swr';
 import RoarSWR from '../src/index';
 import { getFirebaseConfig } from '../../shared/firebaseConfig';
+import { mountVariantPicker } from '../../shared/variantPicker.js';
 // Import necessary for async in the top level of the experiment script
 import 'regenerator-runtime/runtime';
 
@@ -30,13 +31,13 @@ const useParameterValidation = urlParams.get('useParameterValidation') === 'true
 const lngParam = urlParams.get('lng') ?? 'en';
 const language = SWR_LANGUAGES[lngParam] ?? SWR_LANGUAGES.en;
 
+// App config
 const firebaseConfig = await getFirebaseConfig();
 const app = initializeApp(firebaseConfig);
 const auth = getAuth(app);
+const baseUrl = ROAR_API_BASE_URL;
 
-// eslint-disable-next-line no-undef
 if (process.env.FIREBASE_AUTH_EMULATOR_HOST) {
-  // eslint-disable-next-line no-undef
   connectAuthEmulator(auth, `http://${process.env.FIREBASE_AUTH_EMULATOR_HOST}`, { disableWarnings: true });
 }
 
@@ -49,14 +50,12 @@ onAuthStateChanged(auth, async (user) => {
       // Performs the participant-free calls and hands back the participantId and resolved variantId.
       // The variantId URL param wins; otherwise it falls back to the first published variant.
       const { participantId, variantId: resolvedVariantId } = await bootstrapAnonymousSession(
-        // eslint-disable-next-line no-undef
-        { baseUrl: ROAR_API_BASE_URL, auth: authCallbacks },
+        { baseUrl, auth: authCallbacks },
         { ...(variantId ? { variantId } : {}), taskId: language.taskId },
       );
 
       const ctx = {
-        // eslint-disable-next-line no-undef
-        baseUrl: ROAR_API_BASE_URL,
+        baseUrl,
         auth: authCallbacks,
         participant: { participantId },
       };
@@ -66,6 +65,17 @@ onAuthStateChanged(auth, async (user) => {
         taskVersion,
         isAnonymous: true,
       });
+
+      // Dev/staging only: mount a variant switcher so reviewers can hop between published
+      // variants without hand-editing the URL. No-op in production (guard is eliminated at build).
+      if (ROAR_DB !== 'production') {
+        mountVariantPicker({
+          baseUrl,
+          auth: authCallbacks,
+          taskId: language.taskId,
+          currentVariantId: resolvedVariantId,
+        });
+      }
 
       const { variantParams } = await getVariantById(resolvedVariantId);
 

--- a/apps/assessments/roav-apps/serve/serve.js
+++ b/apps/assessments/roav-apps/serve/serve.js
@@ -4,6 +4,7 @@ import { getVariantById, initFirekitCompat } from '@roar-platform/assessment-sdk
 import { bootstrapAnonymousSession } from '@roar-platform/assessment-sdk';
 import { TaskLauncher } from '../src';
 import { getFirebaseConfig } from '../../shared/firebaseConfig.js';
+import { mountVariantPicker } from '../../shared/variantPicker.js';
 // Import necessary for async in the top level of the experiment script
 import 'regenerator-runtime/runtime';
 
@@ -30,9 +31,11 @@ const ageMonths = urlParams.get('agemonths');
 // dev locale override stays on the URL; roav-apps ships en/es/it.
 const languageOverride = urlParams.get('lng');
 
+// App config
 const firebaseConfig = await getFirebaseConfig();
 const app = initializeApp(firebaseConfig);
 const auth = getAuth(app);
+const baseUrl = ROAR_API_BASE_URL;
 
 if (process.env.FIREBASE_AUTH_EMULATOR_HOST) {
   connectAuthEmulator(auth, `http://${process.env.FIREBASE_AUTH_EMULATOR_HOST}`, { disableWarnings: true });
@@ -46,12 +49,12 @@ onAuthStateChanged(auth, async (user) => {
       // Provision the anonymous ROAR user and resolve a variant via the SDK.
       // variantId wins; otherwise falls back to the first published variant for taskId.
       const { participantId, variantId: resolvedVariantId } = await bootstrapAnonymousSession(
-        { baseUrl: ROAR_API_BASE_URL, auth: authCallbacks },
+        { baseUrl, auth: authCallbacks },
         { ...(variantId ? { variantId } : {}), taskId },
       );
 
       const ctx = {
-        baseUrl: ROAR_API_BASE_URL,
+        baseUrl,
         auth: authCallbacks,
         participant: { participantId },
       };
@@ -61,6 +64,17 @@ onAuthStateChanged(auth, async (user) => {
         taskVersion,
         isAnonymous: true,
       });
+
+      // Dev/staging only: mount a variant switcher so reviewers can hop between published
+      // variants without hand-editing the URL. No-op in production (guard is eliminated at build).
+      if (ROAR_DB !== 'production') {
+        mountVariantPicker({
+          baseUrl,
+          auth: authCallbacks,
+          taskId,
+          currentVariantId: resolvedVariantId,
+        });
+      }
 
       const { variantParams } = await getVariantById(resolvedVariantId);
 

--- a/apps/assessments/roav-ran/eslint.config.mjs
+++ b/apps/assessments/roav-ran/eslint.config.mjs
@@ -19,6 +19,7 @@ export default [
         ...globals.browser,
         ...globals.worker,
         process: 'readonly',
+        ROAR_DB: 'readonly',
         ROAR_API_BASE_URL: 'readonly',
       },
     },

--- a/apps/assessments/roav-ran/serve/serve.js
+++ b/apps/assessments/roav-ran/serve/serve.js
@@ -4,6 +4,7 @@ import { getVariantById, initFirekitCompat } from '@roar-platform/assessment-sdk
 import { bootstrapAnonymousSession } from '@roar-platform/assessment-sdk';
 import TaskLauncher from '../src/experiment/index';
 import { getFirebaseConfig } from '../../shared/firebaseConfig.js';
+import { mountVariantPicker } from '../../shared/variantPicker.js';
 // Import necessary for async in the top level of the experiment script
 import 'regenerator-runtime/runtime';
 
@@ -27,9 +28,11 @@ const ageMonths = urlParams.get('agemonths');
 // Dev-only locale override; roav-ran ships English only (i18next defaults to en).
 const languageOverride = urlParams.get('lng');
 
+// App config
 const firebaseConfig = await getFirebaseConfig();
 const app = initializeApp(firebaseConfig);
 const auth = getAuth(app);
+const baseUrl = ROAR_API_BASE_URL;
 
 if (process.env.FIREBASE_AUTH_EMULATOR_HOST) {
   connectAuthEmulator(auth, `http://${process.env.FIREBASE_AUTH_EMULATOR_HOST}`, { disableWarnings: true });
@@ -43,12 +46,12 @@ onAuthStateChanged(auth, async (user) => {
       // Provision the anonymous ROAR user and resolve a variant via the SDK.
       // variantId wins; otherwise falls back to the first published variant for taskId.
       const { participantId, variantId: resolvedVariantId } = await bootstrapAnonymousSession(
-        { baseUrl: ROAR_API_BASE_URL, auth: authCallbacks },
+        { baseUrl, auth: authCallbacks },
         { ...(variantId ? { variantId } : {}), taskId },
       );
 
       const ctx = {
-        baseUrl: ROAR_API_BASE_URL,
+        baseUrl,
         auth: authCallbacks,
         participant: { participantId },
       };
@@ -58,6 +61,17 @@ onAuthStateChanged(auth, async (user) => {
         taskVersion,
         isAnonymous: true,
       });
+
+      // Dev/staging only: mount a variant switcher so reviewers can hop between published
+      // variants without hand-editing the URL. No-op in production (guard is eliminated at build).
+      if (ROAR_DB !== 'production') {
+        mountVariantPicker({
+          baseUrl,
+          auth: authCallbacks,
+          taskId,
+          currentVariantId: resolvedVariantId,
+        });
+      }
 
       const { variantParams } = await getVariantById(resolvedVariantId);
 

--- a/apps/assessments/shared/eslint.config.mjs
+++ b/apps/assessments/shared/eslint.config.mjs
@@ -1,0 +1,19 @@
+import { config as base } from '@roar-platform/eslint-config';
+import globals from 'globals';
+
+export default [
+  ...base,
+
+  // Browser globals for the shared assessment helpers and their unit tests. Unlike the
+  // per-assessment serve.js files, nothing here reads the ROAR_DB / ROAR_API_BASE_URL
+  // build-time constants, so they are intentionally not declared.
+  {
+    files: ['**/*.js'],
+    languageOptions: {
+      globals: {
+        ...globals.browser,
+        process: 'readonly',
+      },
+    },
+  },
+];

--- a/apps/assessments/shared/package.json
+++ b/apps/assessments/shared/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@roar-platform/assessment-shared",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Shared helpers used across ROAR assessment standalone harnesses (serve.js).",
+  "type": "module",
+  "scripts": {
+    "lint": "eslint .",
+    "lint:fix": "eslint . --fix",
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "dependencies": {
+    "@roar-platform/assessment-schema": "^0.1.0",
+    "@roar-platform/assessment-sdk": "^0.1.0"
+  },
+  "peerDependencies": {
+    "@sentry/browser": ">=7",
+    "@sentry/integrations": ">=7"
+  },
+  "devDependencies": {
+    "@roar-platform/eslint-config": "*",
+    "eslint": "^9.0.0",
+    "globals": "^16.0.0",
+    "jsdom": "^29.1.1",
+    "vitest": "^3.2.4"
+  }
+}

--- a/apps/assessments/shared/package.json
+++ b/apps/assessments/shared/package.json
@@ -5,6 +5,7 @@
   "description": "Shared helpers used across ROAR assessment standalone harnesses (serve.js).",
   "type": "module",
   "scripts": {
+    "build": "echo \"assessment-shared is source-only (imported directly and bundled by consuming assessments); no build step\"",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "test": "vitest run",

--- a/apps/assessments/shared/package.json
+++ b/apps/assessments/shared/package.json
@@ -13,7 +13,8 @@
   },
   "dependencies": {
     "@roar-platform/assessment-schema": "^0.1.0",
-    "@roar-platform/assessment-sdk": "^0.1.0"
+    "@roar-platform/assessment-sdk": "^0.1.0",
+    "http-status-codes": "^2.3.0"
   },
   "peerDependencies": {
     "@sentry/browser": ">=7",

--- a/apps/assessments/shared/variantPicker.js
+++ b/apps/assessments/shared/variantPicker.js
@@ -1,11 +1,9 @@
+import { StatusCodes } from 'http-status-codes';
 import { createApiClient } from '@roar-platform/assessment-sdk';
 
-// listTaskVariants sits behind the auth guard and returns the success envelope
-// { data: { items, pagination } } on 200.
-const HTTP_STATUS_OK = 200;
-
-// Published variants per task are few; a single large page avoids pagination
-// bookkeeping for what is only a dev/staging convenience.
+// 100 is the API's max perPage. Published variants per task are few, so a single page
+// avoids pagination bookkeeping for a dev/staging convenience; if a task ever exceeds it,
+// mountVariantPicker logs rather than silently truncating (see the totalPages check).
 const VARIANTS_PER_PAGE = 100;
 
 const PICKER_CONTAINER_ID = 'roar-variant-picker';
@@ -34,6 +32,8 @@ export async function mountVariantPicker({ baseUrl, auth, taskId, currentVariant
     const client = createApiClient({ baseUrl, auth });
     const result = await client.tasks.listTaskVariants({
       params: { taskId },
+      // Sort/status are set explicitly (rather than leaning on the contract's defaults) so the
+      // dropdown stays name-sorted and published-only regardless of future schema-default changes.
       query: {
         status: 'published',
         perPage: VARIANTS_PER_PAGE,
@@ -42,13 +42,22 @@ export async function mountVariantPicker({ baseUrl, auth, taskId, currentVariant
       },
     });
 
-    if (result.status !== HTTP_STATUS_OK) {
+    if (result.status !== StatusCodes.OK) {
       console.warn(`[variant-picker] listTaskVariants returned ${result.status}`);
       return;
     }
 
-    const variants = result.body.data.items;
+    const { items: variants, pagination } = result.body.data;
     if (variants.length === 0) return;
+
+    // The single page is capped at the API max (VARIANTS_PER_PAGE); make truncation
+    // visible rather than silently showing only the first page.
+    if (pagination && pagination.totalPages > 1) {
+      console.warn(
+        `[variant-picker] ${taskId} has more than ${VARIANTS_PER_PAGE} published variants; ` +
+          `showing only the first page (${pagination.totalPages} pages total).`,
+      );
+    }
 
     renderPicker(variants, currentVariantId);
   } catch (err) {

--- a/apps/assessments/shared/variantPicker.js
+++ b/apps/assessments/shared/variantPicker.js
@@ -1,0 +1,135 @@
+import { createApiClient } from '@roar-platform/assessment-sdk';
+
+// listTaskVariants sits behind the auth guard and returns the success envelope
+// { data: { items, pagination } } on 200.
+const HTTP_STATUS_OK = 200;
+
+// Published variants per task are few; a single large page avoids pagination
+// bookkeeping for what is only a dev/staging convenience.
+const VARIANTS_PER_PAGE = 100;
+
+const PICKER_CONTAINER_ID = 'roar-variant-picker';
+
+/**
+ * Mounts a discreet variant-switcher dropdown for non-production (dev/staging) runs.
+ *
+ * Lists the published variants for `taskId` and lets a reviewer switch between them
+ * without hand-editing the URL: selecting one reloads the page with the chosen
+ * `variantId` (all other query params preserved), re-entering the standalone flow.
+ *
+ * This is a convenience for ephemeral/staging review only — callers gate on
+ * `ROAR_DB !== 'production'`. Any failure is swallowed so the picker can never affect
+ * the assessment itself. Relies on the caller having already provisioned the anonymous
+ * ROAR user (via `bootstrapAnonymousSession`), which the auth-guarded list call requires.
+ *
+ * @param {object} options
+ * @param {string} options.baseUrl - ROAR backend API base URL (ROAR_API_BASE_URL).
+ * @param {{ getToken: () => Promise<string | undefined> }} options.auth - Anonymous auth callbacks.
+ * @param {string} options.taskId - Task slug or UUID whose published variants to list.
+ * @param {string} [options.currentVariantId] - Variant to pre-select in the dropdown.
+ * @returns {Promise<void>}
+ */
+export async function mountVariantPicker({ baseUrl, auth, taskId, currentVariantId }) {
+  try {
+    const client = createApiClient({ baseUrl, auth });
+    const result = await client.tasks.listTaskVariants({
+      params: { taskId },
+      query: {
+        status: 'published',
+        perPage: VARIANTS_PER_PAGE,
+        sortBy: 'name',
+        sortOrder: 'asc',
+      },
+    });
+
+    if (result.status !== HTTP_STATUS_OK) {
+      console.warn(`[variant-picker] listTaskVariants returned ${result.status}`);
+      return;
+    }
+
+    const variants = result.body.data.items;
+    if (variants.length === 0) return;
+
+    renderPicker(variants, currentVariantId);
+  } catch (err) {
+    // Never let a dev/staging convenience break the assessment.
+    console.warn('[variant-picker] failed to mount', err);
+  }
+}
+
+/**
+ * Renders (or re-renders) the fixed-position picker with the given variants.
+ *
+ * @param {Array<{ id: string, name: string | null }>} variants - Published variants, sorted by name.
+ * @param {string | undefined} currentVariantId - Active variant to pre-select.
+ * @returns {void}
+ */
+function renderPicker(variants, currentVariantId) {
+  document.getElementById(PICKER_CONTAINER_ID)?.remove();
+
+  const options = [...variants];
+  // If the active variant isn't in the published set (e.g. a draft targeted directly by
+  // URL), surface it so the dropdown always reflects what is actually running.
+  if (currentVariantId && !options.some((variant) => variant.id === currentVariantId)) {
+    options.unshift({ id: currentVariantId, name: '(current)' });
+  }
+
+  const container = document.createElement('div');
+  container.id = PICKER_CONTAINER_ID;
+  Object.assign(container.style, {
+    position: 'fixed',
+    top: '8px',
+    right: '8px',
+    zIndex: '2147483647',
+    display: 'flex',
+    alignItems: 'center',
+    gap: '6px',
+    padding: '6px 8px',
+    borderRadius: '6px',
+    background: 'rgba(17, 24, 39, 0.85)',
+    color: '#fff',
+    font: '12px/1.4 system-ui, -apple-system, sans-serif',
+    boxShadow: '0 1px 4px rgba(0, 0, 0, 0.3)',
+  });
+
+  const label = document.createElement('span');
+  label.textContent = 'Variant';
+  label.style.opacity = '0.8';
+
+  const select = document.createElement('select');
+  select.id = `${PICKER_CONTAINER_ID}-select`;
+  Object.assign(select.style, {
+    font: 'inherit',
+    color: '#111',
+    background: '#fff',
+    border: '1px solid #d1d5db',
+    borderRadius: '4px',
+    padding: '2px 4px',
+    maxWidth: '240px',
+  });
+
+  for (const variant of options) {
+    const option = document.createElement('option');
+    option.value = variant.id;
+    // Fall back to a short id prefix when unnamed. The full uuid isn't needed in the label —
+    // selecting a variant writes it to the URL (?variantId=), so this can stay compact.
+    option.textContent = variant.name || `variant ${variant.id.slice(0, 8)}`;
+    option.selected = variant.id === currentVariantId;
+    select.appendChild(option);
+  }
+
+  // Selecting a variant reloads with the new variantId while preserving other params
+  // (e.g. ?task= for multi-task assessments), re-entering the standalone flow.
+  select.addEventListener('change', () => {
+    const url = new URL(window.location.href);
+    url.searchParams.set('variantId', select.value);
+    window.location.assign(url.toString());
+  });
+
+  container.append(label, select);
+  // Mount on <html>, not <body>: jsPsych resets `document.body.innerHTML` when the
+  // experiment starts, which would wipe a body-mounted picker (it flashes in, then
+  // vanishes). The picker is position:fixed, so its parent doesn't affect placement,
+  // and its max z-index keeps it above the progress bar.
+  document.documentElement.appendChild(container);
+}

--- a/apps/assessments/shared/variantPicker.test.js
+++ b/apps/assessments/shared/variantPicker.test.js
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { StatusCodes } from 'http-status-codes';
 
 // The picker builds its client via the SDK's createApiClient; mock it so we can
 // drive listTaskVariants responses without a backend.
@@ -16,8 +17,8 @@ const SELECT_ID = 'roar-variant-picker-select';
 const baseArgs = { baseUrl: '/v1', auth: { getToken: vi.fn() }, taskId: 'pa' };
 
 /** Build a 200 listTaskVariants envelope for the given variant items. */
-function okResponse(items) {
-  return { status: 200, body: { data: { items } } };
+function okResponse(items, totalPages = 1) {
+  return { status: StatusCodes.OK, body: { data: { items, pagination: { totalPages } } } };
 }
 
 function getSelect() {
@@ -85,6 +86,15 @@ describe('mountVariantPicker', () => {
     expect(getSelect().value).toBe('draft-x');
   });
 
+  it('warns (but still renders) when the results span more than one page', async () => {
+    listTaskVariants.mockResolvedValue(okResponse([{ id: 'v1', name: 'English' }], 3));
+
+    await mountVariantPicker({ ...baseArgs, currentVariantId: 'v1' });
+
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('pages total'));
+    expect(getSelect()).not.toBeNull();
+  });
+
   it('navigates to the chosen variant, preserving other query params', async () => {
     const assign = vi.fn();
     const original = window.location;
@@ -120,7 +130,7 @@ describe('mountVariantPicker', () => {
   });
 
   it('renders nothing and does not throw on a non-200 response', async () => {
-    listTaskVariants.mockResolvedValue({ status: 403, body: {} });
+    listTaskVariants.mockResolvedValue({ status: StatusCodes.FORBIDDEN, body: {} });
 
     await expect(mountVariantPicker({ ...baseArgs })).resolves.toBeUndefined();
     expect(document.getElementById(PICKER_ID)).toBeNull();

--- a/apps/assessments/shared/variantPicker.test.js
+++ b/apps/assessments/shared/variantPicker.test.js
@@ -1,0 +1,149 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// The picker builds its client via the SDK's createApiClient; mock it so we can
+// drive listTaskVariants responses without a backend.
+const listTaskVariants = vi.fn();
+vi.mock('@roar-platform/assessment-sdk', () => ({
+  createApiClient: vi.fn(() => ({ tasks: { listTaskVariants } })),
+}));
+
+// Imported after vi.mock so the mocked SDK is in place.
+const { mountVariantPicker } = await import('./variantPicker.js');
+
+const PICKER_ID = 'roar-variant-picker';
+const SELECT_ID = 'roar-variant-picker-select';
+
+const baseArgs = { baseUrl: '/v1', auth: { getToken: vi.fn() }, taskId: 'pa' };
+
+/** Build a 200 listTaskVariants envelope for the given variant items. */
+function okResponse(items) {
+  return { status: 200, body: { data: { items } } };
+}
+
+function getSelect() {
+  return document.getElementById(SELECT_ID);
+}
+
+describe('mountVariantPicker', () => {
+  let warnSpy;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    document.getElementById(PICKER_ID)?.remove();
+    document.body.innerHTML = '';
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  it('requests only published variants, sorted by name', async () => {
+    listTaskVariants.mockResolvedValue(okResponse([{ id: 'v1', name: 'English' }]));
+
+    await mountVariantPicker({ ...baseArgs, currentVariantId: 'v1' });
+
+    expect(listTaskVariants).toHaveBeenCalledWith({
+      params: { taskId: 'pa' },
+      query: { status: 'published', perPage: 100, sortBy: 'name', sortOrder: 'asc' },
+    });
+  });
+
+  it('renders one option per variant and pre-selects the current one', async () => {
+    listTaskVariants.mockResolvedValue(
+      okResponse([
+        { id: 'v1', name: 'English' },
+        { id: 'v2', name: 'Spanish' },
+      ]),
+    );
+
+    await mountVariantPicker({ ...baseArgs, currentVariantId: 'v2' });
+
+    const select = getSelect();
+    expect(select).not.toBeNull();
+    expect([...select.options].map((o) => o.value)).toEqual(['v1', 'v2']);
+    expect([...select.options].map((o) => o.textContent)).toEqual(['English', 'Spanish']);
+    expect(select.value).toBe('v2');
+  });
+
+  it('labels an unnamed variant with a short id prefix', async () => {
+    listTaskVariants.mockResolvedValue(okResponse([{ id: 'abcdef1234-5678', name: null }]));
+
+    await mountVariantPicker({ ...baseArgs });
+
+    expect(document.querySelector(`#${SELECT_ID} option`).textContent).toBe('variant abcdef12');
+  });
+
+  it('surfaces the active variant as "(current)" when it is not in the published set', async () => {
+    listTaskVariants.mockResolvedValue(okResponse([{ id: 'v1', name: 'English' }]));
+
+    await mountVariantPicker({ ...baseArgs, currentVariantId: 'draft-x' });
+
+    const options = [...getSelect().options];
+    expect(options[0].value).toBe('draft-x');
+    expect(options[0].textContent).toBe('(current)');
+    expect(getSelect().value).toBe('draft-x');
+  });
+
+  it('navigates to the chosen variant, preserving other query params', async () => {
+    const assign = vi.fn();
+    const original = window.location;
+    delete window.location;
+    window.location = { href: 'http://localhost/?task=pa', assign };
+
+    listTaskVariants.mockResolvedValue(
+      okResponse([
+        { id: 'v1', name: 'English' },
+        { id: 'v2', name: 'Spanish' },
+      ]),
+    );
+    await mountVariantPicker({ ...baseArgs, currentVariantId: 'v1' });
+
+    const select = getSelect();
+    select.value = 'v2';
+    select.dispatchEvent(new Event('change'));
+
+    expect(assign).toHaveBeenCalledTimes(1);
+    const navigatedTo = new URL(assign.mock.calls[0][0]);
+    expect(navigatedTo.searchParams.get('variantId')).toBe('v2');
+    expect(navigatedTo.searchParams.get('task')).toBe('pa');
+
+    window.location = original;
+  });
+
+  it('renders nothing when there are no published variants', async () => {
+    listTaskVariants.mockResolvedValue(okResponse([]));
+
+    await mountVariantPicker({ ...baseArgs });
+
+    expect(document.getElementById(PICKER_ID)).toBeNull();
+  });
+
+  it('renders nothing and does not throw on a non-200 response', async () => {
+    listTaskVariants.mockResolvedValue({ status: 403, body: {} });
+
+    await expect(mountVariantPicker({ ...baseArgs })).resolves.toBeUndefined();
+    expect(document.getElementById(PICKER_ID)).toBeNull();
+    expect(warnSpy).toHaveBeenCalled();
+  });
+
+  it('swallows request errors so the picker never breaks the assessment', async () => {
+    listTaskVariants.mockRejectedValue(new Error('network'));
+
+    await expect(mountVariantPicker({ ...baseArgs })).resolves.toBeUndefined();
+    expect(document.getElementById(PICKER_ID)).toBeNull();
+    expect(warnSpy).toHaveBeenCalled();
+  });
+
+  it('mounts on <html> so a jsPsych document.body reset does not remove it', async () => {
+    listTaskVariants.mockResolvedValue(okResponse([{ id: 'v1', name: 'English' }]));
+
+    await mountVariantPicker({ ...baseArgs, currentVariantId: 'v1' });
+    expect(document.getElementById(PICKER_ID).parentElement).toBe(document.documentElement);
+
+    // jsPsych wipes document.body.innerHTML when the experiment starts.
+    document.body.innerHTML = '';
+
+    expect(document.getElementById(PICKER_ID)).not.toBeNull();
+  });
+});

--- a/apps/assessments/shared/vitest.config.js
+++ b/apps/assessments/shared/vitest.config.js
@@ -1,0 +1,12 @@
+import { defineConfig } from 'vitest/config';
+
+// Shared assessment helpers. variantPicker renders DOM, so a jsdom environment is
+// required (matches roar-levante-tasks). Pure-node helpers here run fine under jsdom too.
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'jsdom',
+    include: ['*.test.js'],
+    clearMocks: true,
+  },
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -3746,6 +3746,25 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "apps/assessments/shared": {
+      "name": "@roar-platform/assessment-shared",
+      "version": "0.0.0",
+      "dependencies": {
+        "@roar-platform/assessment-schema": "^0.1.0",
+        "@roar-platform/assessment-sdk": "^0.1.0"
+      },
+      "devDependencies": {
+        "@roar-platform/eslint-config": "*",
+        "eslint": "^9.0.0",
+        "globals": "^16.0.0",
+        "jsdom": "^29.1.1",
+        "vitest": "^3.2.4"
+      },
+      "peerDependencies": {
+        "@sentry/browser": ">=7",
+        "@sentry/integrations": ">=7"
+      }
+    },
     "apps/backend": {
       "name": "roar-backend",
       "version": "0.0.0",
@@ -15322,6 +15341,10 @@
     },
     "node_modules/@roar-platform/assessment-sdk": {
       "resolved": "packages/assessment-sdk",
+      "link": true
+    },
+    "node_modules/@roar-platform/assessment-shared": {
+      "resolved": "apps/assessments/shared",
       "link": true
     },
     "node_modules/@roar-platform/authz": {
@@ -40318,6 +40341,7 @@
     },
     "node_modules/npm/node_modules/lodash._baseindexof": {
       "version": "3.1.0",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
@@ -40342,16 +40366,19 @@
     },
     "node_modules/npm/node_modules/lodash._bindcallback": {
       "version": "3.0.1",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/lodash._cacheindexof": {
       "version": "3.0.2",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/lodash._createcache": {
       "version": "3.1.2",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -40360,6 +40387,7 @@
     },
     "node_modules/npm/node_modules/lodash._getnative": {
       "version": "3.9.1",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
@@ -40370,6 +40398,7 @@
     },
     "node_modules/npm/node_modules/lodash.restparam": {
       "version": "3.6.1",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },


### PR DESCRIPTION
## Proposed changes

<!--
Describe your changes here. Why are they necessary?

If it fixes a bug or resolves a feature request, be sure to link to that issue.

If appropriate, include images of the expected behavior or user experience.
You can drag and drop images into this text box.
-->

## Summary

This pull request adds a variant picker dropdown menu to the top corner of assessments running in staging and/or development environments. This feature is not active in production environments in order to preserve psychometric validity.

The variant picker pulls from variants with status `published` that exists in its environment (either permanent staging database or ephemeral local dev environment). The list shows the name of the variant if available, and falls back to a truncated (8-character) UUID when name is null or undefined.

Variant ids are inserted into the url such that other parameters (age, grade, participant, etc.) are preserved when the variant is changed in the dropdown list.

Across the assessments, eslint configs are modified to declare `ROAR_DB` and `ROAR_API_BASE_URL` as global, readonly variables.

The `assessments/shared` directory is also given an esling config and full workspace infra as a shared, internal dependency with a no-op build script.

## Screenshots
<img width="2166" height="242" alt="image" src="https://github.com/user-attachments/assets/9e2ef6be-7614-4391-8202-459ae11c9926" />


## Types of changes

What types of changes does this pull request introduce?

<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (non-breaking change that does not add functionality but makes code cleaner or more efficient)
- [ ] Documentation Update
- [x] Tests (new or updated tests)
- [ ] Style (changes to code styling)
- [ ] CI (continuous integration changes)
- [ ] Repository Maintenance
- [ ] Other (please describe below)

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask.  We're here
to help! This is simply a reminder of what we are going to look for before
merging your code.
-->

- [x] I have read the [guidelines for contributing](https://github.com/yeatmanlab/roar-dashboard/blob/main/.github/CONTRIBUTING.md).
- [x The changes in this PR are as small as they can be. They represent one and only one fix or enhancement.
- [x] Linting checks pass with my changes.
- [x] Any existing unit tests pass with my changes.
- [x] Any existing end-to-end tests pass with my changes.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] If this PR fixes an existing issue, I have added a unit or end-to-end test that will detect if this issue reoccurs.
- [x] I have added JSDoc comments as appropriate.
- [ ] I have added the necessary documentation to the [roar-docs repository](https://github.com/yeatmanlab/roar-docs).
- [x] I have shared this PR on the roar-pr-reviews channel (if I have access)
- [x] I have linked relevant issues (if any)

## Justification of missing checklist items

<!--
If you feel that a checklist item above is not applicable to this PR, please
provide your justification here. Otherwise, delete this section.
-->

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
