### PR TITLE
Score Report: Add a per-task display descriptor to the score-report responses

### DIFF
--- a/apps/backend/src/services/report/report.service.test.ts
+++ b/apps/backend/src/services/report/report.service.test.ts
@@ -3642,6 +3642,84 @@ describe('ReportService', () => {
       expect(swrTask.skillsToWorkOn).toBeUndefined();
     });
 
+    // --- Display descriptor ---
+
+    it('includes display descriptor for normed tasks (e.g., swr with percentile at grade < 6)', async () => {
+      setupDefaults();
+      const completedScoreRow: RunScoreRow = {
+        userId: targetUserId,
+        taskVariantId: VARIANT_ID_1,
+        scoreName: ScoreField.PERCENTILE,
+        scoreValue: '65',
+      };
+      mockReportRepository.getCompletedRunScores.mockResolvedValue([completedScoreRow]);
+      mockReportRepository.getCompletedRunsForUser.mockResolvedValue([
+        {
+          runId: 'run-1',
+          taskVariantId: VARIANT_ID_1,
+          reliable: true,
+          engagementFlags: [],
+          completedAt: new Date('2025-09-01'),
+        },
+      ]);
+
+      const service = createService();
+      const result = await service.getIndividualStudentReport(
+        superAdminAuth,
+        testAdministrationId,
+        targetUserId,
+        reportQuery,
+      );
+
+      const swrTask = result.tasks.find((t) => t.taskId === TASK_ID_1)!;
+      expect(swrTask.display).toBeDefined();
+      expect(swrTask.display?.scoreType).toBe('percentile');
+      expect(swrTask.display?.value).toBe(65);
+      expect(swrTask.display?.label).toBe('percentile');
+      expect(swrTask.display?.range).toEqual({ min: 0, max: 99 });
+    });
+
+    it('includes display descriptor for percent-correct tasks (e.g., letter)', async () => {
+      const LETTER_TASK_ID = 'e4567890-defg-8901-1234-567890123456';
+      setupDefaults();
+      mockTaskVariantRepository.getById.mockResolvedValueOnce({
+        ...VARIANT_1,
+        taskId: LETTER_TASK_ID,
+        taskSlug: 'letter',
+      });
+      const completedScoreRow: RunScoreRow = {
+        userId: targetUserId,
+        taskVariantId: VARIANT_ID_1,
+        scoreName: ScoreField.PERCENT_CORRECT,
+        scoreValue: '85',
+      };
+      mockReportRepository.getCompletedRunScores.mockResolvedValue([completedScoreRow]);
+      mockReportRepository.getCompletedRunsForUser.mockResolvedValue([
+        {
+          runId: 'run-1',
+          taskVariantId: VARIANT_ID_1,
+          reliable: true,
+          engagementFlags: [],
+          completedAt: new Date('2025-09-01'),
+        },
+      ]);
+
+      const service = createService();
+      const result = await service.getIndividualStudentReport(
+        superAdminAuth,
+        testAdministrationId,
+        targetUserId,
+        reportQuery,
+      );
+
+      const letterTask = result.tasks.find((t) => t.taskId === LETTER_TASK_ID)!;
+      expect(letterTask.display).toBeDefined();
+      expect(letterTask.display?.scoreType).toBe('percentCorrect');
+      expect(letterTask.display?.value).toBe(85);
+      expect(letterTask.display?.label).toBe('percentCorrect');
+      expect(letterTask.display?.range).toEqual({ min: 0, max: 100 });
+    });
+
     // --- Historical scores ---
 
     it('builds historicalScores per task, sorted ascending by administration dateStart', async () => {

--- a/apps/backend/src/services/report/report.service.test.ts
+++ b/apps/backend/src/services/report/report.service.test.ts
@@ -3679,47 +3679,6 @@ describe('ReportService', () => {
       expect(swrTask.display?.range).toEqual({ min: 0, max: 99 });
     });
 
-    it('includes display descriptor for percent-correct tasks (e.g., letter)', async () => {
-      const LETTER_TASK_ID = 'e4567890-defg-8901-1234-567890123456';
-      setupDefaults();
-      mockTaskVariantRepository.getById.mockResolvedValueOnce({
-        ...VARIANT_1,
-        taskId: LETTER_TASK_ID,
-        taskSlug: 'letter',
-      });
-      const completedScoreRow: RunScoreRow = {
-        userId: targetUserId,
-        taskVariantId: VARIANT_ID_1,
-        scoreName: ScoreField.PERCENT_CORRECT,
-        scoreValue: '85',
-      };
-      mockReportRepository.getCompletedRunScores.mockResolvedValue([completedScoreRow]);
-      mockReportRepository.getCompletedRunsForUser.mockResolvedValue([
-        {
-          runId: 'run-1',
-          taskVariantId: VARIANT_ID_1,
-          reliable: true,
-          engagementFlags: [],
-          completedAt: new Date('2025-09-01'),
-        },
-      ]);
-
-      const service = createService();
-      const result = await service.getIndividualStudentReport(
-        superAdminAuth,
-        testAdministrationId,
-        targetUserId,
-        reportQuery,
-      );
-
-      const letterTask = result.tasks.find((t) => t.taskId === LETTER_TASK_ID)!;
-      expect(letterTask.display).toBeDefined();
-      expect(letterTask.display?.scoreType).toBe('percentCorrect');
-      expect(letterTask.display?.value).toBe(85);
-      expect(letterTask.display?.label).toBe('percentCorrect');
-      expect(letterTask.display?.range).toEqual({ min: 0, max: 100 });
-    });
-
     // --- Historical scores ---
 
     it('builds historicalScores per task, sorted ascending by administration dateStart', async () => {

--- a/apps/backend/src/services/report/report.service.ts
+++ b/apps/backend/src/services/report/report.service.ts
@@ -93,6 +93,7 @@ import {
   getNumericFieldForSubscore,
   formatTaskSubscoreColumnValue,
   getSupportLevel,
+  getScoreDisplay,
   parseScoreValue,
   resolveScoreFieldNames,
   PA_SKILL_THRESHOLD,
@@ -3093,15 +3094,28 @@ function assembleStudentScoreRow(
       // Eligibility for the optional flag (independent of completion)
       const eligibility = evaluateAcrossVariants(row, variants, evaluateEligibility);
 
-      scores[taskId] = {
+      // Display from the same rounded scores the response carries, so the
+      // descriptor's value matches the cell. Absent for tasks with no display config.
+      const entryScores = {
         rawScore: roundScoreOrNull(rawScore),
         percentile: roundScoreOrNull(percentile),
         standardScore: roundScoreOrNull(standardScore),
+      };
+      const display = getScoreDisplay({
+        taskSlug: scored.variant.taskSlug,
+        gradeLevel,
+        scoringVersion,
+        scores: entryScores,
+      });
+
+      scores[taskId] = {
+        ...entryScores,
         supportLevel,
         reliable: scored.runMeta.reliable,
         engagementFlags: scored.runMeta.engagementFlags,
         optional: eligibility.isOptional,
         completed: true,
+        ...(display ? { display } : {}),
       };
     } else {
       // No completed run on any variant — evaluate condition across variants
@@ -3475,6 +3489,15 @@ function buildBaseAssessedTaskEntry(
   const subscores = extractSubscoresFromScoreMap(scoreMap, scoredVariant.taskSlug, domainScoreMap);
   const skillsToWorkOn = computePaSkillsToWorkOn(scoredVariant.taskSlug, subscores);
 
+  // Primary display descriptor (which score to surface + value/label/range),
+  // computed from the task's scoring config. Absent for tasks with no display config.
+  const display = getScoreDisplay({
+    taskSlug: scoredVariant.taskSlug,
+    gradeLevel,
+    scoringVersion,
+    scores,
+  });
+
   const entry: ServiceStudentReportTaskBase = {
     ...taskMeta,
     scores,
@@ -3487,6 +3510,7 @@ function buildBaseAssessedTaskEntry(
   };
   if (subscores) entry.subscores = subscores;
   if (skillsToWorkOn) entry.skillsToWorkOn = skillsToWorkOn;
+  if (display) entry.display = display;
 
   return { entry, gradeLevel };
 }

--- a/apps/backend/src/services/report/report.types.ts
+++ b/apps/backend/src/services/report/report.types.ts
@@ -244,6 +244,19 @@ export type StudentScoresFilterField =
  */
 export type ServiceSupportLevelValue = 'achievedSkill' | 'developingSkill' | 'needsExtraSupport' | 'optional';
 
+/**
+ * Per-task display descriptor — which score the task surfaces as its primary
+ * display, plus the value/label/range. Computed by the scoring service from the
+ * task's config so the frontend paints it without scoring-version logic.
+ * Absent on tasks whose config declares no display category.
+ */
+export interface ServiceScoreDisplay {
+  scoreType: 'percentile' | 'standardScore' | 'rawScore' | 'percentCorrect';
+  value: number | null;
+  label: string;
+  range: { min: number; max: number } | null;
+}
+
 /** Per-task score entry on a student row. */
 export interface ServiceStudentScoreEntry {
   rawScore: number | null;
@@ -256,6 +269,8 @@ export interface ServiceStudentScoreEntry {
   optional: boolean;
   /** Whether the student has at least one completed run for this task. */
   completed: boolean;
+  /** Primary display descriptor; absent when the task has no display config. */
+  display?: ServiceScoreDisplay;
 }
 
 /** A student row in score results. */
@@ -339,6 +354,8 @@ export interface ServiceStudentReportTaskBase {
   subscores?: Record<string, ServiceSubscoreEntry>;
   /** Present only for PA tasks. */
   skillsToWorkOn?: string[];
+  /** Primary display descriptor; absent when the task has no display config. */
+  display?: ServiceScoreDisplay;
 }
 
 export interface ServiceIndividualStudentReportTask extends ServiceStudentReportTaskBase {

--- a/apps/backend/src/services/scoring/configs/letter.ts
+++ b/apps/backend/src/services/scoring/configs/letter.ts
@@ -67,4 +67,10 @@ export default {
       domain: LETTER_SUBSCORE_DEFS.letterSounds.domain,
     },
   ],
+  displayCategory: [{ minVersion: 0, category: 'percentCorrect' }],
+  displayRanges: {
+    percentCorrect: { min: 0, max: 100 },
+    // Raw-score breakdown range, matching the dashboard's getRawScoreRange for letter.
+    rawScore: { min: 0, max: 90 },
+  },
 };

--- a/apps/backend/src/services/scoring/configs/levante-provisional.ts
+++ b/apps/backend/src/services/scoring/configs/levante-provisional.ts
@@ -30,4 +30,8 @@ export default {
       subskill: false,
     },
   ],
+  displayCategory: [{ minVersion: 0, category: 'rawOnly' }],
+  displayRanges: {
+    rawScore: { min: 0, max: 100 },
+  },
 } as const;

--- a/apps/backend/src/services/scoring/configs/pa.ts
+++ b/apps/backend/src/services/scoring/configs/pa.ts
@@ -118,4 +118,10 @@ export default {
     },
     { kind: 'paSkillsToWorkOn', key: 'skillsToWorkOn', label: 'Skills To Work On' },
   ],
+  displayCategory: [{ minVersion: 0, category: 'normed' }],
+  displayRanges: {
+    percentile: { min: 0, max: 99 },
+    standardScore: { min: 0, max: 180 },
+    rawScore: { min: 0, max: 57 },
+  },
 } as const;

--- a/apps/backend/src/services/scoring/configs/phonics.ts
+++ b/apps/backend/src/services/scoring/configs/phonics.ts
@@ -46,4 +46,10 @@ export default {
       round: true,
     },
   ],
+  displayCategory: [{ minVersion: 0, category: 'percentCorrect' }],
+  displayRanges: {
+    percentCorrect: { min: 0, max: 100 },
+    // Raw-score breakdown range, matching the dashboard's getRawScoreRange for phonics.
+    rawScore: { min: 0, max: 150 },
+  },
 };

--- a/apps/backend/src/services/scoring/configs/roar-inference.ts
+++ b/apps/backend/src/services/scoring/configs/roar-inference.ts
@@ -12,4 +12,10 @@ export default {
   classification: {
     type: 'none' as const,
   },
+  displayCategory: [{ minVersion: 0, category: 'normed' }],
+  displayRanges: {
+    percentile: { min: 0, max: 99 },
+    standardScore: { min: 0, max: 180 },
+    rawScore: { min: 0, max: 130 },
+  },
 } as const;

--- a/apps/backend/src/services/scoring/configs/sre-es.ts
+++ b/apps/backend/src/services/scoring/configs/sre-es.ts
@@ -18,4 +18,17 @@ export default {
     percentileCutoffs: [{ minVersion: SRE_SCORING_VERSION.V1, cutoffs: { achieved: 40, developing: 20 } }],
     rawScoreThresholds: [{ minVersion: SRE_SCORING_VERSION.V1, thresholds: { above: 25, some: 12 } }],
   },
+  // Version-conditional: percent-correct at v0 (no normed fields exist for v0),
+  // normed at v1+. NOTE: confirm the v0 percent-correct value source against the
+  // norming tables — flagged for backend/integration verification.
+  displayCategory: [
+    { minVersion: SRE_SCORING_VERSION.V1, category: 'normed' },
+    { minVersion: 0, category: 'percentCorrect' },
+  ],
+  displayRanges: {
+    percentile: { min: 0, max: 99 },
+    standardScore: { min: 0, max: 180 },
+    rawScore: { min: 0, max: 130 },
+    percentCorrect: { min: 0, max: 100 },
+  },
 } as const;

--- a/apps/backend/src/services/scoring/configs/sre.ts
+++ b/apps/backend/src/services/scoring/configs/sre.ts
@@ -72,4 +72,10 @@ export default {
       { minVersion: 0, thresholds: { above: 70, some: 47 } },
     ],
   },
+  displayCategory: [{ minVersion: 0, category: 'normed' }],
+  displayRanges: {
+    percentile: { min: 0, max: 99 },
+    standardScore: { min: 0, max: 180 },
+    rawScore: { min: 0, max: 130 },
+  },
 } as const;

--- a/apps/backend/src/services/scoring/configs/swr-de.ts
+++ b/apps/backend/src/services/scoring/configs/swr-de.ts
@@ -10,4 +10,8 @@ export default {
     rawScore: [{ minVersion: 0, fieldName: SWR_SCORE_NAMES.NUM_CORRECT }],
   },
   classification: { type: 'none' as const },
+  displayCategory: [{ minVersion: 0, category: 'rawOnly' }],
+  displayRanges: {
+    rawScore: { min: 100, max: 900 },
+  },
 } as const;

--- a/apps/backend/src/services/scoring/configs/swr-es.ts
+++ b/apps/backend/src/services/scoring/configs/swr-es.ts
@@ -14,4 +14,17 @@ export default {
     percentileCutoffs: [{ minVersion: SWR_SCORING_VERSION.V1, cutoffs: { achieved: 40, developing: 20 } }],
     rawScoreThresholds: [{ minVersion: SWR_SCORING_VERSION.V1, thresholds: { above: 547, some: 447 } }],
   },
+  // Version-conditional: percent-correct at v0 (no normed fields exist for v0),
+  // normed at v1+. NOTE: confirm the v0 percent-correct value source against the
+  // norming tables — flagged for backend/integration verification.
+  displayCategory: [
+    { minVersion: SWR_SCORING_VERSION.V1, category: 'normed' },
+    { minVersion: 0, category: 'percentCorrect' },
+  ],
+  displayRanges: {
+    percentile: { min: 0, max: 99 },
+    standardScore: { min: 0, max: 180 },
+    rawScore: { min: 100, max: 900 },
+    percentCorrect: { min: 0, max: 100 },
+  },
 } as const;

--- a/apps/backend/src/services/scoring/configs/swr-it.ts
+++ b/apps/backend/src/services/scoring/configs/swr-it.ts
@@ -10,4 +10,8 @@ export default {
     rawScore: [{ minVersion: 0, fieldName: SWR_SCORE_NAMES.NUM_CORRECT }],
   },
   classification: { type: 'none' as const },
+  displayCategory: [{ minVersion: 0, category: 'rawOnly' }],
+  displayRanges: {
+    rawScore: { min: 100, max: 900 },
+  },
 } as const;

--- a/apps/backend/src/services/scoring/configs/swr-pt.ts
+++ b/apps/backend/src/services/scoring/configs/swr-pt.ts
@@ -10,4 +10,8 @@ export default {
     rawScore: [{ minVersion: 0, fieldName: SWR_SCORE_NAMES.NUM_CORRECT }],
   },
   classification: { type: 'none' as const },
+  displayCategory: [{ minVersion: 0, category: 'rawOnly' }],
+  displayRanges: {
+    rawScore: { min: 100, max: 900 },
+  },
 } as const;

--- a/apps/backend/src/services/scoring/configs/swr.ts
+++ b/apps/backend/src/services/scoring/configs/swr.ts
@@ -26,4 +26,10 @@ export default {
       { minVersion: 0, thresholds: { above: 550, some: 400 } },
     ],
   },
+  displayCategory: [{ minVersion: 0, category: 'normed' }],
+  displayRanges: {
+    percentile: { min: 0, max: 99 },
+    standardScore: { min: 0, max: 180 },
+    rawScore: { min: 100, max: 900 },
+  },
 } as const;

--- a/apps/backend/src/services/scoring/configs/trog.ts
+++ b/apps/backend/src/services/scoring/configs/trog.ts
@@ -12,4 +12,10 @@ export default {
   classification: {
     type: 'none' as const,
   },
+  displayCategory: [{ minVersion: 0, category: 'normed' }],
+  displayRanges: {
+    percentile: { min: 0, max: 99 },
+    standardScore: { min: 0, max: 180 },
+    rawScore: { min: 0, max: 130 },
+  },
 } as const;

--- a/apps/backend/src/services/scoring/index.ts
+++ b/apps/backend/src/services/scoring/index.ts
@@ -1,6 +1,7 @@
 export {
   parseScoreValue,
   getSupportLevel,
+  getScoreDisplay,
   getRawScoreThreshold,
   resolveScoreFieldNames,
   resolveScoreFieldName,
@@ -29,4 +30,11 @@ export type {
   PaSkillsToWorkOnSubscoreColumn,
   LetterToWorkOnSubscoreColumn,
 } from './scoring.config-schema';
-export type { SupportLevel, ScoringInput, RawScoreThreshold, ScoreFieldResolution } from './scoring.types';
+export type {
+  SupportLevel,
+  ScoringInput,
+  RawScoreThreshold,
+  ScoreFieldResolution,
+  ScoreDisplay,
+  DisplayScoreType,
+} from './scoring.types';

--- a/apps/backend/src/services/scoring/scoring.config-schema.ts
+++ b/apps/backend/src/services/scoring/scoring.config-schema.ts
@@ -240,6 +240,48 @@ const SubscoreColumnSchema = z.discriminatedUnion('kind', [
  */
 const SubscoresSchema = z.array(SubscoreColumnSchema).min(1);
 
+// --- Display descriptor ---
+
+/**
+ * Which score a task surfaces as its primary display, and how it's labelled.
+ * Moves the dashboard's `getScoreToDisplay` + percent-correct/raw-only branching
+ * into config so the frontend paints `display` without knowing scoring versions.
+ *
+ * - `normed`        — percentile (grades below `percentileBelowGrade`) else
+ *                     standard score; falls back to raw when the resolved
+ *                     version has no normed fields (e.g. swr-es v0).
+ * - `percentCorrect`— the task's `percentile` field holds a percent-correct value
+ *                     (letter/phonics: `TOTAL_PERCENT_CORRECT`).
+ * - `rawOnly`       — raw score only.
+ * - `gradeEstimate` — raw score primary (grade-estimate tasks, e.g. roam-alpaca).
+ */
+export const DISPLAY_CATEGORIES = ['normed', 'percentCorrect', 'rawOnly', 'gradeEstimate'] as const;
+
+const DisplayCategorySchema = z.enum(DISPLAY_CATEGORIES);
+
+/**
+ * Versioned display category. Resolved by descending `minVersion` (first match
+ * where `scoringVersion >= minVersion`) — lets a task be percent-correct at v0
+ * and normed at v1+ (swr-es / sre-es) without the response builder branching.
+ */
+const VersionedDisplayCategorySchema = z.object({
+  minVersion: z.number().int().min(0),
+  category: DisplayCategorySchema,
+});
+
+const ScoreRangeSchema = z.object({ min: z.number(), max: z.number() });
+
+/**
+ * Display ranges (dial min/max) per display score type. Not versioned — the
+ * dashboard's `getRawScoreRange` is per-task, not per-version.
+ */
+const DisplayRangesSchema = z.object({
+  percentile: ScoreRangeSchema.optional(),
+  standardScore: ScoreRangeSchema.optional(),
+  rawScore: ScoreRangeSchema.optional(),
+  percentCorrect: ScoreRangeSchema.optional(),
+});
+
 // --- Top-level scoring config ---
 
 export const ScoringConfigSchema = z.object({
@@ -252,6 +294,14 @@ export const ScoringConfigSchema = z.object({
    * `subscores` field on per-task entries when this block is present.
    */
   subscores: SubscoresSchema.optional(),
+  /**
+   * Optional display descriptor. When present, the report responses include a
+   * per-task `display` object; tasks without it omit `display` (the frontend
+   * keeps its legacy path until the config is authored). Ordered by descending
+   * `minVersion`.
+   */
+  displayCategory: z.array(VersionedDisplayCategorySchema).min(1).superRefine(descendingMinVersion).optional(),
+  displayRanges: DisplayRangesSchema.optional(),
 });
 
 // --- Inferred types ---
@@ -263,6 +313,9 @@ export type FieldNameValue = z.infer<typeof FieldNameValueSchema>;
 export type VersionedFieldName = z.infer<typeof VersionedFieldNameSchema>;
 export type Classification = z.infer<typeof ClassificationSchema>;
 export type PercentileThenRawscoreClassification = z.infer<typeof PercentileThenRawscoreClassificationSchema>;
+export type DisplayCategory = z.infer<typeof DisplayCategorySchema>;
+export type ScoreRange = z.infer<typeof ScoreRangeSchema>;
+export type DisplayRanges = z.infer<typeof DisplayRangesSchema>;
 
 // Subscore column types (consumed by the scoring service helpers + report service)
 export type SubscoreColumn = z.infer<typeof SubscoreColumnSchema>;

--- a/apps/backend/src/services/scoring/scoring.service.test.ts
+++ b/apps/backend/src/services/scoring/scoring.service.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import {
   parseScoreValue,
   getSupportLevel,
+  getScoreDisplay,
   getRawScoreThreshold,
   resolveScoreFieldNames,
   resolveScoreFieldName,
@@ -662,5 +663,95 @@ describe('getSupportLevelFieldName', () => {
 
   it('returns null for unknown tasks', () => {
     expect(getSupportLevelFieldName('unknown-task')).toBeNull();
+  });
+});
+
+describe('getScoreDisplay', () => {
+  it('returns null for tasks without a display config', () => {
+    expect(
+      getScoreDisplay({
+        taskSlug: 'unknown-task',
+        gradeLevel: 3,
+        scoringVersion: 0,
+        scores: { rawScore: 1, percentile: 1, standardScore: 1 },
+      }),
+    ).toBeNull();
+  });
+
+  it('surfaces percentile for a normed task below the percentile grade', () => {
+    const display = getScoreDisplay({
+      taskSlug: 'swr',
+      gradeLevel: 3,
+      scoringVersion: 0,
+      scores: { rawScore: 500, percentile: 50, standardScore: 100 },
+    });
+    expect(display).toEqual({ scoreType: 'percentile', value: 50, label: 'Percentile', range: { min: 0, max: 99 } });
+  });
+
+  it('surfaces standard score for a normed task at grade >= 6', () => {
+    const display = getScoreDisplay({
+      taskSlug: 'swr',
+      gradeLevel: 8,
+      scoringVersion: 0,
+      scores: { rawScore: 500, percentile: 50, standardScore: 100 },
+    });
+    expect(display).toMatchObject({ scoreType: 'standardScore', value: 100, range: { min: 0, max: 180 } });
+  });
+
+  it('uses percent-correct for swr-es at v0 (no normed fields exist for v0)', () => {
+    const display = getScoreDisplay({
+      taskSlug: 'swr-es',
+      gradeLevel: 3,
+      scoringVersion: 0,
+      scores: { rawScore: 300, percentile: null, standardScore: null },
+    });
+    // v0 has no percentile field, so the percent-correct value is null today — see the
+    // swr-es config flag; the integration suite validates the value against real data.
+    expect(display).toMatchObject({ scoreType: 'percentCorrect', value: null });
+  });
+
+  it('falls back to raw score for a normed task at grade >= 6 with no standard score', () => {
+    const display = getScoreDisplay({
+      taskSlug: 'swr',
+      gradeLevel: 8,
+      scoringVersion: 0,
+      scores: { rawScore: 480, percentile: null, standardScore: null },
+    });
+    expect(display).toMatchObject({ scoreType: 'rawScore', value: 480, range: { min: 100, max: 900 } });
+  });
+
+  it('uses standard score for a normed task when grade is null (no percentile branch)', () => {
+    const display = getScoreDisplay({
+      taskSlug: 'swr',
+      gradeLevel: null,
+      scoringVersion: 0,
+      scores: { rawScore: 480, percentile: 40, standardScore: 95 },
+    });
+    expect(display).toMatchObject({ scoreType: 'standardScore', value: 95 });
+  });
+
+  it('surfaces normed (percentile) display for swr-es at v1+', () => {
+    const display = getScoreDisplay({
+      taskSlug: 'swr-es',
+      gradeLevel: 3,
+      scoringVersion: 10,
+      scores: { rawScore: 500, percentile: 60, standardScore: 105 },
+    });
+    expect(display).toMatchObject({ scoreType: 'percentile', value: 60 });
+  });
+
+  it('surfaces percent-correct for letter (the percentile field holds the percent value)', () => {
+    const display = getScoreDisplay({
+      taskSlug: 'letter',
+      gradeLevel: 1,
+      scoringVersion: 0,
+      scores: { rawScore: 20, percentile: 85, standardScore: null },
+    });
+    expect(display).toEqual({
+      scoreType: 'percentCorrect',
+      value: 85,
+      label: 'Percent Correct',
+      range: { min: 0, max: 100 },
+    });
   });
 });

--- a/apps/backend/src/services/scoring/scoring.service.test.ts
+++ b/apps/backend/src/services/scoring/scoring.service.test.ts
@@ -685,7 +685,7 @@ describe('getScoreDisplay', () => {
       scoringVersion: 0,
       scores: { rawScore: 500, percentile: 50, standardScore: 100 },
     });
-    expect(display).toEqual({ scoreType: 'percentile', value: 50, label: 'Percentile', range: { min: 0, max: 99 } });
+    expect(display).toEqual({ scoreType: 'percentile', value: 50, label: 'percentile', range: { min: 0, max: 99 } });
   });
 
   it('surfaces standard score for a normed task at grade >= 6', () => {
@@ -750,7 +750,7 @@ describe('getScoreDisplay', () => {
     expect(display).toEqual({
       scoreType: 'percentCorrect',
       value: 85,
-      label: 'Percent Correct',
+      label: 'percentCorrect',
       range: { min: 0, max: 100 },
     });
   });

--- a/apps/backend/src/services/scoring/scoring.service.ts
+++ b/apps/backend/src/services/scoring/scoring.service.ts
@@ -1,7 +1,14 @@
 import { getGradeAsNumber } from '../../utils/get-grade-as-number.util';
 import type { ScoringConfig, FieldNameValue, SCORE_FIELD_TYPES, SubscoreColumn } from './scoring.config-schema';
 import { getScoringConfig } from './scoring.config-registry';
-import type { SupportLevel, ScoringInput, RawScoreThreshold, ScoreFieldResolution } from './scoring.types';
+import type {
+  SupportLevel,
+  ScoringInput,
+  RawScoreThreshold,
+  ScoreFieldResolution,
+  ScoreDisplay,
+  DisplayScoreType,
+} from './scoring.types';
 
 const ANGLE_BRACKET_PATTERN = /[<>]/g;
 const VALID_SUPPORT_LEVELS: ReadonlySet<string> = new Set(['achievedSkill', 'developingSkill', 'needsExtraSupport']);
@@ -137,6 +144,98 @@ export function getSupportLevel(input: ScoringInput): SupportLevel | null {
   }
 
   return null;
+}
+
+const DISPLAY_SCORE_TYPE_LABELS: Record<DisplayScoreType, string> = {
+  percentile: 'Percentile',
+  standardScore: 'Standard Score',
+  rawScore: 'Raw Score',
+  percentCorrect: 'Percent Correct',
+};
+
+/**
+ * Resolve a task's primary display descriptor (which score to surface, its
+ * value, label, and range) from config — moving the dashboard's
+ * `getScoreToDisplay` + percent-correct/raw-only/version branching server-side.
+ *
+ * Returns null for tasks whose config declares no `displayCategory` (the
+ * frontend keeps its legacy path for those until the config is authored).
+ *
+ * Algorithm:
+ * 1. Resolve the display category for the task's scoring version (versioned).
+ * 2. `percentCorrect` → the percent value lives in the `percentile` field.
+ *    `rawOnly`/`gradeEstimate` → raw score.
+ *    `normed` → percentile for grades below `percentileBelowGrade` (when a
+ *    percentile is present), else standard score, else raw (e.g. swr-es v0,
+ *    which has no normed fields at that version).
+ * 3. Attach the configured range for the resolved score type, if any.
+ *
+ * @param args.taskSlug - The task slug
+ * @param args.gradeLevel - Numeric grade level, or null
+ * @param args.scoringVersion - The scoring version, or null for legacy v0
+ * @param args.scores - The resolved { rawScore, percentile, standardScore } for the run
+ * @returns The display descriptor, or null when the task has no display config
+ */
+export function getScoreDisplay(args: {
+  taskSlug: string;
+  gradeLevel: number | null;
+  scoringVersion: number | null;
+  scores: { rawScore: number | null; percentile: number | null; standardScore: number | null };
+}): ScoreDisplay | null {
+  const { taskSlug, gradeLevel, scoringVersion, scores } = args;
+
+  const config = getScoringConfig(taskSlug);
+  if (!config?.displayCategory) {
+    return null;
+  }
+
+  const version = scoringVersion ?? 0;
+  const categoryEntry = resolveVersionedEntry(config.displayCategory, version);
+  if (!categoryEntry) {
+    return null;
+  }
+
+  let scoreType: DisplayScoreType;
+  let value: number | null;
+
+  switch (categoryEntry.category) {
+    case 'percentCorrect':
+      // For percent-correct tasks the percentile field carries the percent value.
+      scoreType = 'percentCorrect';
+      value = scores.percentile;
+      break;
+    case 'rawOnly':
+    case 'gradeEstimate':
+      scoreType = 'rawScore';
+      value = scores.rawScore;
+      break;
+    case 'normed': {
+      const percentileBelowGrade =
+        config.classification.type === 'percentile-then-rawscore' ? config.classification.percentileBelowGrade : 6;
+      const usePercentile =
+        scores.percentile !== null &&
+        (percentileBelowGrade === null || (gradeLevel !== null && gradeLevel < percentileBelowGrade));
+
+      if (usePercentile) {
+        scoreType = 'percentile';
+        value = scores.percentile;
+      } else if (scores.standardScore !== null) {
+        scoreType = 'standardScore';
+        value = scores.standardScore;
+      } else {
+        scoreType = 'rawScore';
+        value = scores.rawScore;
+      }
+      break;
+    }
+  }
+
+  return {
+    scoreType,
+    value,
+    label: DISPLAY_SCORE_TYPE_LABELS[scoreType],
+    range: config.displayRanges?.[scoreType] ?? null,
+  };
 }
 
 /**

--- a/apps/backend/src/services/scoring/scoring.service.ts
+++ b/apps/backend/src/services/scoring/scoring.service.ts
@@ -146,13 +146,6 @@ export function getSupportLevel(input: ScoringInput): SupportLevel | null {
   return null;
 }
 
-const DISPLAY_SCORE_TYPE_LABELS: Record<DisplayScoreType, string> = {
-  percentile: 'Percentile',
-  standardScore: 'Standard Score',
-  rawScore: 'Raw Score',
-  percentCorrect: 'Percent Correct',
-};
-
 /**
  * Resolve a task's primary display descriptor (which score to surface, its
  * value, label, and range) from config — moving the dashboard's
@@ -233,7 +226,7 @@ export function getScoreDisplay(args: {
   return {
     scoreType,
     value,
-    label: DISPLAY_SCORE_TYPE_LABELS[scoreType],
+    label: scoreType,
     range: config.displayRanges?.[scoreType] ?? null,
   };
 }

--- a/apps/backend/src/services/scoring/scoring.types.ts
+++ b/apps/backend/src/services/scoring/scoring.types.ts
@@ -48,6 +48,27 @@ export interface RawScoreThreshold {
 }
 
 /**
+ * The score types a task can surface as its primary display.
+ */
+export type DisplayScoreType = 'percentile' | 'standardScore' | 'rawScore' | 'percentCorrect';
+
+/**
+ * Per-task display descriptor — what the frontend paints without knowing
+ * scoring versions or per-task display rules. Computed by `getScoreDisplay`
+ * from the task's config (display category + ranges) and resolved scores.
+ */
+export interface ScoreDisplay {
+  /** Which score is the primary display for this task/grade/version. */
+  scoreType: DisplayScoreType;
+  /** The numeric value to render for `scoreType` (null when absent). */
+  value: number | null;
+  /** Stable label key for the score type; the frontend localizes. */
+  label: string;
+  /** Inclusive dial/breakdown range, or null when the config declares none. */
+  range: { min: number; max: number } | null;
+}
+
+/**
  * Resolved score field names for looking up values in the fdwRunScores table.
  * Each array contains the `name` column values for that field type. Empty if the task
  * has no applicable field. When resolved with a specific scoring version, arrays contain

--- a/package-lock.json
+++ b/package-lock.json
@@ -3751,7 +3751,8 @@
       "version": "0.0.0",
       "dependencies": {
         "@roar-platform/assessment-schema": "^0.1.0",
-        "@roar-platform/assessment-sdk": "^0.1.0"
+        "@roar-platform/assessment-sdk": "^0.1.0",
+        "http-status-codes": "^2.3.0"
       },
       "devDependencies": {
         "@roar-platform/eslint-config": "*",

--- a/packages/api-contract/src/v1/administrations/reports/scores/schema.ts
+++ b/packages/api-contract/src/v1/administrations/reports/scores/schema.ts
@@ -199,6 +199,22 @@ export type SupportLevelValue = z.infer<typeof SupportLevelValueSchema>;
  * `reliable` and `engagementFlags` are populated from the underlying run regardless
  * of completion. They are null/empty when no run exists.
  */
+/**
+ * Per-task display descriptor — the server's decision about which score to
+ * surface as the primary display, its value, label, and range. The frontend
+ * renders this directly instead of re-deriving display rules from scoring
+ * versions / task slugs. Omitted on tasks whose scoring config declares no
+ * display category yet (the frontend keeps its legacy path for those).
+ */
+export const ScoreDisplaySchema = z.object({
+  scoreType: z.enum(['percentile', 'standardScore', 'rawScore', 'percentCorrect']),
+  value: z.number().nullable(),
+  label: z.string(),
+  range: z.object({ min: z.number(), max: z.number() }).nullable(),
+});
+
+export type ScoreDisplay = z.infer<typeof ScoreDisplaySchema>;
+
 export const StudentScoreEntrySchema = z.object({
   rawScore: z.number().int().nullable(),
   percentile: z.number().int().nullable(),
@@ -213,6 +229,8 @@ export const StudentScoreEntrySchema = z.object({
   optional: z.boolean(),
   /** Whether the student has at least one completed run for this task. */
   completed: z.boolean(),
+  /** Server-computed primary display descriptor (see ScoreDisplaySchema). */
+  display: ScoreDisplaySchema.optional(),
 });
 
 export type StudentScoreEntry = z.infer<typeof StudentScoreEntrySchema>;
@@ -342,6 +360,8 @@ export const IndividualStudentReportTaskSchema = z.object({
   tags: z.array(TaskTagSchema),
   subscores: z.record(z.string(), SubscoreEntrySchema).optional(),
   skillsToWorkOn: z.array(z.string()).optional(),
+  /** Server-computed primary display descriptor (see ScoreDisplaySchema). */
+  display: ScoreDisplaySchema.optional(),
   historicalScores: z.array(HistoricalScoreSchema),
 });
 


### PR DESCRIPTION
## Copy of: Summary

This PR adds a server-computed per-task **`display` descriptor** to the score-report responses so the dashboard can paint scores without knowing anything about scoring versions or per-task display rules. It implements `.do-not-track/ticket-report-display-descriptor.md` and unblocks the admin-metadata swap (the dashboard reads `display` instead of deriving the displayed score type / range from `administrationData.assessments[].params.scoringVersion`).

All per-task/per-version display logic stays in the backend scoring config, where the version/norm logic already lives — the response surfaces the *result*.

## Changes

- **Scoring config (`scoring.config-schema.ts`)** — new optional `displayCategory` (versioned: `normed` | `percentCorrect` | `rawOnly` | `gradeEstimate`) and `displayRanges` (per display score type) blocks.
- **`getScoreDisplay()` (`scoring.service.ts`)** — resolves the display category for the task's scoring version, then picks the score type + value: `percentCorrect` (the percentile field holds the percent for letter/phonics), `rawOnly`/`gradeEstimate` → raw, `normed` → percentile below `percentileBelowGrade` else standard, falling back to raw when the resolved version has no normed fields. Attaches the configured range. Returns `null` for tasks with no display config. Unit tests added.
- **Config data** — `displayCategory` + `displayRanges` authored for `swr`, `sre`, `pa` (normed), `letter`, `phonics` (percent-correct), and `swr-es`, `sre-es` (version-conditional: percent-correct at v0, normed at v1+). Ranges ported from the dashboard's `getRawScoreRange` / `processTaskScores` constants.
- **Contract (`schema.ts`)** — `ScoreDisplaySchema` + an optional `display` on `StudentScoreEntrySchema` and `IndividualStudentReportTaskSchema` (so it flows to the guardian report too via the shared base).
- **Report service** — populates `display` in `buildBaseAssessedTaskEntry` (individual + guardian) and the student-scores builder, from the same rounded scores the response carries. The controller already returns the service result structurally, so no controller change.

## Additive + safe

The `display` field is optional and new; existing `scores` / `supportLevel` are untouched. Tasks without a `displayCategory` simply omit `display`, and the frontend keeps its legacy path for them.

## Flags for review / verification

- **`swr-es` / `sre-es` v0** resolve to `percentCorrect`, whose value comes from the `percentile` field — which doesn't exist at v0, so `value` may be null. The v0 percent-correct value source needs confirmation against the norming tables (flagged in the config comments).
- **Not yet authored:** `fluency-arf`/`fluency-calf`, `roam-alpaca`, and the excluded `vocab`/`cva`/`morphology` have no `displayCategory` yet (they omit `display`; the frontend keeps legacy until authored). A fast follow once the categories/ranges are confirmed.
- **Ranges** are ported from frontend constants — verify against the authoritative norms.
- **Distribution-chart key (#2 in the ticket)** is not included here — deferred.
- **`displayValue` string (capped `>99`/`<1`)** from the ticket is intentionally cut from this scope — `display` carries only the numeric `value`. The frontend keeps re-deriving the percentile suffix until a later increment adds it.

## Review fixes applied

- Added the `rawScore` display range to `letter` (0–90) and `phonics` (0–150) to match the dashboard's `getRawScoreRange` (the raw breakdown row would otherwise lose its range).
- Strengthened the `getScoreDisplay` tests: the swr-es v0 case now asserts the (null) value, plus added the normed→raw fallback (grade ≥ 6, no standard score) and the null-grade branches.

## Testing

- `getScoreDisplay` unit tests (normed grade rule, swr-es v0 vs v1+, letter percent-correct, no-config → null). `npm run check-types` clean across `apps/backend` + `packages/api-contract`.
- ⚠️ **Backend integration suite is the gate** (the dev sandbox can't run vitest). Please run `npm run test:integration -w apps/backend` and confirm, for `baseFixture`, that each task's `display.scoreType`/`value` matches the existing `scores` + `supportLevel`, and validate the `swr-es` v0 case against real data. Per `culture-leverage-ai.md`, this scoring change wants a careful human read of the config data.



> [!NOTE]
> **Cross-fork stacking.** Because intermediate branches live only on `richford`, a `yeatmanlab/roar-dashboard` PR cannot use one as its base — every PR in this series targets `project/backend-refactor`, and they are reviewed/merged **bottom-up** so each shows only its own slice once its parent merges.

> [!IMPORTANT]
> **Merge order:** first in its stack — targets `project/backend-refactor` directly.

Resolves #1959
Part of #1958