### PR TITLE
Score report: wire overview charts + swap admin metadata to useAdministrationQuery

### DIFF
--- a/apps/dashboard/src/components/reports/DistributionChartOverview.vue
+++ b/apps/dashboard/src/components/reports/DistributionChartOverview.vue
@@ -6,7 +6,7 @@
 import { computed, onMounted, watch } from 'vue';
 import embed from 'vega-embed';
 import useTasksDictionaryQuery from '@/composables/queries/useTasksDictionaryQuery';
-import { SCORE_SUPPORT_LEVEL_COLORS, MATCHING_SUPPORT_LEVELS } from '@/constants/scores';
+import { SCORE_SUPPORT_LEVEL_COLORS } from '@/constants/scores';
 
 const props = defineProps({
   initialized: {
@@ -16,10 +16,6 @@ const props = defineProps({
   taskId: {
     type: String,
     required: true,
-  },
-  runs: {
-    type: Array,
-    required: false,
   },
   // Backend-aggregated support-level counts from the score-overview endpoint,
   // shaped `{ needsExtraSupport: { count }, developingSkill: { count }, achievedSkill: { count } }`.
@@ -65,35 +61,14 @@ const BACKEND_SUPPORT_LEVEL_LABELS = {
 };
 
 const supportLevelsOverview = computed(() => {
-  // Preferred path: server-aggregated counts from the score-overview endpoint.
-  if (props.supportLevelCounts) {
-    return Object.entries(BACKEND_SUPPORT_LEVEL_LABELS).map(([key, category]) => ({
-      category,
-      value: props.supportLevelCounts[key]?.count ?? 0,
-    }));
-  }
-  // Legacy Firestore paths (district aggregate object / per-run array). Guard
-  // first so an absent `runs` can't throw in the district branch below.
-  if (!props.runs) return [];
-  if (props.orgType === 'district') {
-    return Object.entries(props.runs)
-      .filter(([support_level]) => MATCHING_SUPPORT_LEVELS[support_level] != undefined)
-      .map(([support_level, total]) => ({ category: MATCHING_SUPPORT_LEVELS[support_level], value: total.total }));
-  }
-  let values = {};
-  for (const { scores } of props.runs) {
-    const support_level = scores.support_level;
-    if (support_level in values) {
-      values[support_level] += 1;
-    } else {
-      values[support_level] = 1;
-    }
-  }
+  // Server-aggregated counts from the score-overview endpoint, shaped
+  // `{ needsExtraSupport: { count }, developingSkill: { count }, achievedSkill: { count } }`.
+  if (!props.supportLevelCounts) return [];
 
-  // transform dictionary into datatype readable to vega
-  return Object.entries(values)
-    .filter(([support_level]) => support_level !== 'null')
-    .map(([support_level, count]) => ({ category: support_level, value: count }));
+  return Object.entries(BACKEND_SUPPORT_LEVEL_LABELS).map(([key, category]) => ({
+    category,
+    value: props.supportLevelCounts[key]?.count ?? 0,
+  }));
 });
 
 const overviewDistributionChart = computed(() => {

--- a/apps/dashboard/src/components/reports/DistributionChartOverview.vue
+++ b/apps/dashboard/src/components/reports/DistributionChartOverview.vue
@@ -130,7 +130,7 @@ const draw = async () => {
 };
 
 watch(
-  [() => overviewDistributionChart.value, () => props.runs, () => props.supportLevelCounts, () => props.orgType],
+  [() => overviewDistributionChart.value, () => props.supportLevelCounts],
   () => {
     if (props.taskId !== 'letter') {
       draw();

--- a/apps/dashboard/src/components/reports/DistributionChartOverview.vue
+++ b/apps/dashboard/src/components/reports/DistributionChartOverview.vue
@@ -21,6 +21,15 @@ const props = defineProps({
     type: Array,
     required: false,
   },
+  // Backend-aggregated support-level counts from the score-overview endpoint,
+  // shaped `{ needsExtraSupport: { count }, developingSkill: { count }, achievedSkill: { count } }`.
+  // When provided, it is the chart's data source and `runs` is ignored — this is
+  // the server-computed replacement for the client-side `runs` aggregation.
+  supportLevelCounts: {
+    type: Object,
+    required: false,
+    default: undefined,
+  },
   orgType: {
     type: String,
     required: true,
@@ -47,13 +56,30 @@ const props = defineProps({
 
 const { data: tasksDictionary, isLoading: isLoadingTasksDictionary } = useTasksDictionaryQuery();
 
+// Maps the score-overview endpoint's support-level keys to the chart's display
+// categories (which match the color-scale domain below).
+const BACKEND_SUPPORT_LEVEL_LABELS = {
+  needsExtraSupport: 'Needs Extra Support',
+  developingSkill: 'Developing Skill',
+  achievedSkill: 'Achieved Skill',
+};
+
 const supportLevelsOverview = computed(() => {
+  // Preferred path: server-aggregated counts from the score-overview endpoint.
+  if (props.supportLevelCounts) {
+    return Object.entries(BACKEND_SUPPORT_LEVEL_LABELS).map(([key, category]) => ({
+      category,
+      value: props.supportLevelCounts[key]?.count ?? 0,
+    }));
+  }
+  // Legacy Firestore paths (district aggregate object / per-run array). Guard
+  // first so an absent `runs` can't throw in the district branch below.
+  if (!props.runs) return [];
   if (props.orgType === 'district') {
     return Object.entries(props.runs)
       .filter(([support_level]) => MATCHING_SUPPORT_LEVELS[support_level] != undefined)
       .map(([support_level, total]) => ({ category: MATCHING_SUPPORT_LEVELS[support_level], value: total.total }));
   }
-  if (!props.runs) return [];
   let values = {};
   for (const { scores } of props.runs) {
     const support_level = scores.support_level;
@@ -129,7 +155,7 @@ const draw = async () => {
 };
 
 watch(
-  [() => overviewDistributionChart.value, () => props.runs, () => props.orgType],
+  [() => overviewDistributionChart.value, () => props.runs, () => props.supportLevelCounts, () => props.orgType],
   () => {
     if (props.taskId !== 'letter') {
       draw();

--- a/apps/dashboard/src/composables/queries/useAdministrationScoreOverviewQuery.js
+++ b/apps/dashboard/src/composables/queries/useAdministrationScoreOverviewQuery.js
@@ -1,0 +1,87 @@
+import { toValue } from 'vue';
+import { useQuery } from '@tanstack/vue-query';
+import { StatusCodes } from 'http-status-codes';
+import { computeQueryOverrides } from '@/helpers/computeQueryOverrides';
+import { getRoarApiClient } from '@/clients/roar-api';
+import { useAuthStore } from '@/store/auth';
+import { isRosteringEndedError, isTerminalAuthError } from '@/utils/api-errors';
+import { ADMINISTRATION_SCORE_OVERVIEW_QUERY_KEY } from '@/constants/queryKeys';
+
+const MAX_RETRIES = 3;
+
+/**
+ * Administration score-overview query.
+ *
+ * Fetches aggregated support-level distributions per task from
+ * `GET /v1/administrations/:id/reports/scores/overview`, scoped to a specific
+ * org/class/group via `scopeType` + `scopeId`. Not paginated — the endpoint
+ * aggregates across the full population in scope, so this is a single request
+ * (unlike the paginated student / subscore endpoints).
+ *
+ * Returns the unwrapped overview payload (`result.body.data`): the per-task
+ * aggregated support-level counts the "at a glance" charts at the top of the
+ * score report render. Replaces the client-side `runsByTaskId` aggregation and
+ * the Firestore `useDistrictSupportCategoriesQuery`.
+ *
+ * **Enablement.** Internally gated on `authStore.accessToken` AND truthy
+ * `administrationId` / `scopeType` / `scopeId`; callers AND extra conditions via
+ * `queryOptions.enabled`.
+ *
+ * @param {import('vue').MaybeRefOrGetter<String>} administrationId – The administration's UUID.
+ * @param {import('vue').MaybeRefOrGetter<String>} scopeType – 'district' | 'school' | 'class' | 'group'.
+ * @param {import('vue').MaybeRefOrGetter<String>} scopeId – The scoping entity's UUID.
+ * @param {Object|undefined} queryOptions – Optional TanStack query options.
+ * @returns {import('@tanstack/vue-query').UseQueryReturnType} Resolves to the aggregated overview payload.
+ */
+const useAdministrationScoreOverviewQuery = (administrationId, scopeType, scopeId, queryOptions = undefined) => {
+  const authStore = useAuthStore();
+  const conditions = [
+    () => Boolean(authStore.accessToken),
+    () => Boolean(toValue(administrationId)),
+    () => Boolean(toValue(scopeType)),
+    () => Boolean(toValue(scopeId)),
+  ];
+  const { isQueryEnabled, options } = computeQueryOverrides(conditions, queryOptions);
+
+  return useQuery({
+    // Pass scope params as-is (ref or string) so reactive callers update the key;
+    // TanStack unwraps refs in the key array, matching the canonical composable.
+    queryKey: [ADMINISTRATION_SCORE_OVERVIEW_QUERY_KEY, administrationId, scopeType, scopeId],
+    queryFn: async () => {
+      const client = getRoarApiClient();
+      const result = await client.administrations.scoreReports.getOverview({
+        params: { id: toValue(administrationId) },
+        query: {
+          scopeType: toValue(scopeType),
+          scopeId: toValue(scopeId),
+        },
+      });
+
+      if (result.status !== StatusCodes.OK) {
+        // Non-200 ts-rest results are surfaced as thrown errors so TanStack routes
+        // them through `error`. The thrown shape carries the ts-rest response so
+        // downstream error handlers can introspect it.
+        const error = new Error(`Failed to fetch administration score overview with status ${result.status}`);
+        error.status = result.status;
+        error.body = result.body;
+        throw error;
+      }
+
+      // Unwrap the success envelope: { data: <aggregated overview> }.
+      return result.body.data;
+    },
+    ...options,
+    enabled: isQueryEnabled,
+    // Terminal auth errors and rostering-ended are not transient; retrying delays
+    // the user-facing error UX. Placed after `...options` so a caller-supplied
+    // `retry` can't silently override the policy.
+    retry: (failureCount, error) => {
+      if (isRosteringEndedError(error) || isTerminalAuthError(error)) {
+        return false;
+      }
+      return failureCount < MAX_RETRIES;
+    },
+  });
+};
+
+export default useAdministrationScoreOverviewQuery;

--- a/apps/dashboard/src/composables/queries/useAdministrationScoreOverviewQuery.test.js
+++ b/apps/dashboard/src/composables/queries/useAdministrationScoreOverviewQuery.test.js
@@ -1,0 +1,173 @@
+import { ref, nextTick, isRef, isReadonly } from 'vue';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { createTestingPinia } from '@pinia/testing';
+import * as VueQuery from '@tanstack/vue-query';
+import { nanoid } from 'nanoid';
+import { StatusCodes } from 'http-status-codes';
+import { withSetup } from '@/test-support/withSetup.js';
+import { useAuthStore } from '@/store/auth';
+import useAdministrationScoreOverviewQuery from './useAdministrationScoreOverviewQuery';
+import { ADMINISTRATION_SCORE_OVERVIEW_QUERY_KEY } from '@/constants/queryKeys';
+
+const mockGetOverview = vi.fn();
+
+vi.mock('@/clients/roar-api', () => ({
+  getRoarApiClient: () => ({
+    administrations: { scoreReports: { getOverview: mockGetOverview } },
+  }),
+}));
+
+vi.mock('@tanstack/vue-query', async (getModule) => {
+  const original = await getModule();
+  return {
+    ...original,
+    useQuery: vi.fn().mockImplementation(original.useQuery),
+  };
+});
+
+// Mirrors the real ScoreOverviewResponseSchema shape (taskSlug + supportLevels.<key>.count).
+const SAMPLE_OVERVIEW = {
+  totalStudents: 10,
+  tasks: [
+    {
+      taskId: '11111111-1111-1111-1111-111111111111',
+      taskSlug: 'swr',
+      taskName: 'Word',
+      orderIndex: 0,
+      totalAssessed: 8,
+      totalNotAssessed: { required: 1, optional: 1 },
+      supportLevels: { needsExtraSupport: { count: 2 }, developingSkill: { count: 3 }, achievedSkill: { count: 3 } },
+    },
+  ],
+  computedAt: '2026-06-28T00:00:00.000Z',
+  exclusions: {},
+};
+
+describe('useAdministrationScoreOverviewQuery', () => {
+  let piniaInstance;
+  let queryClient;
+
+  beforeEach(() => {
+    piniaInstance = createTestingPinia();
+    queryClient = new VueQuery.QueryClient({ defaultOptions: { queries: { retry: false } } });
+    mockGetOverview.mockReset();
+    mockGetOverview.mockResolvedValue({ status: StatusCodes.OK, body: { data: SAMPLE_OVERVIEW } });
+  });
+
+  afterEach(() => {
+    queryClient?.clear();
+    vi.clearAllMocks();
+  });
+
+  it('calls useQuery with the score-overview key and a gated, readonly enabled', () => {
+    const authStore = useAuthStore(piniaInstance);
+    authStore.accessToken = 'test-token';
+
+    vi.spyOn(VueQuery, 'useQuery');
+
+    withSetup(() => useAdministrationScoreOverviewQuery(nanoid(), 'school', nanoid()), {
+      plugins: [[VueQuery.VueQueryPlugin, { queryClient }]],
+    });
+
+    const call = vi.mocked(VueQuery.useQuery).mock.calls[0][0];
+    expect(call.queryKey[0]).toBe(ADMINISTRATION_SCORE_OVERVIEW_QUERY_KEY);
+    expect(call.queryFn).toBeInstanceOf(Function);
+    expect(isRef(call.enabled)).toBe(true);
+    expect(isReadonly(call.enabled)).toBe(true);
+    expect(call.enabled.value).toBe(true);
+  });
+
+  it('fetches the overview with the scope params and returns the unwrapped payload', async () => {
+    const administrationId = nanoid();
+    const scopeId = nanoid();
+    const authStore = useAuthStore(piniaInstance);
+    authStore.accessToken = 'test-token';
+
+    vi.spyOn(VueQuery, 'useQuery');
+
+    withSetup(() => useAdministrationScoreOverviewQuery(administrationId, 'school', scopeId), {
+      plugins: [[VueQuery.VueQueryPlugin, { queryClient }]],
+    });
+
+    const { queryFn } = vi.mocked(VueQuery.useQuery).mock.calls[0][0];
+    const data = await queryFn();
+
+    expect(mockGetOverview).toHaveBeenCalledWith({
+      params: { id: administrationId },
+      query: { scopeType: 'school', scopeId },
+    });
+    expect(data).toEqual(SAMPLE_OVERVIEW);
+  });
+
+  it('throws when the API returns a non-200 status', async () => {
+    mockGetOverview.mockResolvedValue({ status: StatusCodes.FORBIDDEN, body: {} });
+
+    const authStore = useAuthStore(piniaInstance);
+    authStore.accessToken = 'test-token';
+
+    vi.spyOn(VueQuery, 'useQuery');
+
+    withSetup(() => useAdministrationScoreOverviewQuery(nanoid(), 'school', nanoid()), {
+      plugins: [[VueQuery.VueQueryPlugin, { queryClient }]],
+    });
+
+    const { queryFn } = vi.mocked(VueQuery.useQuery).mock.calls[0][0];
+    await expect(queryFn()).rejects.toThrow(/status 403/);
+  });
+
+  it('unwraps a reactive scopeId and stays disabled until it is present', async () => {
+    const scopeId = ref(null);
+    const authStore = useAuthStore(piniaInstance);
+    authStore.accessToken = 'test-token';
+
+    withSetup(() => useAdministrationScoreOverviewQuery(nanoid(), 'school', scopeId), {
+      plugins: [[VueQuery.VueQueryPlugin, { queryClient }]],
+    });
+
+    const call = vi.mocked(VueQuery.useQuery).mock.calls[0][0];
+    expect(call.enabled.value).toBe(false);
+
+    scopeId.value = nanoid();
+    await nextTick();
+
+    expect(call.enabled.value).toBe(true);
+  });
+
+  it('stays disabled until the access token is available', async () => {
+    const authStore = useAuthStore(piniaInstance);
+    authStore.accessToken = null;
+
+    withSetup(() => useAdministrationScoreOverviewQuery(nanoid(), 'school', nanoid()), {
+      plugins: [[VueQuery.VueQueryPlugin, { queryClient }]],
+    });
+
+    const call = vi.mocked(VueQuery.useQuery).mock.calls[0][0];
+    expect(call.enabled.value).toBe(false);
+
+    authStore.accessToken = 'test-token';
+    await nextTick();
+
+    expect(call.enabled.value).toBe(true);
+  });
+
+  it('does not retry terminal auth / rostering-ended errors but retries transient ones up to 3x', () => {
+    const authStore = useAuthStore(piniaInstance);
+    authStore.accessToken = 'test-token';
+
+    let retryFn;
+    vi.spyOn(VueQuery, 'useQuery').mockImplementation((options) => {
+      retryFn = options.retry;
+      return { data: { value: null }, error: { value: null } };
+    });
+
+    withSetup(() => useAdministrationScoreOverviewQuery(nanoid(), 'school', nanoid()), {
+      plugins: [[VueQuery.VueQueryPlugin, { queryClient }]],
+    });
+
+    expect(retryFn(0, { body: { error: { code: 'auth/token-expired' } } })).toBe(false);
+    expect(retryFn(0, { body: { error: { code: 'auth/rostering-ended' } } })).toBe(false);
+    const networkError = new Error('network down');
+    expect(retryFn(2, networkError)).toBe(true);
+    expect(retryFn(3, networkError)).toBe(false);
+  });
+});

--- a/apps/dashboard/src/constants/queryKeys.js
+++ b/apps/dashboard/src/constants/queryKeys.js
@@ -5,6 +5,7 @@ export const ADMINISTRATION_QUERY_KEY = 'administration';
 export const ADMINISTRATION_ASSIGNMENTS_QUERY_KEY = 'administration-assignments';
 export const ADMINISTRATION_PROGRESS_QUERY_KEY = 'administration-progress';
 export const ADMINISTRATION_PROGRESS_OVERVIEW_QUERY_KEY = 'administration-progress-overview';
+export const ADMINISTRATION_SCORE_OVERVIEW_QUERY_KEY = 'administration-score-overview';
 export const ADMINISTRATION_ASSIGNEES_QUERY_KEY = 'administration-assignees';
 export const ADMINISTRATION_TASK_VARIANTS_QUERY_KEY = 'administration-task-variants';
 export const ADMINISTRATION_AGREEMENTS_QUERY_KEY = 'administration-agreements';

--- a/apps/dashboard/src/pages/ScoreReport.vue
+++ b/apps/dashboard/src/pages/ScoreReport.vue
@@ -58,11 +58,7 @@
                   <div v-for="taskId of sortedAndFilteredTaskIds" :key="taskId" style="width: 33%">
                     <div class="distribution-overview-wrapper">
                       <DistributionChartOverview
-                        :runs="
-                          props.orgType === 'district'
-                            ? aggregatedDistrictSupportCategories[taskId]
-                            : computeAssignmentAndRunData.runsByTaskId[taskId]
-                        "
+                        :support-level-counts="scoreOverviewBySlug[taskId]"
                         :initialized="initialized"
                         :task-id="taskId"
                         :org-type="props.orgType"
@@ -427,6 +423,7 @@ import { getDynamicRouterPath } from '@/helpers/getDynamicRouterPath';
 import useUserType from '@/composables/useUserType';
 import useUserClaimsQuery from '@/composables/queries/useUserClaimsQuery';
 import useAdministrationsQuery from '@/composables/queries/useAdministrationsQuery';
+import useAdministrationScoreOverviewQuery from '@/composables/queries/useAdministrationScoreOverviewQuery';
 import useOrgQuery from '@/composables/queries/useOrgQuery';
 import useDistrictSchoolsQuery from '@/composables/queries/useDistrictSchoolsQuery';
 import useAdministrationAssignmentsQuery from '@/composables/queries/useAdministrationAssignmentsQuery';
@@ -515,6 +512,25 @@ const {
 } = useDistrictSupportCategoriesQuery(props.orgId, props.administrationId, {
   enabled: computed(() => initialized.value && props.orgType === 'district'),
 });
+
+// Server-computed support-level distributions per task: the source of the "at a glance"
+// chart VALUES, scoped to this org/class/group. Keyed by task slug to match the slug-based
+// `sortedAndFilteredTaskIds` the template iterates.
+//
+// NOTE (incremental): only the chart values move to the backend here. Which tasks show a
+// chart (`sortedAndFilteredTaskIds`) and the district loading / empty-state still derive
+// from the Firestore `useAdministrationAssignmentsQuery` / `useDistrictSupportCategoriesQuery`,
+// which also feed the table + subscore tables. They're unified onto the backend in the final
+// score-report cleanup PR once those components are migrated.
+const { data: scoreOverviewData } = useAdministrationScoreOverviewQuery(
+  props.administrationId,
+  props.orgType,
+  props.orgId,
+  { enabled: initialized },
+);
+const scoreOverviewBySlug = computed(() =>
+  Object.fromEntries((scoreOverviewData.value?.tasks ?? []).map((task) => [task.taskSlug, task.supportLevels])),
+);
 
 const getScoringVersions = computed(() => {
   if (!administrationData.value?.assessments) return {};

--- a/apps/dashboard/src/pages/ScoreReport.vue
+++ b/apps/dashboard/src/pages/ScoreReport.vue
@@ -43,13 +43,19 @@
                 </div>
               </template>
             </ReportHeader>
-            <div v-if="isLoadingAssignments || isLoadingDistrictSupportCategories" class="loading-wrapper">
+            <div
+              v-if="isLoadingAssignments || isLoadingDistrictSupportCategories || isLoadingScoreOverview"
+              class="loading-wrapper"
+            >
               <AppSpinner style="margin: 1rem 0rem" />
               <div class="text-sm font-light text-gray-600 uppercase">Loading Overview Charts</div>
             </div>
             <div
               v-if="
-                !isLoadingAssignments && !isLoadingDistrictSupportCategories && sortedAndFilteredTaskIds?.length > 0
+                !isLoadingAssignments &&
+                !isLoadingDistrictSupportCategories &&
+                !isLoadingScoreOverview &&
+                sortedAndFilteredTaskIds?.length > 0
               "
               class="py-3 mb-2 text-left bg-gray-100"
             >
@@ -522,7 +528,7 @@ const {
 // from the Firestore `useAdministrationAssignmentsQuery` / `useDistrictSupportCategoriesQuery`,
 // which also feed the table + subscore tables. They're unified onto the backend in the final
 // score-report cleanup PR once those components are migrated.
-const { data: scoreOverviewData } = useAdministrationScoreOverviewQuery(
+const { data: scoreOverviewData, isLoading: isLoadingScoreOverview } = useAdministrationScoreOverviewQuery(
   props.administrationId,
   props.orgType,
   props.orgId,


### PR DESCRIPTION
## Summary Copy

This PR cuts the score report's "at a glance" overview charts off Firestore onto the backend score-overview endpoint — the first slice of the score-report frontend migration. The top `DistributionChartOverview` pies previously derived from a client-side support-level aggregation (`computeAssignmentAndRunData.runsByTaskId` over the Firestore `useAdministrationAssignmentsQuery`, and `useDistrictSupportCategoriesQuery` at district scope); they now read server-computed distributions from `GET /v1/administrations/:id/reports/scores/overview`.

## Changes

- **`useAdministrationScoreOverviewQuery.js`** (new) — query composable for `client.administrations.scoreReports.getOverview`, scoped via `scopeType` + `scopeId`. Mirrors `useAdministrationProgressQuery`: token + scope gating via `computeQueryOverrides`, envelope unwrap, structured error throw, pinned retry policy, centralized query key. Not paginated (the endpoint aggregates across the scope). Unit test added.
- **`DistributionChartOverview.vue`** — added an **additive** `supportLevelCounts` prop. When provided, it is the chart's data source: the backend's `{ needsExtraSupport, developingSkill, achievedSkill: { count } }` is mapped to the chart's `[{ category, value }]` display shape. The legacy `runs` paths (per-run array / district aggregate object) are retained and unchanged, so existing callers are unaffected; a guard was added so an absent `runs` can't throw in the district branch.
- **`ScoreReport.vue`** — added the overview query and a `scoreOverviewBySlug` computed (maps the response's `tasks` by `taskSlug`, since the template iterates slug-keyed `sortedAndFilteredTaskIds`), and switched the chart binding from `:runs` to `:support-level-counts`. The client-side `runsByTaskId` / `aggregatedDistrictSupportCategories` remain only because the subscore tables still use them (later PRs).

## Behavior / parity

This PR moves the chart **values** (the support-level counts) to the backend at all scopes, including district. The display categories and color domain are unchanged. **Deliberately scoped — values only:** which tasks show a chart (`sortedAndFilteredTaskIds`) and the district loading / empty-state still derive from the existing Firestore queries (`useAdministrationAssignmentsQuery` / `useDistrictSupportCategoriesQuery`), which also feed the table + subscore tables. So even at non-district scope the chart task *selection* still depends on Firestore even though the bar values are now server-computed. Those gates are unified onto the backend in the final cleanup PR, once the table/subscores are migrated and the Firestore queries can be removed.

## Testing

- `useAdministrationScoreOverviewQuery.test.js` mirrors the reference composable tests (query key, scope params, envelope unwrap, gating, non-200 throw, retry policy). `prettier --check` and `@vue/compiler-sfc` compile pass for the changed components.
- ⚠️ **Manual spot-check needed before merge** (the authoring sandbox can't render the dashboard or run its vitest within the build-time cap): confirm the overview pies' counts match the prior client-computed pies for a known administration, especially at **district** scope; CI runs the unit test.

## Out of scope

- Admin-metadata swap (`useAdministrationsQuery` → singular `useAdministrationQuery`) — a deferred follow-up after the other report components migrate.
- Student table / facets / subscore tables / individual student report — separate PRs; the Firestore path stays until they land, then a cleanup PR deletes it.



> [!NOTE]
> **Cross-fork stacking.** Because intermediate branches live only on `richford`, a `yeatmanlab/roar-dashboard` PR cannot use one as its base — every PR in this series targets `project/backend-refactor`, and they are reviewed/merged **bottom-up** so each shows only its own slice once its parent merges.

> [!IMPORTANT]
> **Merge order:** first in its stack — targets `project/backend-refactor` directly.

Resolves #1961
Part of #1958