### PR TITLE
Bulk user import/update endpoint: POST /v1/users/import (needs rebase/adoption)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -205,6 +205,16 @@ jobs:
       # the job container (no official emulator-only Docker image).
       FIREBASE_AUTH_EMULATOR_HOST: 127.0.0.1:9099
       GCLOUD_PROJECT: demo-roar
+      # Firebase scrypt parameters for the bulk-import create bin. These are the
+      # PUBLIC values from Firebase's own documentation/known-answer test vector
+      # (also pinned in firebase-password-hash.test.ts) — NOT real project
+      # secrets. The import service hashes with these and passes the same params
+      # to importUsers, so the emulator round-trip is self-consistent regardless
+      # of the values. Real deployments inject the project's actual secrets.
+      FIREBASE_SCRYPT_SIGNER_KEY: jxspr8Ki0RYycVU8zykbdLGjFQ3McFUH0uiiTvC8pVMXAn210wjLNmdZJzxUECKbm0QsEmYUSDzZvpjeJ9WmXA==
+      FIREBASE_SCRYPT_SALT_SEPARATOR: Bw==
+      FIREBASE_SCRYPT_ROUNDS: "8"
+      FIREBASE_SCRYPT_MEM_COST: "14"
       # The dashboard bakes this into its bundle at build time so it can
       # reach the locally-running backend.
       VITE_ROAR_API_BASE_URL: http://127.0.0.1:4000

--- a/apps/backend/.env.example
+++ b/apps/backend/.env.example
@@ -36,3 +36,16 @@ FGA_MODEL_ID=
 #   When set, the FGA client uses Google identity tokens for authentication.
 #   Leave blank for local development (FGA runs without auth locally).
 FGA_OIDC_AUDIENCE=
+
+# Bulk user import (POST /v1/users/import)
+# - Firebase's modified-scrypt password-hash parameters for the Firebase project this backend
+#   authenticates against. Required by the bulk-import create bin: importUsers needs pre-hashed
+#   passwords. Find them in the Firebase console: Authentication → Users → ⋮ (top-right of the
+#   users table) → "Password hash parameters". SIGNER_KEY and SALT_SEPARATOR are base64 strings;
+#   ROUNDS and MEM_COST are integers. Each Firebase project (dev/staging/prod) has its own values.
+#   Against the Auth emulator any consistent values work (e.g. the public Firebase test vector),
+#   since the emulator verifies sign-in against the hash config the import call carries.
+FIREBASE_SCRYPT_SIGNER_KEY=
+FIREBASE_SCRYPT_SALT_SEPARATOR=
+FIREBASE_SCRYPT_ROUNDS=
+FIREBASE_SCRYPT_MEM_COST=

--- a/apps/backend/src/controllers/users.controller.ts
+++ b/apps/backend/src/controllers/users.controller.ts
@@ -4,12 +4,13 @@ import type {
   UserResponse,
   CreateUserRequestBody,
   UpdateUserRequestBody,
+  ImportUsersRequest,
   RecordUserAgreementRequestBody,
   GuardianStudentReportResponse,
   AdministrationsListQuery,
 } from '@roar-platform/api-contract';
 import { StatusCodes } from 'http-status-codes';
-import { UserService } from '../services/user';
+import { UserService, UserImportService } from '../services/user';
 import { ReportService } from '../services/report/report.service';
 import type { GuardianStudentReportResult } from '../services/report/report.types';
 import { AdministrationService } from '../services/administration/administration.service';
@@ -18,6 +19,7 @@ import { toErrorResponse } from '../utils/to-error-response.util';
 import { transformAdministration, transformAdministrationBase } from './utils/administration.transform';
 
 const userService = UserService();
+const userImportService = UserImportService();
 const administrationService = AdministrationService();
 const reportService = ReportService();
 
@@ -134,6 +136,37 @@ export const UsersController = {
           StatusCodes.TOO_MANY_REQUESTS,
           StatusCodes.INTERNAL_SERVER_ERROR,
         ]);
+      }
+      throw error;
+    }
+  },
+
+  /**
+   * Bulk create / update / unenroll users.
+   *
+   * Always returns 200 with a multi-status body for a well-formed, authenticated request — per-row
+   * outcomes (including failures) live in `results`, never in the HTTP status code. The `summary`
+   * totals each bin. Only a failure of the whole request before per-row processing maps to a 500.
+   */
+  bulkImport: async (authContext: AuthContext, body: ImportUsersRequest) => {
+    try {
+      const results = await userImportService.bulkImport(authContext, body.users);
+
+      const summary = {
+        total: results.length,
+        created: results.filter((r) => r.status === 'ok' && r.classification === 'created').length,
+        updated: results.filter((r) => r.status === 'ok' && r.classification === 'updated').length,
+        unenrolled: results.filter((r) => r.status === 'ok' && r.classification === 'unenrolled').length,
+        failed: results.filter((r) => r.status === 'failed').length,
+      };
+
+      return {
+        status: StatusCodes.OK as const,
+        body: { data: { results, summary } },
+      };
+    } catch (error) {
+      if (error instanceof ApiError) {
+        return toErrorResponse(error, [StatusCodes.INTERNAL_SERVER_ERROR]);
       }
       throw error;
     }

--- a/apps/backend/src/repositories/base.repository.ts
+++ b/apps/backend/src/repositories/base.repository.ts
@@ -234,8 +234,9 @@ export abstract class BaseRepository<
    * Updates an existing entity.
    */
   async update(params: BaseUpdateParams<InferInsertModel<TTable>>): Promise<void> {
+    const db = params.transaction ?? this.db;
     const idColumn = this.typedTable.id as Parameters<typeof eq>[0];
-    await this.db.update(this.typedTable).set(params.data).where(eq(idColumn, params.id));
+    await db.update(this.typedTable).set(params.data).where(eq(idColumn, params.id));
   }
 
   /**

--- a/apps/backend/src/repositories/user.repository.integration.test.ts
+++ b/apps/backend/src/repositories/user.repository.integration.test.ts
@@ -274,6 +274,34 @@ describe('UserRepository', () => {
 
       expect(await repository.getActiveMembershipsWithRoles(user.id)).toHaveLength(1);
     });
+
+    it('reconciles family memberships via the joinedOn/leftOn columns', async () => {
+      // Families use joinedOn/leftOn (not enrollmentStart/enrollmentEnd), so exercise that branch of
+      // endMembershipRow and upsertMembershipRow directly.
+      const user = await UserFactory.create();
+      const familyKept = await FamilyFactory.create();
+      const familyRemoved = await FamilyFactory.create();
+      const familyAdded = await FamilyFactory.create();
+      await UserFamilyFactory.create({ userId: user.id, familyId: familyKept.id, role: 'parent' });
+      await UserFamilyFactory.create({ userId: user.id, familyId: familyRemoved.id, role: 'parent' });
+
+      const current = await repository.getActiveMembershipsWithRoles(user.id);
+      const desired = [
+        { entityType: EntityType.FAMILY, entityId: familyKept.id, role: 'parent' },
+        { entityType: EntityType.FAMILY, entityId: familyAdded.id, role: 'parent' },
+      ];
+
+      const result = await repository.runTransaction({
+        fn: (tx) => repository.reconcileMemberships(user.id, desired, current, tx),
+      });
+
+      expect(result.removed.map((m) => m.entityId)).toEqual([familyRemoved.id]);
+      expect(result.added.map((m) => m.entityId)).toEqual([familyAdded.id]);
+
+      const afterIds = (await repository.getActiveMembershipsWithRoles(user.id)).map((m) => m.entityId);
+      expect(afterIds).toEqual(expect.arrayContaining([familyKept.id, familyAdded.id]));
+      expect(afterIds).not.toContain(familyRemoved.id);
+    });
   });
 
   describe('findClassParentSchool', () => {

--- a/apps/backend/src/repositories/user.repository.integration.test.ts
+++ b/apps/backend/src/repositories/user.repository.integration.test.ts
@@ -15,6 +15,7 @@ import { GroupFactory } from '../test-support/factories/group.factory';
 import { FamilyFactory } from '../test-support/factories/family.factory';
 import { UserFamilyFactory } from '../test-support/factories/user-family.factory';
 import { UserRole } from '../enums/user-role.enum';
+import { EntityType } from '../types/entity-type';
 import { UserType } from '../enums/user-type.enum';
 import { AuthProvider } from '../enums/auth-provider.enum';
 import { UserRepository } from './user.repository';
@@ -229,6 +230,49 @@ describe('UserRepository', () => {
       await repository.archiveUser(user.id);
 
       expect((await repository.getById({ id: user.id }))!.rosteringEnded).not.toBeNull();
+    });
+  });
+
+  describe('reconcileMemberships', () => {
+    it('ends removed, adds new, and leaves unchanged memberships (per provided type)', async () => {
+      const user = await UserFactory.create();
+      const groupKept = await GroupFactory.create();
+      const groupRemoved = await GroupFactory.create();
+      const groupAdded = await GroupFactory.create();
+      await UserGroupFactory.create({ userId: user.id, groupId: groupKept.id, role: UserRole.STUDENT });
+      await UserGroupFactory.create({ userId: user.id, groupId: groupRemoved.id, role: UserRole.STUDENT });
+
+      const current = await repository.getActiveMembershipsWithRoles(user.id);
+      const desired = [
+        { entityType: EntityType.GROUP, entityId: groupKept.id, role: 'student' },
+        { entityType: EntityType.GROUP, entityId: groupAdded.id, role: 'student' },
+      ];
+
+      const result = await repository.runTransaction({
+        fn: (tx) => repository.reconcileMemberships(user.id, desired, current, tx),
+      });
+
+      expect(result.removed.map((m) => m.entityId)).toEqual([groupRemoved.id]);
+      expect(result.added.map((m) => m.entityId)).toEqual([groupAdded.id]);
+
+      const afterIds = (await repository.getActiveMembershipsWithRoles(user.id)).map((m) => m.entityId);
+      expect(afterIds).toEqual(expect.arrayContaining([groupKept.id, groupAdded.id]));
+      expect(afterIds).not.toContain(groupRemoved.id);
+    });
+
+    it('reactivates a previously-ended membership via upsert', async () => {
+      const user = await UserFactory.create();
+      const group = await GroupFactory.create();
+      await UserGroupFactory.create({ userId: user.id, groupId: group.id, role: UserRole.STUDENT });
+      await repository.endAllEnrollments(user.id);
+      expect(await repository.getActiveMembershipsWithRoles(user.id)).toHaveLength(0);
+
+      const desired = [{ entityType: EntityType.GROUP, entityId: group.id, role: 'student' }];
+      await repository.runTransaction({
+        fn: (tx) => repository.reconcileMemberships(user.id, desired, [], tx),
+      });
+
+      expect(await repository.getActiveMembershipsWithRoles(user.id)).toHaveLength(1);
     });
   });
 

--- a/apps/backend/src/repositories/user.repository.integration.test.ts
+++ b/apps/backend/src/repositories/user.repository.integration.test.ts
@@ -155,6 +155,49 @@ describe('UserRepository', () => {
     });
   });
 
+  describe('findByEmails', () => {
+    it('returns users matching the emails, case-insensitively', async () => {
+      const user = await UserFactory.create({ email: 'Found.User@example.org' });
+
+      const result = await repository.findByEmails(['found.user@EXAMPLE.org', 'missing@example.org']);
+
+      expect(result).toHaveLength(1);
+      expect(result[0]!.id).toBe(user.id);
+    });
+
+    it('returns an empty array for empty input', async () => {
+      expect(await repository.findByEmails([])).toEqual([]);
+    });
+  });
+
+  describe('endAllEnrollments', () => {
+    it('ends every active org, class, and family enrollment for the user', async () => {
+      const user = await UserFactory.create();
+      const family = await FamilyFactory.create();
+      await UserOrgFactory.create({ userId: user.id, orgId: baseFixture.district.id, role: UserRole.ADMINISTRATOR });
+      await UserClassFactory.create({
+        userId: user.id,
+        classId: baseFixture.classInSchoolA.id,
+        role: UserRole.TEACHER,
+      });
+      await UserFamilyFactory.create({ userId: user.id, familyId: family.id, role: 'parent' });
+
+      expect(await repository.getUserEntityMemberships(user.id)).not.toHaveLength(0);
+
+      await repository.endAllEnrollments(user.id);
+
+      // Every enrollment is now ended, so none are active.
+      expect(await repository.getUserEntityMemberships(user.id)).toHaveLength(0);
+    });
+
+    it('is a no-op for a user with no enrollments', async () => {
+      const user = await UserFactory.create();
+
+      await expect(repository.endAllEnrollments(user.id)).resolves.toBeUndefined();
+      expect(await repository.getUserEntityMemberships(user.id)).toHaveLength(0);
+    });
+  });
+
   describe('findClassParentSchool', () => {
     it('returns the parent school id for a class that exists', async () => {
       const result = await repository.findClassParentSchool(baseFixture.classInSchoolA.id);

--- a/apps/backend/src/repositories/user.repository.integration.test.ts
+++ b/apps/backend/src/repositories/user.repository.integration.test.ts
@@ -10,6 +10,7 @@ import { baseFixture } from '../test-support/fixtures';
 import { UserFactory } from '../test-support/factories/user.factory';
 import { UserOrgFactory } from '../test-support/factories/user-org.factory';
 import { UserClassFactory } from '../test-support/factories/user-class.factory';
+import { UserGroupFactory } from '../test-support/factories/user-group.factory';
 import { GroupFactory } from '../test-support/factories/group.factory';
 import { FamilyFactory } from '../test-support/factories/family.factory';
 import { UserFamilyFactory } from '../test-support/factories/user-family.factory';
@@ -171,10 +172,12 @@ describe('UserRepository', () => {
   });
 
   describe('endAllEnrollments', () => {
-    it('ends every active org, class, and family enrollment for the user', async () => {
+    it('ends every active org, class, group, and family enrollment for the user', async () => {
       const user = await UserFactory.create();
       const family = await FamilyFactory.create();
+      const group = await GroupFactory.create();
       await UserOrgFactory.create({ userId: user.id, orgId: baseFixture.district.id, role: UserRole.ADMINISTRATOR });
+      await UserGroupFactory.create({ userId: user.id, groupId: group.id, role: UserRole.STUDENT });
       await UserClassFactory.create({
         userId: user.id,
         classId: baseFixture.classInSchoolA.id,

--- a/apps/backend/src/repositories/user.repository.integration.test.ts
+++ b/apps/backend/src/repositories/user.repository.integration.test.ts
@@ -198,6 +198,37 @@ describe('UserRepository', () => {
     });
   });
 
+  describe('getActiveMembershipsWithRoles', () => {
+    it('returns active memberships with their roles', async () => {
+      const user = await UserFactory.create();
+      await UserOrgFactory.create({ userId: user.id, orgId: baseFixture.district.id, role: UserRole.ADMINISTRATOR });
+
+      const result = await repository.getActiveMembershipsWithRoles(user.id);
+
+      const districtMembership = result.find((m) => m.entityId === baseFixture.district.id);
+      expect(districtMembership).toMatchObject({ entityType: 'district', role: UserRole.ADMINISTRATOR });
+    });
+
+    it('excludes ended enrollments', async () => {
+      const user = await UserFactory.create();
+      await UserOrgFactory.create({ userId: user.id, orgId: baseFixture.district.id, role: UserRole.ADMINISTRATOR });
+      await repository.endAllEnrollments(user.id);
+
+      expect(await repository.getActiveMembershipsWithRoles(user.id)).toHaveLength(0);
+    });
+  });
+
+  describe('archiveUser', () => {
+    it('stamps rosteringEnded on the user', async () => {
+      const user = await UserFactory.create();
+      expect((await repository.getById({ id: user.id }))!.rosteringEnded).toBeNull();
+
+      await repository.archiveUser(user.id);
+
+      expect((await repository.getById({ id: user.id }))!.rosteringEnded).not.toBeNull();
+    });
+  });
+
   describe('findClassParentSchool', () => {
     it('returns the parent school id for a class that exists', async () => {
       const result = await repository.findClassParentSchool(baseFixture.classInSchoolA.id);

--- a/apps/backend/src/repositories/user.repository.ts
+++ b/apps/backend/src/repositories/user.repository.ts
@@ -1,4 +1,4 @@
-import { eq, and, or, isNull } from 'drizzle-orm';
+import { eq, and, or, isNull, inArray, sql } from 'drizzle-orm';
 import type { NodePgDatabase } from 'drizzle-orm/node-postgres';
 import type { User, NewUser, NewUserOrg, NewUserClass, NewUserGroup, NewUserFamily } from '../db/schema';
 import { EntityType } from '../types/entity-type';
@@ -220,5 +220,32 @@ export class UserRepository extends BaseRepository<User, typeof users> {
       .limit(1);
 
     return row !== undefined;
+  }
+
+  /**
+   * Find all users whose email matches any in the provided list, case-insensitively.
+   *
+   * Used by the bulk-import pre-flight to classify each row as create vs. update/unenroll by
+   * existence. Matching is case-insensitive to mirror the legacy classification (Firebase Auth
+   * treats emails case-insensitively) and to avoid misclassifying a cased variant as a new create
+   * that would then collide at Firebase. Rostered-out users are included — their email still
+   * occupies the unique field — so a re-import resolves to the existing user rather than a create.
+   *
+   * @param emails - The emails to look up.
+   * @returns The matching user records (may be fewer than the input when some don't exist).
+   *
+   * @NOTE The `lower(email)` predicate won't use the plain email index. For the bulk-import batch
+   *   size (≤100) against admin-initiated requests this is acceptable; a functional index on
+   *   `lower(email)` (or normalizing emails to lowercase on write) would remove the scan at scale.
+   */
+  async findByEmails(emails: string[]): Promise<User[]> {
+    if (emails.length === 0) return [];
+
+    const lowered = emails.map((email) => email.toLowerCase());
+
+    return this.db
+      .select()
+      .from(users)
+      .where(inArray(sql<string>`lower(${users.email})`, lowered));
   }
 }

--- a/apps/backend/src/repositories/user.repository.ts
+++ b/apps/backend/src/repositories/user.repository.ts
@@ -283,4 +283,66 @@ export class UserRepository extends BaseRepository<User, typeof users> {
       .set({ leftOn: endedAt })
       .where(and(eq(userFamilies.userId, userId), isNull(userFamilies.leftOn)));
   }
+
+  /**
+   * Return a user's active memberships with their roles, across orgs, classes, groups, and families.
+   *
+   * Mirrors {@link getUserEntityMemberships} (same active-enrollment filtering and org-type mapping)
+   * but additionally returns the role, which the unenroll flow needs to reconstruct the FGA tuples to
+   * delete. Org memberships with FGA-unsupported org types are dropped (logged by
+   * {@link getUserEntityMemberships}).
+   *
+   * @param userId - The user to look up.
+   * @returns Active memberships as `{ entityType, entityId, role }`.
+   */
+  async getActiveMembershipsWithRoles(
+    userId: string,
+  ): Promise<{ entityType: EntityType; entityId: string; role: string }[]> {
+    const [orgRows, classRows, groupRows, familyRows] = await Promise.all([
+      this.db
+        .select({ entityId: userOrgs.orgId, orgType: orgs.orgType, role: userOrgs.role })
+        .from(userOrgs)
+        .innerJoin(orgs, eq(userOrgs.orgId, orgs.id))
+        .where(and(eq(userOrgs.userId, userId), isEnrollmentActive(userOrgs))),
+      this.db
+        .select({ entityId: userClasses.classId, role: userClasses.role })
+        .from(userClasses)
+        .where(and(eq(userClasses.userId, userId), isEnrollmentActive(userClasses))),
+      this.db
+        .select({ entityId: userGroups.groupId, role: userGroups.role })
+        .from(userGroups)
+        .where(and(eq(userGroups.userId, userId), isEnrollmentActive(userGroups))),
+      this.db
+        .select({ entityId: userFamilies.familyId, role: userFamilies.role })
+        .from(userFamilies)
+        .where(and(eq(userFamilies.userId, userId), isActiveInFamily(userFamilies))),
+    ]);
+
+    const FGA_SUPPORTED_ORG_TYPES: ReadonlySet<string> = new Set([EntityType.DISTRICT, EntityType.SCHOOL]);
+    const orgMemberships: { entityType: EntityType; entityId: string; role: string }[] = [];
+    for (const row of orgRows) {
+      if (FGA_SUPPORTED_ORG_TYPES.has(row.orgType)) {
+        orgMemberships.push({ entityType: row.orgType as EntityType, entityId: row.entityId, role: row.role });
+      }
+    }
+
+    return [
+      ...orgMemberships,
+      ...classRows.map((r) => ({ entityType: EntityType.CLASS, entityId: r.entityId, role: r.role })),
+      ...groupRows.map((r) => ({ entityType: EntityType.GROUP, entityId: r.entityId, role: r.role })),
+      ...familyRows.map((r) => ({ entityType: EntityType.FAMILY, entityId: r.entityId, role: r.role })),
+    ];
+  }
+
+  /**
+   * Archive a user by stamping `rosteringEnded`. Used by the bulk-import unenroll bin alongside
+   * {@link endAllEnrollments}; pass the same transaction so both land atomically.
+   *
+   * @param userId - The user to archive.
+   * @param transaction - Optional transaction to run within.
+   */
+  async archiveUser(userId: string, transaction?: CoreTransaction): Promise<void> {
+    const db = transaction ?? this.db;
+    await db.update(users).set({ rosteringEnded: new Date() }).where(eq(users.id, userId));
+  }
 }

--- a/apps/backend/src/repositories/user.repository.ts
+++ b/apps/backend/src/repositories/user.repository.ts
@@ -2,6 +2,8 @@ import { eq, and, or, isNull, inArray, sql } from 'drizzle-orm';
 import type { NodePgDatabase } from 'drizzle-orm/node-postgres';
 import type { User, NewUser, NewUserOrg, NewUserClass, NewUserGroup, NewUserFamily } from '../db/schema';
 import { EntityType } from '../types/entity-type';
+import type { UserRole } from '../enums/user-role.enum';
+import type { UserFamilyRole } from '../enums/user-family-role.enum';
 import { users, userOrgs, userClasses, userGroups, userFamilies, orgs, classes } from '../db/schema';
 import { CoreDbClient } from '../db/clients';
 import type { CoreTransaction } from '../db/clients';
@@ -344,5 +346,169 @@ export class UserRepository extends BaseRepository<User, typeof users> {
   async archiveUser(userId: string, transaction?: CoreTransaction): Promise<void> {
     const db = transaction ?? this.db;
     await db.update(users).set({ rosteringEnded: new Date() }).where(eq(users.id, userId));
+  }
+
+  /**
+   * Reconcile a user's memberships to match `desired`, with replace-semantics per entity type (the
+   * legacy `batchImportUpdate` behavior): for every entity type the desired list mentions, memberships
+   * present now but not desired are ended, desired memberships not present now are added, and
+   * memberships in both are left untouched. Entity types `desired` doesn't mention are left alone.
+   *
+   * Adds use an upsert, so a previously-ended membership (e.g. a student returning to a prior school)
+   * is reactivated rather than colliding with its existing junction row. `current` is supplied by the
+   * caller so the diff and the writes share the caller's transaction context.
+   *
+   * @param userId - The user to reconcile.
+   * @param desired - The membership set the row asks for (with roles).
+   * @param current - The user's current active memberships (with roles).
+   * @param transaction - The active transaction.
+   * @returns The memberships added and removed (with roles), so the caller can sync FGA tuples.
+   */
+  async reconcileMemberships(
+    userId: string,
+    desired: { entityType: EntityType; entityId: string; role: string }[],
+    current: { entityType: EntityType; entityId: string; role: string }[],
+    transaction: CoreTransaction,
+  ): Promise<{
+    added: { entityType: EntityType; entityId: string; role: string }[];
+    removed: { entityType: EntityType; entityId: string; role: string }[];
+  }> {
+    const groupByType = (list: { entityType: EntityType; entityId: string; role: string }[]) => {
+      const byType = new Map<EntityType, Map<string, string>>();
+      for (const m of list) {
+        const ids = byType.get(m.entityType) ?? new Map<string, string>();
+        ids.set(m.entityId, m.role);
+        byType.set(m.entityType, ids);
+      }
+      return byType;
+    };
+
+    const desiredByType = groupByType(desired);
+    const currentByType = groupByType(current);
+
+    const added: { entityType: EntityType; entityId: string; role: string }[] = [];
+    const removed: { entityType: EntityType; entityId: string; role: string }[] = [];
+    const now = new Date();
+
+    for (const [entityType, desiredIds] of desiredByType) {
+      const currentIds = currentByType.get(entityType) ?? new Map<string, string>();
+
+      // End memberships present now but no longer desired.
+      for (const [entityId, role] of currentIds) {
+        if (!desiredIds.has(entityId)) {
+          await this.endMembershipRow(entityType, userId, entityId, now, transaction);
+          removed.push({ entityType, entityId, role });
+        }
+      }
+
+      // Add (or reactivate) desired memberships not present now.
+      for (const [entityId, role] of desiredIds) {
+        if (!currentIds.has(entityId)) {
+          await this.upsertMembershipRow(entityType, userId, entityId, role, now, transaction);
+          added.push({ entityType, entityId, role });
+        }
+      }
+    }
+
+    return { added, removed };
+  }
+
+  /** End a single membership row (stamp the end date) for the given entity type. */
+  private async endMembershipRow(
+    entityType: EntityType,
+    userId: string,
+    entityId: string,
+    endedAt: Date,
+    tx: CoreTransaction,
+  ): Promise<void> {
+    switch (entityType) {
+      case EntityType.DISTRICT:
+      case EntityType.SCHOOL:
+        await tx
+          .update(userOrgs)
+          .set({ enrollmentEnd: endedAt })
+          .where(and(eq(userOrgs.userId, userId), eq(userOrgs.orgId, entityId)));
+        return;
+      case EntityType.CLASS:
+        await tx
+          .update(userClasses)
+          .set({ enrollmentEnd: endedAt })
+          .where(and(eq(userClasses.userId, userId), eq(userClasses.classId, entityId)));
+        return;
+      case EntityType.GROUP:
+        await tx
+          .update(userGroups)
+          .set({ enrollmentEnd: endedAt })
+          .where(and(eq(userGroups.userId, userId), eq(userGroups.groupId, entityId)));
+        return;
+      case EntityType.FAMILY:
+        await tx
+          .update(userFamilies)
+          .set({ leftOn: endedAt })
+          .where(and(eq(userFamilies.userId, userId), eq(userFamilies.familyId, entityId)));
+        return;
+    }
+  }
+
+  /** Insert a membership row, reactivating it (clear end date, refresh role + start) on conflict. */
+  private async upsertMembershipRow(
+    entityType: EntityType,
+    userId: string,
+    entityId: string,
+    role: string,
+    startedAt: Date,
+    tx: CoreTransaction,
+  ): Promise<void> {
+    switch (entityType) {
+      case EntityType.DISTRICT:
+      case EntityType.SCHOOL:
+        await tx
+          .insert(userOrgs)
+          .values({ userId, orgId: entityId, role: role as UserRole, enrollmentStart: startedAt, enrollmentEnd: null })
+          .onConflictDoUpdate({
+            target: [userOrgs.userId, userOrgs.orgId],
+            set: { role: role as UserRole, enrollmentStart: startedAt, enrollmentEnd: null },
+          });
+        return;
+      case EntityType.CLASS:
+        await tx
+          .insert(userClasses)
+          .values({
+            userId,
+            classId: entityId,
+            role: role as UserRole,
+            enrollmentStart: startedAt,
+            enrollmentEnd: null,
+          })
+          .onConflictDoUpdate({
+            target: [userClasses.userId, userClasses.classId],
+            set: { role: role as UserRole, enrollmentStart: startedAt, enrollmentEnd: null },
+          });
+        return;
+      case EntityType.GROUP:
+        await tx
+          .insert(userGroups)
+          .values({
+            userId,
+            groupId: entityId,
+            role: role as UserRole,
+            enrollmentStart: startedAt,
+            enrollmentEnd: null,
+          })
+          .onConflictDoUpdate({
+            target: [userGroups.userId, userGroups.groupId],
+            set: { role: role as UserRole, enrollmentStart: startedAt, enrollmentEnd: null },
+          });
+        return;
+      case EntityType.FAMILY:
+        await tx
+          .insert(userFamilies)
+          .values({ userId, familyId: entityId, role: role as UserFamilyRole, joinedOn: startedAt, leftOn: null })
+          .onConflictDoUpdate({
+            target: [userFamilies.userId, userFamilies.familyId],
+            set: { role: role as UserFamilyRole, joinedOn: startedAt, leftOn: null },
+          });
+        return;
+    }
   }
 }

--- a/apps/backend/src/repositories/user.repository.ts
+++ b/apps/backend/src/repositories/user.repository.ts
@@ -358,6 +358,11 @@ export class UserRepository extends BaseRepository<User, typeof users> {
    * is reactivated rather than colliding with its existing junction row. `current` is supplied by the
    * caller so the diff and the writes share the caller's transaction context.
    *
+   * Reconciliation is by presence only: a membership present in both `current` and `desired` is left
+   * untouched even if its role differs, so a re-import does not change the role of an existing
+   * membership (matching the legacy behavior and avoiding needless FGA churn). Within a single entity
+   * type, a duplicate `entityId` in `desired` collapses to its last role.
+   *
    * @param userId - The user to reconcile.
    * @param desired - The membership set the row asks for (with roles).
    * @param current - The user's current active memberships (with roles).

--- a/apps/backend/src/repositories/user.repository.ts
+++ b/apps/backend/src/repositories/user.repository.ts
@@ -248,4 +248,39 @@ export class UserRepository extends BaseRepository<User, typeof users> {
       .from(users)
       .where(inArray(sql<string>`lower(${users.email})`, lowered));
   }
+
+  /**
+   * End all of a user's currently-active enrollments by stamping the end date on every open junction
+   * row across orgs, classes, groups, and families.
+   *
+   * Used by the bulk-import unenroll bin, which — matching the legacy `batchImportUpdate` — ends ALL
+   * of a user's enrollments (not just the memberships named in the request). Already-ended rows are
+   * left untouched so their original end date is preserved.
+   *
+   * @param userId - The user whose enrollments to end.
+   * @param transaction - Optional transaction so the caller can archive the user and clean up FGA in
+   *   the same unit of work.
+   */
+  async endAllEnrollments(userId: string, transaction?: CoreTransaction): Promise<void> {
+    const db = transaction ?? this.db;
+    const endedAt = new Date();
+
+    // Sequential (not Promise.all) so this is safe inside a single transaction/connection.
+    await db
+      .update(userOrgs)
+      .set({ enrollmentEnd: endedAt })
+      .where(and(eq(userOrgs.userId, userId), isNull(userOrgs.enrollmentEnd)));
+    await db
+      .update(userClasses)
+      .set({ enrollmentEnd: endedAt })
+      .where(and(eq(userClasses.userId, userId), isNull(userClasses.enrollmentEnd)));
+    await db
+      .update(userGroups)
+      .set({ enrollmentEnd: endedAt })
+      .where(and(eq(userGroups.userId, userId), isNull(userGroups.enrollmentEnd)));
+    await db
+      .update(userFamilies)
+      .set({ leftOn: endedAt })
+      .where(and(eq(userFamilies.userId, userId), isNull(userFamilies.leftOn)));
+  }
 }

--- a/apps/backend/src/routes/users.ts
+++ b/apps/backend/src/routes/users.ts
@@ -23,6 +23,10 @@ export function registerUserRoutes(routerInstance: Router) {
       middleware: [AuthGuardMiddleware],
       handler: async ({ req: { user }, body }) => UsersController.create(user!, body),
     },
+    bulkImport: {
+      middleware: [AuthGuardMiddleware],
+      handler: async ({ req: { user }, body }) => UsersController.bulkImport(user!, body),
+    },
     update: {
       middleware: [AuthGuardMiddleware],
       handler: async ({ req: { user }, params: { id }, body }) => UsersController.update(user!, id, body),

--- a/apps/backend/src/services/user/index.ts
+++ b/apps/backend/src/services/user/index.ts
@@ -1,1 +1,2 @@
 export { UserService } from './user.service';
+export { UserImportService } from './user-import.service';

--- a/apps/backend/src/services/user/user-import.service.test.ts
+++ b/apps/backend/src/services/user/user-import.service.test.ts
@@ -12,6 +12,7 @@ import { FIREBASE_ERROR_CODES } from '../../constants/firebase-error-codes';
 import { UserRole } from '../../enums/user-role.enum';
 import { UserType } from '../../enums/user-type.enum';
 import { EntityType } from '../../types/entity-type';
+import { FGA_CONDITION_ACTIVE_MEMBERSHIP } from '../authorization/fga-constants';
 import type { FirebaseScryptParams } from './utils/firebase-password-hash';
 import type { CoreTransaction } from '../../db/clients';
 
@@ -476,10 +477,9 @@ describe('UserImportService.bulkImport', () => {
       expect(updateUser).not.toHaveBeenCalled();
     });
 
-    it('reconciles memberships and syncs FGA tuples (write added, delete removed)', async () => {
-      mockUserRepository.getActiveMembershipsWithRoles.mockResolvedValue([
-        { entityType: EntityType.SCHOOL, entityId: 'school-1', role: 'student' },
-      ]);
+    it('reconciles memberships and syncs FGA tuples with the right shapes', async () => {
+      const user = existing();
+      mockUserRepository.findByEmails.mockResolvedValue([user]);
       mockUserRepository.reconcileMemberships.mockResolvedValue({
         added: [{ entityType: EntityType.SCHOOL, entityId: 'school-2', role: 'student' }],
         removed: [{ entityType: EntityType.SCHOOL, entityId: 'school-1', role: 'student' }],
@@ -492,10 +492,74 @@ describe('UserImportService.bulkImport', () => {
         }),
       ]);
 
-      expect(mockUserRepository.reconcileMemberships).toHaveBeenCalled();
-      expect(mockAuthz.writeTuplesOrThrow).toHaveBeenCalled(); // tuple for the added membership
-      expect(mockAuthz.deleteTuples).toHaveBeenCalled(); // tuple for the removed membership
+      // Added membership → condition-carrying tuple (identical shape to single-create). Without the
+      // active_membership condition the grant would never evaluate true, so assert it explicitly.
+      expect(mockAuthz.writeTuplesOrThrow).toHaveBeenCalledWith([
+        {
+          user: `user:${user.id}`,
+          relation: 'student',
+          object: 'school:school-2',
+          condition: expect.objectContaining({ name: FGA_CONDITION_ACTIVE_MEMBERSHIP }),
+        },
+      ]);
+      // Removed membership → key-only deletion tuple (no condition; FGA deletes by key).
+      expect(mockAuthz.deleteTuples).toHaveBeenCalledWith([
+        { user: `user:${user.id}`, relation: 'student', object: 'school:school-1' },
+      ]);
       expect(results[0]!).toMatchObject({ classification: 'updated', status: 'ok' });
+    });
+
+    it('revokes before granting so a failed grant-write cannot strand a removed tuple', async () => {
+      mockUserRepository.reconcileMemberships.mockResolvedValue({
+        added: [{ entityType: EntityType.SCHOOL, entityId: 'school-2', role: 'student' }],
+        removed: [{ entityType: EntityType.SCHOOL, entityId: 'school-1', role: 'student' }],
+      });
+      mockAuthz.writeTuplesOrThrow.mockRejectedValueOnce(new Error('fga down'));
+
+      const results = await buildService().bulkImport(superAdmin, [makeRow({ email: 'updatee@example.org' })]);
+
+      // The revocation must have run (and run first) even though the grant-write threw — otherwise the
+      // removed membership would stay authorized in FGA.
+      expect(mockAuthz.deleteTuples).toHaveBeenCalled();
+      const deleteOrder = mockAuthz.deleteTuples.mock.invocationCallOrder[0]!;
+      const writeOrder = mockAuthz.writeTuplesOrThrow.mock.invocationCallOrder[0]!;
+      expect(deleteOrder).toBeLessThan(writeOrder);
+      expect(results[0]!.status).toBe('failed');
+    });
+
+    it('uses the family relation when reconciliation adds a family membership', async () => {
+      const user = existing();
+      mockUserRepository.findByEmails.mockResolvedValue([user]);
+      mockUserRepository.reconcileMemberships.mockResolvedValue({
+        added: [{ entityType: EntityType.FAMILY, entityId: 'fam-1', role: 'parent' }],
+        removed: [],
+      });
+
+      await buildService().bulkImport(superAdmin, [makeRow({ email: 'updatee@example.org' })]);
+
+      expect(mockAuthz.writeTuplesOrThrow).toHaveBeenCalledWith([
+        {
+          user: `user:${user.id}`,
+          relation: 'parent',
+          object: 'family:fam-1',
+          condition: expect.objectContaining({ name: FGA_CONDITION_ACTIVE_MEMBERSHIP }),
+        },
+      ]);
+    });
+
+    it('writes and deletes no FGA tuple for an admin-tier class membership (add/delete symmetry)', async () => {
+      // administrator is not an FGA-valid class role — class admin access cascades via the org
+      // hierarchy. Such a membership reconciles in the DB but maps to zero tuples on both paths.
+      mockUserRepository.reconcileMemberships.mockResolvedValue({
+        added: [{ entityType: EntityType.CLASS, entityId: 'class-1', role: 'administrator' }],
+        removed: [{ entityType: EntityType.CLASS, entityId: 'class-2', role: 'administrator' }],
+      });
+
+      const results = await buildService().bulkImport(superAdmin, [makeRow({ email: 'updatee@example.org' })]);
+
+      expect(mockAuthz.writeTuplesOrThrow).not.toHaveBeenCalled();
+      expect(mockAuthz.deleteTuples).not.toHaveBeenCalled();
+      expect(results[0]!.status).toBe('ok');
     });
 
     it('does not touch FGA when reconciliation reports no membership change', async () => {

--- a/apps/backend/src/services/user/user-import.service.test.ts
+++ b/apps/backend/src/services/user/user-import.service.test.ts
@@ -75,6 +75,10 @@ describe('UserImportService.bulkImport', () => {
     mockUserService.createWithImportedAuth.mockImplementation(async () => ({ id: `new-user-${counter++}` }));
     mockUserRepository.runTransaction.mockImplementation(async ({ fn }) => fn({} as CoreTransaction));
     mockUserRepository.getActiveMembershipsWithRoles.mockResolvedValue([]);
+    // Default the update-bin membership-delta check to "no change" (matches makeRow's school-1).
+    mockUserRepository.getUserEntityMemberships.mockResolvedValue([
+      { entityType: EntityType.SCHOOL, entityId: 'school-1' },
+    ]);
   });
 
   describe('create bin', () => {
@@ -448,6 +452,47 @@ describe('UserImportService.bulkImport', () => {
 
       expect(results[0]!.status).toBe('failed');
       expect(results[1]!.status).toBe('ok');
+    });
+
+    it('does not write nameMiddle when the row omits it (no clobber)', async () => {
+      await buildService().bulkImport(superAdmin, [makeRow({ email: 'updatee@example.org' })]);
+
+      const updateData = mockUserRepository.update.mock.calls[0]![0].data;
+      expect(updateData).not.toHaveProperty('nameMiddle');
+    });
+
+    it('rejects an update to a rostering-ended (archived) user without writing anything', async () => {
+      mockUserRepository.findByEmails.mockResolvedValue([existing({ rosteringEnded: new Date() })]);
+
+      const results = await buildService().bulkImport(superAdmin, [makeRow({ email: 'updatee@example.org' })]);
+
+      expect(results[0]!).toMatchObject({
+        classification: 'updated',
+        status: 'failed',
+        error: { code: ApiErrorCode.RESOURCE_NOT_FOUND },
+      });
+      expect(mockUserRepository.update).not.toHaveBeenCalled();
+      expect(updateUser).not.toHaveBeenCalled();
+    });
+
+    it('fails (rather than silently ok) a row whose memberships differ from the current set', async () => {
+      mockUserRepository.getUserEntityMemberships.mockResolvedValue([
+        { entityType: EntityType.SCHOOL, entityId: 'school-1' },
+      ]);
+
+      const results = await buildService().bulkImport(superAdmin, [
+        makeRow({
+          email: 'updatee@example.org',
+          memberships: [{ entityType: EntityType.SCHOOL, entityId: 'school-2', role: UserRole.STUDENT }],
+        }),
+      ]);
+
+      expect(results[0]!).toMatchObject({
+        classification: 'updated',
+        status: 'failed',
+        error: { code: ApiErrorCode.RESOURCE_UNPROCESSABLE },
+      });
+      expect(mockUserRepository.update).not.toHaveBeenCalled();
     });
   });
 });

--- a/apps/backend/src/services/user/user-import.service.test.ts
+++ b/apps/backend/src/services/user/user-import.service.test.ts
@@ -1,0 +1,262 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { UserImportService, type ImportUserRowInput } from './user-import.service';
+import { createMockUserRepository } from '../../test-support/repositories/user.repository';
+import { createMockUserService } from '../../test-support/services/user.service';
+import { createMockAuthorizationService } from '../../test-support/services/authorization.service';
+import { UserFactory, AuthContextFactory } from '../../test-support/factories/user.factory';
+import { FirebaseAuthClient } from '../../clients/firebase-auth.clients';
+import { ApiError } from '../../errors/api-error';
+import { ApiErrorCode } from '../../enums/api-error-code.enum';
+import { ApiErrorMessage } from '../../enums/api-error-message.enum';
+import { FIREBASE_ERROR_CODES } from '../../constants/firebase-error-codes';
+import { UserRole } from '../../enums/user-role.enum';
+import { UserType } from '../../enums/user-type.enum';
+import { EntityType } from '../../types/entity-type';
+import type { FirebaseScryptParams } from './utils/firebase-password-hash';
+
+// Public Firebase scrypt test-vector params — fine for tests (no real secrets needed).
+const SCRYPT_PARAMS: FirebaseScryptParams = {
+  signerKey: Buffer.from(
+    'jxspr8Ki0RYycVU8zykbdLGjFQ3McFUH0uiiTvC8pVMXAn210wjLNmdZJzxUECKbm0QsEmYUSDzZvpjeJ9WmXA==',
+    'base64',
+  ),
+  saltSeparator: Buffer.from('Bw==', 'base64'),
+  rounds: 8,
+  memoryCost: 14,
+};
+
+const firebaseUserNotFound = Object.assign(new Error('no user'), { code: FIREBASE_ERROR_CODES.AUTH.USER_NOT_FOUND });
+
+const makeRow = (overrides: Partial<ImportUserRowInput> = {}): ImportUserRowInput => ({
+  email: 'student@example.org',
+  password: 'password123',
+  name: { first: 'Ada', last: 'Lovelace' },
+  userType: UserType.STUDENT,
+  memberships: [{ entityType: EntityType.SCHOOL, entityId: 'school-1', role: UserRole.STUDENT }],
+  ...overrides,
+});
+
+const forbidden = () => new ApiError(ApiErrorMessage.FORBIDDEN, { statusCode: 403, code: ApiErrorCode.AUTH_FORBIDDEN });
+
+describe('UserImportService.bulkImport', () => {
+  let mockUserRepository: ReturnType<typeof createMockUserRepository>;
+  let mockUserService: ReturnType<typeof createMockUserService>;
+  let mockAuthz: ReturnType<typeof createMockAuthorizationService>;
+  const getUserByEmail = vi.fn();
+  const importUsers = vi.fn();
+  const mockFirebaseAuth = { getUserByEmail, importUsers } as unknown as typeof FirebaseAuthClient;
+
+  const superAdmin = AuthContextFactory.build({ isSuperAdmin: true });
+  const partnerAdmin = AuthContextFactory.build({ isSuperAdmin: false });
+
+  const buildService = () =>
+    UserImportService({
+      userService: mockUserService,
+      userRepository: mockUserRepository,
+      authorizationService: mockAuthz,
+      firebaseAuth: mockFirebaseAuth,
+      scryptParams: SCRYPT_PARAMS,
+    });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUserRepository = createMockUserRepository();
+    mockUserService = createMockUserService();
+    mockAuthz = createMockAuthorizationService();
+
+    // Happy-path defaults: nobody exists yet, nothing collides, persistence succeeds.
+    mockUserRepository.findByEmails.mockResolvedValue([]);
+    mockUserRepository.existsByUniqueFields.mockResolvedValue(false);
+    mockUserRepository.findClassParentSchool.mockResolvedValue('school-parent');
+    mockAuthz.requirePermission.mockResolvedValue(undefined);
+    getUserByEmail.mockRejectedValue(firebaseUserNotFound);
+    importUsers.mockResolvedValue({ successCount: 0, failureCount: 0, errors: [] });
+    let counter = 0;
+    mockUserService.createWithImportedAuth.mockImplementation(async () => ({ id: `new-user-${counter++}` }));
+  });
+
+  describe('create bin', () => {
+    it('creates every row in a single importUsers call and persists each one', async () => {
+      const rows = [makeRow({ email: 'a@example.org' }), makeRow({ email: 'b@example.org' })];
+
+      const results = await buildService().bulkImport(superAdmin, rows);
+
+      expect(importUsers).toHaveBeenCalledTimes(1);
+      expect(importUsers.mock.calls[0]![0]).toHaveLength(2);
+      expect(mockUserService.createWithImportedAuth).toHaveBeenCalledTimes(2);
+      expect(results.every((r) => r.status === 'ok' && r.classification === 'created')).toBe(true);
+    });
+
+    it('passes the SCRYPT hash options to importUsers', async () => {
+      await buildService().bulkImport(superAdmin, [makeRow()]);
+
+      const options = importUsers.mock.calls[0]![1];
+      expect(options.hash.algorithm).toBe('SCRYPT');
+      expect(options.hash.rounds).toBe(8);
+      expect(options.hash.memoryCost).toBe(14);
+    });
+
+    it('marks a within-batch duplicate email as a conflict, processing the first occurrence', async () => {
+      const rows = [makeRow({ email: 'dup@example.org' }), makeRow({ email: 'DUP@example.org' })];
+
+      const results = await buildService().bulkImport(superAdmin, rows);
+
+      expect(results[0]!.status).toBe('ok');
+      expect(results[1]!).toMatchObject({ status: 'failed', error: { code: ApiErrorCode.RESOURCE_CONFLICT } });
+      expect(importUsers.mock.calls[0]![0]).toHaveLength(1);
+    });
+
+    it('fails a create row that is missing a password and excludes it from importUsers', async () => {
+      const results = await buildService().bulkImport(superAdmin, [makeRow({ password: undefined })]);
+
+      expect(results[0]!).toMatchObject({
+        status: 'failed',
+        classification: 'created',
+        error: { code: ApiErrorCode.REQUEST_VALIDATION_FAILED },
+      });
+      expect(importUsers).not.toHaveBeenCalled();
+    });
+
+    it('fails a create row that already exists in Postgres', async () => {
+      mockUserRepository.existsByUniqueFields.mockResolvedValue(true);
+
+      const results = await buildService().bulkImport(superAdmin, [makeRow()]);
+
+      expect(results[0]!).toMatchObject({ status: 'failed', error: { code: ApiErrorCode.RESOURCE_CONFLICT } });
+      expect(importUsers).not.toHaveBeenCalled();
+    });
+
+    it('fails a create row whose email already exists in Firebase Auth', async () => {
+      getUserByEmail.mockResolvedValue({ uid: 'existing' });
+
+      const results = await buildService().bulkImport(superAdmin, [makeRow()]);
+
+      expect(results[0]!).toMatchObject({ status: 'failed', error: { code: ApiErrorCode.RESOURCE_CONFLICT } });
+      expect(importUsers).not.toHaveBeenCalled();
+    });
+
+    it('fails only the row Firebase rejected in importUsers and persists the rest', async () => {
+      importUsers.mockResolvedValue({
+        successCount: 1,
+        failureCount: 1,
+        errors: [{ index: 0, error: { code: FIREBASE_ERROR_CODES.AUTH.EMAIL_ALREADY_EXISTS, message: 'exists' } }],
+      });
+
+      const rows = [makeRow({ email: 'a@example.org' }), makeRow({ email: 'b@example.org' })];
+      const results = await buildService().bulkImport(superAdmin, rows);
+
+      expect(results[0]!).toMatchObject({ status: 'failed', error: { code: ApiErrorCode.RESOURCE_CONFLICT } });
+      expect(results[1]!.status).toBe('ok');
+      // Only the surviving row is persisted.
+      expect(mockUserService.createWithImportedAuth).toHaveBeenCalledTimes(1);
+    });
+
+    it('fails only the row whose persistence throws, leaving the others successful', async () => {
+      mockUserService.createWithImportedAuth
+        .mockRejectedValueOnce(
+          new ApiError(ApiErrorMessage.CONFLICT, { statusCode: 409, code: ApiErrorCode.RESOURCE_CONFLICT }),
+        )
+        .mockResolvedValueOnce({ id: 'new-user-ok' });
+
+      const rows = [makeRow({ email: 'a@example.org' }), makeRow({ email: 'b@example.org' })];
+      const results = await buildService().bulkImport(superAdmin, rows);
+
+      expect(results[0]!).toMatchObject({ status: 'failed', error: { code: ApiErrorCode.RESOURCE_CONFLICT } });
+      expect(results[1]!).toMatchObject({ status: 'ok', id: 'new-user-ok' });
+    });
+
+    it('fails every prepared row when the whole importUsers call throws', async () => {
+      importUsers.mockRejectedValue(new Error('admin sdk unavailable'));
+
+      const results = await buildService().bulkImport(superAdmin, [makeRow()]);
+
+      expect(results[0]!).toMatchObject({ status: 'failed', error: { code: ApiErrorCode.EXTERNAL_SERVICE_FAILED } });
+      expect(mockUserService.createWithImportedAuth).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('classification', () => {
+    it('routes an existing user with no unenroll flag to the update bin', async () => {
+      mockUserRepository.findByEmails.mockResolvedValue([UserFactory.build({ email: 'exists@example.org' })]);
+
+      const results = await buildService().bulkImport(superAdmin, [makeRow({ email: 'exists@example.org' })]);
+
+      expect(results[0]!.classification).toBe('updated');
+      expect(results[0]!.status).toBe('failed'); // update bin not yet implemented
+      expect(importUsers).not.toHaveBeenCalled();
+    });
+
+    it('routes an existing user with unenroll=true to the unenroll bin', async () => {
+      mockUserRepository.findByEmails.mockResolvedValue([UserFactory.build({ email: 'exists@example.org' })]);
+
+      const results = await buildService().bulkImport(superAdmin, [
+        makeRow({ email: 'exists@example.org', unenroll: true }),
+      ]);
+
+      expect(results[0]!.classification).toBe('unenrolled');
+      expect(results[0]!.status).toBe('failed'); // unenroll bin not yet implemented
+    });
+
+    it('fails an unenroll request for a non-existent user', async () => {
+      const results = await buildService().bulkImport(superAdmin, [makeRow({ unenroll: true })]);
+
+      expect(results[0]!).toMatchObject({
+        status: 'failed',
+        classification: 'unenrolled',
+        error: { code: ApiErrorCode.RESOURCE_NOT_FOUND },
+      });
+    });
+
+    it('is case-insensitive when matching against existing users', async () => {
+      mockUserRepository.findByEmails.mockResolvedValue([UserFactory.build({ email: 'mixed@example.org' })]);
+
+      const results = await buildService().bulkImport(superAdmin, [makeRow({ email: 'MIXED@example.org' })]);
+
+      // Matched the existing user (routed to update), rather than treated as a new create.
+      expect(results[0]!.classification).toBe('updated');
+    });
+  });
+
+  describe('authorization', () => {
+    it('fails a row the partner admin cannot create, but continues the batch', async () => {
+      mockAuthz.requirePermission.mockRejectedValueOnce(forbidden()).mockResolvedValue(undefined);
+
+      const rows = [makeRow({ email: 'denied@example.org' }), makeRow({ email: 'allowed@example.org' })];
+      const results = await buildService().bulkImport(partnerAdmin, rows);
+
+      expect(results[0]!).toMatchObject({ status: 'failed', error: { code: ApiErrorCode.AUTH_FORBIDDEN } });
+      expect(results[1]!.status).toBe('ok');
+    });
+
+    it('bypasses FGA for super admins', async () => {
+      await buildService().bulkImport(superAdmin, [makeRow()]);
+
+      expect(mockAuthz.requirePermission).not.toHaveBeenCalled();
+    });
+
+    it('skips classification and import entirely when every row fails authorization', async () => {
+      mockAuthz.requirePermission.mockRejectedValue(forbidden());
+
+      const results = await buildService().bulkImport(partnerAdmin, [makeRow(), makeRow({ email: 'b@example.org' })]);
+
+      expect(results.every((r) => r.status === 'failed' && r.error.code === ApiErrorCode.AUTH_FORBIDDEN)).toBe(true);
+      expect(mockUserRepository.findByEmails).not.toHaveBeenCalled();
+      expect(importUsers).not.toHaveBeenCalled();
+    });
+
+    it('checks can_create_users against the parent school for class memberships', async () => {
+      const rows = [
+        makeRow({ memberships: [{ entityType: EntityType.CLASS, entityId: 'class-9', role: UserRole.STUDENT }] }),
+      ];
+
+      await buildService().bulkImport(partnerAdmin, rows);
+
+      expect(mockUserRepository.findClassParentSchool).toHaveBeenCalledWith('class-9');
+      expect(mockAuthz.requirePermission).toHaveBeenCalledWith(
+        partnerAdmin.userId,
+        expect.any(String),
+        'school:school-parent',
+      );
+    });
+  });
+});

--- a/apps/backend/src/services/user/user-import.service.test.ts
+++ b/apps/backend/src/services/user/user-import.service.test.ts
@@ -13,6 +13,7 @@ import { UserRole } from '../../enums/user-role.enum';
 import { UserType } from '../../enums/user-type.enum';
 import { EntityType } from '../../types/entity-type';
 import type { FirebaseScryptParams } from './utils/firebase-password-hash';
+import type { CoreTransaction } from '../../db/clients';
 
 // Public Firebase scrypt test-vector params — fine for tests (no real secrets needed).
 const SCRYPT_PARAMS: FirebaseScryptParams = {
@@ -71,6 +72,8 @@ describe('UserImportService.bulkImport', () => {
     importUsers.mockResolvedValue({ successCount: 0, failureCount: 0, errors: [] });
     let counter = 0;
     mockUserService.createWithImportedAuth.mockImplementation(async () => ({ id: `new-user-${counter++}` }));
+    mockUserRepository.runTransaction.mockImplementation(async ({ fn }) => fn({} as CoreTransaction));
+    mockUserRepository.getActiveMembershipsWithRoles.mockResolvedValue([]);
   });
 
   describe('create bin', () => {
@@ -306,9 +309,61 @@ describe('UserImportService.bulkImport', () => {
       const results = await buildService().bulkImport(superAdmin, rows);
 
       expect(results[0]!).toMatchObject({ classification: 'created', status: 'ok' });
-      // update + unenroll bins are not yet implemented, but routing is verified by classification.
+      // Update bin is not yet implemented; create + unenroll route and process independently.
       expect(results[1]!).toMatchObject({ classification: 'updated', status: 'failed' });
-      expect(results[2]!).toMatchObject({ classification: 'unenrolled', status: 'failed' });
+      expect(results[2]!).toMatchObject({ classification: 'unenrolled', status: 'ok' });
+    });
+  });
+
+  describe('unenroll bin', () => {
+    const existingUser = (email: string) => UserFactory.build({ email });
+
+    beforeEach(() => {
+      mockUserRepository.findByEmails.mockResolvedValue([existingUser('leaver@example.org')]);
+    });
+
+    it('ends enrollments, archives, and deletes the FGA membership tuples, returning ok', async () => {
+      mockUserRepository.getActiveMembershipsWithRoles.mockResolvedValue([
+        { entityType: EntityType.SCHOOL, entityId: 'school-9', role: UserRole.STUDENT },
+      ]);
+
+      const results = await buildService().bulkImport(superAdmin, [
+        makeRow({ email: 'leaver@example.org', unenroll: true }),
+      ]);
+
+      expect(mockUserRepository.endAllEnrollments).toHaveBeenCalled();
+      expect(mockUserRepository.archiveUser).toHaveBeenCalled();
+      expect(mockAuthz.deleteTuples).toHaveBeenCalledWith([
+        { user: expect.stringMatching(/^user:/), relation: UserRole.STUDENT, object: 'school:school-9' },
+      ]);
+      expect(results[0]!).toMatchObject({ classification: 'unenrolled', status: 'ok' });
+    });
+
+    it('skips deleteTuples when the user has no active memberships', async () => {
+      mockUserRepository.getActiveMembershipsWithRoles.mockResolvedValue([]);
+
+      const results = await buildService().bulkImport(superAdmin, [
+        makeRow({ email: 'leaver@example.org', unenroll: true }),
+      ]);
+
+      expect(mockAuthz.deleteTuples).not.toHaveBeenCalled();
+      expect(results[0]!.status).toBe('ok');
+    });
+
+    it('fails the row and continues the batch when the unenroll transaction throws', async () => {
+      mockUserRepository.findByEmails.mockResolvedValue([
+        existingUser('leaver@example.org'),
+        existingUser('other@example.org'),
+      ]);
+      mockUserRepository.runTransaction.mockRejectedValueOnce(new Error('db down'));
+
+      const results = await buildService().bulkImport(superAdmin, [
+        makeRow({ email: 'leaver@example.org', unenroll: true }),
+        makeRow({ email: 'other@example.org', unenroll: true }),
+      ]);
+
+      expect(results[0]!.status).toBe('failed');
+      expect(results[1]!.status).toBe('ok');
     });
   });
 });

--- a/apps/backend/src/services/user/user-import.service.test.ts
+++ b/apps/backend/src/services/user/user-import.service.test.ts
@@ -43,7 +43,8 @@ describe('UserImportService.bulkImport', () => {
   let mockAuthz: ReturnType<typeof createMockAuthorizationService>;
   const getUsers = vi.fn();
   const importUsers = vi.fn();
-  const mockFirebaseAuth = { getUsers, importUsers } as unknown as typeof FirebaseAuthClient;
+  const updateUser = vi.fn();
+  const mockFirebaseAuth = { getUsers, importUsers, updateUser } as unknown as typeof FirebaseAuthClient;
 
   const superAdmin = AuthContextFactory.build({ isSuperAdmin: true });
   const partnerAdmin = AuthContextFactory.build({ isSuperAdmin: false });
@@ -204,7 +205,7 @@ describe('UserImportService.bulkImport', () => {
       const results = await buildService().bulkImport(superAdmin, [makeRow({ email: 'exists@example.org' })]);
 
       expect(results[0]!.classification).toBe('updated');
-      expect(results[0]!.status).toBe('failed'); // update bin not yet implemented
+      expect(results[0]!.status).toBe('ok');
       expect(importUsers).not.toHaveBeenCalled();
     });
 
@@ -310,8 +311,8 @@ describe('UserImportService.bulkImport', () => {
       const results = await buildService().bulkImport(superAdmin, rows);
 
       expect(results[0]!).toMatchObject({ classification: 'created', status: 'ok' });
-      // Update bin is not yet implemented; create + unenroll route and process independently.
-      expect(results[1]!).toMatchObject({ classification: 'updated', status: 'failed' });
+      // Each bin routes and processes independently in one request.
+      expect(results[1]!).toMatchObject({ classification: 'updated', status: 'ok' });
       expect(results[2]!).toMatchObject({ classification: 'unenrolled', status: 'ok' });
     });
   });
@@ -376,6 +377,73 @@ describe('UserImportService.bulkImport', () => {
       const results = await buildService().bulkImport(superAdmin, [
         makeRow({ email: 'leaver@example.org', unenroll: true }),
         makeRow({ email: 'other@example.org', unenroll: true }),
+      ]);
+
+      expect(results[0]!.status).toBe('failed');
+      expect(results[1]!.status).toBe('ok');
+    });
+  });
+
+  describe('update bin', () => {
+    const existing = (overrides = {}) =>
+      UserFactory.build({
+        email: 'updatee@example.org',
+        nameFirst: 'Old',
+        nameMiddle: null,
+        nameLast: 'Name',
+        ...overrides,
+      });
+
+    beforeEach(() => {
+      mockUserRepository.findByEmails.mockResolvedValue([existing()]);
+    });
+
+    it('updates the profile fields and returns ok without touching importUsers', async () => {
+      const results = await buildService().bulkImport(superAdmin, [makeRow({ email: 'updatee@example.org' })]);
+
+      expect(mockUserRepository.update).toHaveBeenCalledWith(
+        expect.objectContaining({ data: expect.objectContaining({ nameFirst: 'Ada', nameLast: 'Lovelace' }) }),
+      );
+      expect(results[0]!).toMatchObject({ classification: 'updated', status: 'ok' });
+      expect(importUsers).not.toHaveBeenCalled();
+    });
+
+    it('syncs the Firebase displayName when the name changed', async () => {
+      await buildService().bulkImport(superAdmin, [makeRow({ email: 'updatee@example.org' })]);
+
+      expect(updateUser).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ displayName: 'Ada Lovelace' }),
+      );
+    });
+
+    it('resets the Firebase password when one is supplied', async () => {
+      await buildService().bulkImport(superAdmin, [makeRow({ email: 'updatee@example.org', password: 'newpass123' })]);
+
+      expect(updateUser).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({ password: 'newpass123' }));
+    });
+
+    it('skips the Firebase write when neither name nor password changed', async () => {
+      // The existing user already matches the row's name (Ada Lovelace), and no password is sent.
+      mockUserRepository.findByEmails.mockResolvedValue([
+        existing({ nameFirst: 'Ada', nameMiddle: null, nameLast: 'Lovelace' }),
+      ]);
+
+      await buildService().bulkImport(superAdmin, [makeRow({ email: 'updatee@example.org', password: undefined })]);
+
+      expect(updateUser).not.toHaveBeenCalled();
+    });
+
+    it('fails the row and continues the batch when the profile update throws', async () => {
+      mockUserRepository.findByEmails.mockResolvedValue([
+        existing({ email: 'a@example.org' }),
+        existing({ email: 'b@example.org' }),
+      ]);
+      mockUserRepository.update.mockRejectedValueOnce(new Error('db down'));
+
+      const results = await buildService().bulkImport(superAdmin, [
+        makeRow({ email: 'a@example.org' }),
+        makeRow({ email: 'b@example.org' }),
       ]);
 
       expect(results[0]!.status).toBe('failed');

--- a/apps/backend/src/services/user/user-import.service.test.ts
+++ b/apps/backend/src/services/user/user-import.service.test.ts
@@ -25,8 +25,6 @@ const SCRYPT_PARAMS: FirebaseScryptParams = {
   memoryCost: 14,
 };
 
-const firebaseUserNotFound = Object.assign(new Error('no user'), { code: FIREBASE_ERROR_CODES.AUTH.USER_NOT_FOUND });
-
 const makeRow = (overrides: Partial<ImportUserRowInput> = {}): ImportUserRowInput => ({
   email: 'student@example.org',
   password: 'password123',
@@ -42,9 +40,9 @@ describe('UserImportService.bulkImport', () => {
   let mockUserRepository: ReturnType<typeof createMockUserRepository>;
   let mockUserService: ReturnType<typeof createMockUserService>;
   let mockAuthz: ReturnType<typeof createMockAuthorizationService>;
-  const getUserByEmail = vi.fn();
+  const getUsers = vi.fn();
   const importUsers = vi.fn();
-  const mockFirebaseAuth = { getUserByEmail, importUsers } as unknown as typeof FirebaseAuthClient;
+  const mockFirebaseAuth = { getUsers, importUsers } as unknown as typeof FirebaseAuthClient;
 
   const superAdmin = AuthContextFactory.build({ isSuperAdmin: true });
   const partnerAdmin = AuthContextFactory.build({ isSuperAdmin: false });
@@ -69,7 +67,7 @@ describe('UserImportService.bulkImport', () => {
     mockUserRepository.existsByUniqueFields.mockResolvedValue(false);
     mockUserRepository.findClassParentSchool.mockResolvedValue('school-parent');
     mockAuthz.requirePermission.mockResolvedValue(undefined);
-    getUserByEmail.mockRejectedValue(firebaseUserNotFound);
+    getUsers.mockResolvedValue({ users: [], notFound: [] });
     importUsers.mockResolvedValue({ successCount: 0, failureCount: 0, errors: [] });
     let counter = 0;
     mockUserService.createWithImportedAuth.mockImplementation(async () => ({ id: `new-user-${counter++}` }));
@@ -127,12 +125,33 @@ describe('UserImportService.bulkImport', () => {
     });
 
     it('fails a create row whose email already exists in Firebase Auth', async () => {
-      getUserByEmail.mockResolvedValue({ uid: 'existing' });
+      getUsers.mockResolvedValue({ users: [{ email: 'student@example.org' }], notFound: [] });
 
       const results = await buildService().bulkImport(superAdmin, [makeRow()]);
 
       expect(results[0]!).toMatchObject({ status: 'failed', error: { code: ApiErrorCode.RESOURCE_CONFLICT } });
       expect(importUsers).not.toHaveBeenCalled();
+    });
+
+    it('checks Firebase existence with a single batched getUsers call', async () => {
+      const rows = [makeRow({ email: 'a@example.org' }), makeRow({ email: 'b@example.org' })];
+
+      await buildService().bulkImport(superAdmin, rows);
+
+      expect(getUsers).toHaveBeenCalledTimes(1);
+      expect(getUsers).toHaveBeenCalledWith([{ email: 'a@example.org' }, { email: 'b@example.org' }]);
+    });
+
+    it('fails a within-batch duplicate assessmentPid', async () => {
+      const rows = [
+        makeRow({ email: 'a@example.org', identifiers: { pid: 'shared-pid' } }),
+        makeRow({ email: 'b@example.org', identifiers: { pid: 'shared-pid' } }),
+      ];
+
+      const results = await buildService().bulkImport(superAdmin, rows);
+
+      expect(results[0]!.status).toBe('ok');
+      expect(results[1]!).toMatchObject({ status: 'failed', error: { code: ApiErrorCode.RESOURCE_CONFLICT } });
     });
 
     it('fails only the row Firebase rejected in importUsers and persists the rest', async () => {
@@ -257,6 +276,39 @@ describe('UserImportService.bulkImport', () => {
         expect.any(String),
         'school:school-parent',
       );
+    });
+
+    it('skips the FGA check for family memberships (matching single-create)', async () => {
+      const rows = [
+        makeRow({ memberships: [{ entityType: EntityType.FAMILY, entityId: 'fam-1', role: UserRole.STUDENT }] }),
+      ];
+
+      const results = await buildService().bulkImport(partnerAdmin, rows);
+
+      expect(mockAuthz.requirePermission).not.toHaveBeenCalled();
+      expect(results[0]!.status).toBe('ok');
+    });
+  });
+
+  describe('mixed batch', () => {
+    it('routes create, update, and unenroll rows independently in one request', async () => {
+      mockUserRepository.findByEmails.mockResolvedValue([
+        UserFactory.build({ email: 'update-me@example.org' }),
+        UserFactory.build({ email: 'unenroll-me@example.org' }),
+      ]);
+
+      const rows = [
+        makeRow({ email: 'new@example.org' }),
+        makeRow({ email: 'update-me@example.org' }),
+        makeRow({ email: 'unenroll-me@example.org', unenroll: true }),
+      ];
+
+      const results = await buildService().bulkImport(superAdmin, rows);
+
+      expect(results[0]!).toMatchObject({ classification: 'created', status: 'ok' });
+      // update + unenroll bins are not yet implemented, but routing is verified by classification.
+      expect(results[1]!).toMatchObject({ classification: 'updated', status: 'failed' });
+      expect(results[2]!).toMatchObject({ classification: 'unenrolled', status: 'failed' });
     });
   });
 });

--- a/apps/backend/src/services/user/user-import.service.test.ts
+++ b/apps/backend/src/services/user/user-import.service.test.ts
@@ -216,7 +216,8 @@ describe('UserImportService.bulkImport', () => {
       ]);
 
       expect(results[0]!.classification).toBe('unenrolled');
-      expect(results[0]!.status).toBe('failed'); // unenroll bin not yet implemented
+      expect(results[0]!.status).toBe('ok');
+      expect(importUsers).not.toHaveBeenCalled();
     });
 
     it('fails an unenroll request for a non-existent user', async () => {
@@ -348,6 +349,21 @@ describe('UserImportService.bulkImport', () => {
 
       expect(mockAuthz.deleteTuples).not.toHaveBeenCalled();
       expect(results[0]!.status).toBe('ok');
+    });
+
+    it('does not delete class tuples for FGA-invalid (admin-tier) roles', async () => {
+      mockUserRepository.getActiveMembershipsWithRoles.mockResolvedValue([
+        { entityType: EntityType.SCHOOL, entityId: 'school-9', role: UserRole.STUDENT },
+        { entityType: EntityType.CLASS, entityId: 'class-9', role: UserRole.ADMINISTRATOR },
+      ]);
+
+      await buildService().bulkImport(superAdmin, [makeRow({ email: 'leaver@example.org', unenroll: true })]);
+
+      // The admin-tier class tuple was never written (it cascades via the org hierarchy), so deletion
+      // must skip it — only the school tuple is removed.
+      const deleted = mockAuthz.deleteTuples.mock.calls[0]![0];
+      expect(deleted).toHaveLength(1);
+      expect(deleted[0]).toMatchObject({ object: 'school:school-9' });
     });
 
     it('fails the row and continues the batch when the unenroll transaction throws', async () => {

--- a/apps/backend/src/services/user/user-import.service.test.ts
+++ b/apps/backend/src/services/user/user-import.service.test.ts
@@ -75,10 +75,11 @@ describe('UserImportService.bulkImport', () => {
     mockUserService.createWithImportedAuth.mockImplementation(async () => ({ id: `new-user-${counter++}` }));
     mockUserRepository.runTransaction.mockImplementation(async ({ fn }) => fn({} as CoreTransaction));
     mockUserRepository.getActiveMembershipsWithRoles.mockResolvedValue([]);
-    // Default the update-bin membership-delta check to "no change" (matches makeRow's school-1).
     mockUserRepository.getUserEntityMemberships.mockResolvedValue([
       { entityType: EntityType.SCHOOL, entityId: 'school-1' },
     ]);
+    // Default the update-bin reconciliation to "no membership change".
+    mockUserRepository.reconcileMemberships.mockResolvedValue({ added: [], removed: [] });
   });
 
   describe('create bin', () => {
@@ -475,10 +476,14 @@ describe('UserImportService.bulkImport', () => {
       expect(updateUser).not.toHaveBeenCalled();
     });
 
-    it('fails (rather than silently ok) a row whose memberships differ from the current set', async () => {
-      mockUserRepository.getUserEntityMemberships.mockResolvedValue([
-        { entityType: EntityType.SCHOOL, entityId: 'school-1' },
+    it('reconciles memberships and syncs FGA tuples (write added, delete removed)', async () => {
+      mockUserRepository.getActiveMembershipsWithRoles.mockResolvedValue([
+        { entityType: EntityType.SCHOOL, entityId: 'school-1', role: 'student' },
       ]);
+      mockUserRepository.reconcileMemberships.mockResolvedValue({
+        added: [{ entityType: EntityType.SCHOOL, entityId: 'school-2', role: 'student' }],
+        removed: [{ entityType: EntityType.SCHOOL, entityId: 'school-1', role: 'student' }],
+      });
 
       const results = await buildService().bulkImport(superAdmin, [
         makeRow({
@@ -487,12 +492,19 @@ describe('UserImportService.bulkImport', () => {
         }),
       ]);
 
-      expect(results[0]!).toMatchObject({
-        classification: 'updated',
-        status: 'failed',
-        error: { code: ApiErrorCode.RESOURCE_UNPROCESSABLE },
-      });
-      expect(mockUserRepository.update).not.toHaveBeenCalled();
+      expect(mockUserRepository.reconcileMemberships).toHaveBeenCalled();
+      expect(mockAuthz.writeTuplesOrThrow).toHaveBeenCalled(); // tuple for the added membership
+      expect(mockAuthz.deleteTuples).toHaveBeenCalled(); // tuple for the removed membership
+      expect(results[0]!).toMatchObject({ classification: 'updated', status: 'ok' });
+    });
+
+    it('does not touch FGA when reconciliation reports no membership change', async () => {
+      const results = await buildService().bulkImport(superAdmin, [makeRow({ email: 'updatee@example.org' })]);
+
+      expect(mockUserRepository.reconcileMemberships).toHaveBeenCalled();
+      expect(mockAuthz.writeTuplesOrThrow).not.toHaveBeenCalled();
+      expect(mockAuthz.deleteTuples).not.toHaveBeenCalled();
+      expect(results[0]!.status).toBe('ok');
     });
   });
 });

--- a/apps/backend/src/services/user/user-import.service.ts
+++ b/apps/backend/src/services/user/user-import.service.ts
@@ -121,6 +121,40 @@ function preRoutingClassification(row: ImportUserRowInput): Classification {
   return row.unenroll ? CLASSIFICATION.UNENROLLED : CLASSIFICATION.CREATED;
 }
 
+/**
+ * Returns true if an update row implies a membership change the update bin does not yet apply — i.e.
+ * for any entity type the row lists, its set of entity IDs differs from the user's current active set
+ * for that type. Entity types the row omits are ignored (the legacy leaves them untouched). Used to
+ * fail such rows explicitly rather than report a misleading `ok` while silently dropping the change.
+ */
+function hasMembershipDelta(
+  rowMemberships: ImportRowMembership[],
+  current: { entityType: EntityType; entityId: string }[],
+): boolean {
+  const currentByType = new Map<EntityType, Set<string>>();
+  for (const m of current) {
+    const set = currentByType.get(m.entityType) ?? new Set<string>();
+    set.add(m.entityId);
+    currentByType.set(m.entityType, set);
+  }
+
+  const rowByType = new Map<EntityType, Set<string>>();
+  for (const m of rowMemberships) {
+    const set = rowByType.get(m.entityType) ?? new Set<string>();
+    set.add(m.entityId);
+    rowByType.set(m.entityType, set);
+  }
+
+  for (const [entityType, rowIds] of rowByType) {
+    const currentIds = currentByType.get(entityType) ?? new Set<string>();
+    if (rowIds.size !== currentIds.size) return true;
+    for (const id of rowIds) {
+      if (!currentIds.has(id)) return true;
+    }
+  }
+  return false;
+}
+
 export function UserImportService({
   userService = UserService(),
   userRepository = new UserRepository(),
@@ -507,8 +541,10 @@ export function UserImportService({
   function toUpdateUserFields(row: ImportUserRowInput) {
     return {
       nameFirst: row.name.first,
-      nameMiddle: row.name.middle ?? null,
       nameLast: row.name.last,
+      // Middle name is optional — only write it when the row carries it, so an omitted middle
+      // doesn't clobber an existing stored value.
+      ...(row.name.middle !== undefined && { nameMiddle: row.name.middle }),
       ...(row.dob !== undefined && { dob: row.dob ?? null }),
       ...(row.grade !== undefined && { grade: row.grade ?? null }),
       ...(row.demographics && {
@@ -550,12 +586,14 @@ export function UserImportService({
    * Process the update bin: update each existing user's profile fields, and sync Firebase Auth
    * (displayName / password) only when those actually changed.
    *
-   * NOTE: membership reconciliation is intentionally NOT performed yet. The legacy replaces a user's
-   * membership set per provided entity type (ending removed memberships, adding new ones), which
-   * needs a reconciliation repository method plus FGA tuple add/delete sync — it's the remaining
-   * update-bin work and is access-control-sensitive enough to warrant its own reviewed change. Until
-   * then an update row's memberships are left unchanged; profile and auth fields are updated. The
-   * dominant re-import case (refreshing profile fields with unchanged memberships) is fully handled.
+   * Rostering-ended (archived) users are rejected (not-found), matching the canonical single-update.
+   *
+   * NOTE: membership reconciliation is intentionally NOT performed yet — the legacy replaces a user's
+   * membership set per provided entity type (ending removed memberships, adding new ones), which needs
+   * a reconciliation repository method plus FGA tuple add/delete sync and is access-control-sensitive
+   * enough to warrant its own reviewed change. To avoid a misleading `ok`, a row whose memberships
+   * differ from the user's current set is failed explicitly; rows that only refresh profile fields
+   * (the dominant re-import case) succeed.
    */
   async function processUpdateBin(
     rows: { index: number; row: ImportUserRowInput; user: User }[],
@@ -563,13 +601,44 @@ export function UserImportService({
   ): Promise<void> {
     for (const { index, row, user } of rows) {
       try {
+        // Rostering-ended (archived) users are not-found for updates, matching the canonical
+        // single-update (404). Never resurrect profile/auth state on an archived account.
+        if (user.rosteringEnded) {
+          outcomes[index] = failed(
+            index,
+            CLASSIFICATION.UPDATED,
+            ApiErrorCode.RESOURCE_NOT_FOUND,
+            ApiErrorMessage.NOT_FOUND,
+          );
+          continue;
+        }
+
+        // Membership reconciliation is deferred (see the JSDoc above). Rather than report a
+        // misleading `ok` for a row that implies a membership change we don't apply, fail it
+        // explicitly when the row's memberships differ from the user's current set.
+        const currentMemberships = await userRepository.getUserEntityMemberships(user.id);
+        if (hasMembershipDelta(row.memberships, currentMemberships)) {
+          outcomes[index] = failed(
+            index,
+            CLASSIFICATION.UPDATED,
+            ApiErrorCode.RESOURCE_UNPROCESSABLE,
+            'Membership changes on update are not yet supported; re-import without membership changes',
+          );
+          continue;
+        }
+
         await userRepository.update({ id: user.id, data: toUpdateUserFields(row) });
 
+        // The DB profile write commits before the Firebase auth sync. If the auth call fails the row
+        // is reported failed even though the profile write persisted — no orphan, just a stale
+        // displayName/password the operator can fix by retrying the row. Acceptable for an update
+        // (unlike create, there's no account to compensate).
         const authUpdate = buildAuthUpdate(row, user);
         if (authUpdate && user.authId) {
           await firebaseAuth.updateUser(user.authId, authUpdate);
         }
 
+        logger.info({ userId: user.id }, 'Updated user (import)');
         outcomes[index] = ok(index, CLASSIFICATION.UPDATED, user.id);
       } catch (error) {
         logger.error({ err: error, context: { userId: user.id } }, 'Update failed during import');

--- a/apps/backend/src/services/user/user-import.service.ts
+++ b/apps/backend/src/services/user/user-import.service.ts
@@ -1,6 +1,8 @@
 import { randomUUID } from 'node:crypto';
 import { StatusCodes } from 'http-status-codes';
 import type { UserImportRecord, UserImportResult } from 'firebase-admin/auth';
+import type { TupleKeyWithoutCondition } from '@openfga/sdk';
+import type { User } from '../../db/schema';
 import type { AuthContext } from '../../types/auth-context';
 import type { UserType } from '../../enums/user-type.enum';
 import type { Grade } from '../../enums/grade.enum';
@@ -18,7 +20,7 @@ import { isFirebaseError } from '../../types/firebase';
 import { FIREBASE_ERROR_CODES } from '../../constants/firebase-error-codes';
 import { generateAssessmentPid } from '../../utils/assessment-pid.util';
 import { AuthorizationService } from '../authorization/authorization.service';
-import { FgaType, FgaRelation } from '../authorization/fga-constants';
+import { FgaType, FgaRelation, FGA_CLASS_VALID_ROLES } from '../authorization/fga-constants';
 import { UserService } from './user.service';
 import {
   hashPasswordForImport,
@@ -434,6 +436,68 @@ export function UserImportService({
   }
 
   /**
+   * Build the FGA membership tuples to delete when unenrolling a user. Mirrors the relations
+   * single-create wrote — a `user:<id>` → `<role>` → `<type>:<id>` tuple per membership — skipping
+   * class memberships whose role isn't FGA-valid (those cascade via the org hierarchy and were never
+   * written to the class type). Conditions are omitted: FGA deletes by tuple key.
+   */
+  function buildMembershipDeletionTuples(
+    userId: string,
+    memberships: { entityType: EntityType; entityId: string; role: string }[],
+  ): TupleKeyWithoutCondition[] {
+    const validClassRoles = FGA_CLASS_VALID_ROLES as ReadonlySet<string>;
+    const tuples: TupleKeyWithoutCondition[] = [];
+    for (const m of memberships) {
+      if (m.entityType === EntityType.CLASS && !validClassRoles.has(m.role)) continue;
+      tuples.push({
+        user: `user:${userId}`,
+        relation: m.role,
+        object: `${ENTITY_TYPE_TO_FGA_TYPE[m.entityType]}:${m.entityId}`,
+      });
+    }
+    return tuples;
+  }
+
+  /**
+   * Process the unenroll bin: per row, end ALL of the user's enrollments and archive them
+   * (`rosteringEnded`) in one transaction, then best-effort delete their FGA membership tuples.
+   *
+   * Ending the DB enrollment does not expire the FGA tuple's stored grant window, so explicit cleanup
+   * is required for the user to actually lose access. Matches the legacy `batchImportUpdate`, which
+   * unenrolls a user from every org and archives them regardless of which memberships the row names.
+   */
+  async function processUnenrollBin(
+    rows: { index: number; user: User }[],
+    outcomes: ImportRowOutcome[],
+  ): Promise<void> {
+    for (const { index, user } of rows) {
+      try {
+        // Capture the tuples to delete before ending the enrollments (afterward they read inactive).
+        const memberships = await userRepository.getActiveMembershipsWithRoles(user.id);
+
+        await userRepository.runTransaction({
+          fn: async (tx) => {
+            await userRepository.endAllEnrollments(user.id, tx);
+            await userRepository.archiveUser(user.id, tx);
+          },
+        });
+
+        // Best-effort: deleteTuples is fire-and-forget (logs on failure, never throws), so a stale
+        // tuple can't fail the row after the DB state has already committed.
+        const tuples = buildMembershipDeletionTuples(user.id, memberships);
+        if (tuples.length > 0) {
+          await authorizationService.deleteTuples(tuples);
+        }
+
+        outcomes[index] = ok(index, CLASSIFICATION.UNENROLLED, user.id);
+      } catch (error) {
+        logger.error({ err: error, context: { userId: user.id } }, 'Unenroll failed during import');
+        outcomes[index] = toFailedOutcome(index, CLASSIFICATION.UNENROLLED, error);
+      }
+    }
+  }
+
+  /**
    * Classify each row into create / update / unenroll and process each bin.
    *
    * @param authContext - The requesting user's auth context.
@@ -465,17 +529,17 @@ export function UserImportService({
     }
 
     const createRows: { index: number; row: ImportUserRowInput }[] = [];
-    const updateRows: { index: number; row: ImportUserRowInput }[] = [];
-    const unenrollRows: { index: number; row: ImportUserRowInput }[] = [];
+    const updateRows: { index: number; row: ImportUserRowInput; user: User }[] = [];
+    const unenrollRows: { index: number; row: ImportUserRowInput; user: User }[] = [];
 
     for (const entry of authorized) {
-      const found = existingByEmail.has(entry.row.email.toLowerCase());
+      const user = existingByEmail.get(entry.row.email.toLowerCase());
       const unenroll = Boolean(entry.row.unenroll);
 
-      if (found && unenroll) {
-        unenrollRows.push(entry);
-      } else if (found) {
-        updateRows.push(entry);
+      if (user && unenroll) {
+        unenrollRows.push({ ...entry, user });
+      } else if (user) {
+        updateRows.push({ ...entry, user });
       } else if (unenroll) {
         // Unenroll requested for a user that does not exist.
         // NOTE: the legacy cloud function routes this to the unenroll bin as a no-op rather than
@@ -494,24 +558,18 @@ export function UserImportService({
     // ── Phase 3: create bin ──────────────────────────────────────────────────────
     await processCreateBin(authContext, createRows, outcomes);
 
-    // ── Phases 4–5: update + unenroll bins (next increment) ──────────────────────
-    // These require new repository support (enrollment-ending, rosteringEnded archiving, membership
-    // reconciliation) and a per-row updateUser path for password/name. Until then, report rather
-    // than silently mishandle.
+    // ── Phase 4: unenroll bin ────────────────────────────────────────────────────
+    await processUnenrollBin(unenrollRows, outcomes);
+
+    // ── Phase 5: update bin (next increment) ─────────────────────────────────────
+    // Requires a membership-reconciliation repository method plus a per-row updateUser path for
+    // password/name. Until then, report rather than silently mishandle.
     for (const entry of updateRows) {
       outcomes[entry.index] = failed(
         entry.index,
         CLASSIFICATION.UPDATED,
         ApiErrorCode.INTERNAL,
         'Update of existing users is not yet supported by this endpoint',
-      );
-    }
-    for (const entry of unenrollRows) {
-      outcomes[entry.index] = failed(
-        entry.index,
-        CLASSIFICATION.UNENROLLED,
-        ApiErrorCode.INTERNAL,
-        'Unenrollment is not yet supported by this endpoint',
       );
     }
 

--- a/apps/backend/src/services/user/user-import.service.ts
+++ b/apps/backend/src/services/user/user-import.service.ts
@@ -195,17 +195,18 @@ export function UserImportService({
     }
   }
 
-  /** Returns true if a Firebase Auth account already exists for the email. */
-  async function firebaseEmailExists(email: string): Promise<boolean> {
-    try {
-      await firebaseAuth.getUserByEmail(email);
-      return true;
-    } catch (error) {
-      if (isFirebaseError(error) && error.code === FIREBASE_ERROR_CODES.AUTH.USER_NOT_FOUND) {
-        return false;
-      }
-      throw error;
-    }
+  /**
+   * Batch-check which of the given emails already have a Firebase Auth account. Uses the Admin SDK's
+   * `getUsers` (one call for up to 100 identifiers — the batch cap) instead of a per-row
+   * `getUserByEmail`, keeping Firebase round-trips to one regardless of batch size
+   * (performance-avoid-quadratic).
+   *
+   * @returns A set of the lowercased emails that already exist in Firebase Auth.
+   */
+  async function getExistingFirebaseEmails(emails: string[]): Promise<Set<string>> {
+    if (emails.length === 0) return new Set();
+    const { users } = await firebaseAuth.getUsers(emails.map((email) => ({ email })));
+    return new Set(users.map((user) => user.email?.toLowerCase()).filter((email): email is string => Boolean(email)));
   }
 
   /** Map a Firebase `importUsers` FailedAccount error to a safe per-row error code. */
@@ -264,7 +265,30 @@ export function UserImportService({
 
     const params = getScryptParams();
 
-    // Pre-flight each candidate: password required, PID + Postgres/Firebase uniqueness, then hash.
+    // Batch Firebase existence check — one getUsers call for the whole batch (≤100). importUsers
+    // bypasses uniqueness validation, so we must pre-check; batching avoids per-row round-trips.
+    let firebaseExistingEmails: Set<string>;
+    try {
+      firebaseExistingEmails = await getExistingFirebaseEmails(candidates.map((candidate) => candidate.row.email));
+    } catch (error) {
+      logger.error({ err: error, context: { count: candidates.length } }, 'Firebase getUsers pre-check failed');
+      for (const candidate of candidates) {
+        outcomes[candidate.index] = failed(
+          candidate.index,
+          CLASSIFICATION.CREATED,
+          ApiErrorCode.EXTERNAL_SERVICE_FAILED,
+          ApiErrorMessage.INTERNAL_SERVER_ERROR,
+        );
+      }
+      return;
+    }
+
+    // Pre-flight each candidate: password required, within-batch PID + Postgres/Firebase uniqueness,
+    // then hash. Note: super admins skip the explicit membership-existence pre-flight that
+    // single-create performs; an invalid entity instead fails at the FK constraint inside
+    // createWithImportedAuth, which compensates by deleting the just-imported Firebase account
+    // (no orphan, just slightly more create+delete churn for that row).
+    const seenPids = new Set<string>();
     const prepared: {
       index: number;
       row: ImportUserRowInput;
@@ -289,9 +313,30 @@ export function UserImportService({
 
       const assessmentPid = row.identifiers?.pid ?? generateAssessmentPid({ userId: row.email });
 
+      // Within-batch PID uniqueness (email is already deduped above; importUsers validates neither).
+      if (seenPids.has(assessmentPid)) {
+        outcomes[index] = failed(
+          index,
+          CLASSIFICATION.CREATED,
+          ApiErrorCode.RESOURCE_CONFLICT,
+          ApiErrorMessage.CONFLICT,
+        );
+        continue;
+      }
+      seenPids.add(assessmentPid);
+
+      if (firebaseExistingEmails.has(row.email.toLowerCase())) {
+        outcomes[index] = failed(
+          index,
+          CLASSIFICATION.CREATED,
+          ApiErrorCode.RESOURCE_CONFLICT,
+          ApiErrorMessage.CONFLICT,
+        );
+        continue;
+      }
+
       try {
-        const exists = await userRepository.existsByUniqueFields({ email: row.email, assessmentPid });
-        if (exists || (await firebaseEmailExists(row.email))) {
+        if (await userRepository.existsByUniqueFields({ email: row.email, assessmentPid })) {
           outcomes[index] = failed(
             index,
             CLASSIFICATION.CREATED,
@@ -301,7 +346,10 @@ export function UserImportService({
           continue;
         }
       } catch (error) {
-        logger.error({ err: error, context: { email: row.email } }, 'Uniqueness pre-check failed during import');
+        logger.error(
+          { err: error, context: { email: row.email } },
+          'Postgres uniqueness pre-check failed during import',
+        );
         outcomes[index] = failed(
           index,
           CLASSIFICATION.CREATED,
@@ -354,7 +402,7 @@ export function UserImportService({
 
     // Mark rows that Firebase rejected (by their position in the records array).
     const failedRecordIndexes = new Set<number>();
-    for (const failure of result.errors ?? []) {
+    for (const failure of result.errors) {
       failedRecordIndexes.add(failure.index);
       const p = prepared[failure.index];
       if (p) {

--- a/apps/backend/src/services/user/user-import.service.ts
+++ b/apps/backend/src/services/user/user-import.service.ts
@@ -45,9 +45,9 @@ import {
  * **Unenroll bin** (implemented): ends all of a user's enrollments and archives them
  * (`rosteringEnded`) in one transaction, then best-effort deletes their FGA membership tuples.
  *
- * **Update bin**: tracked as the next increment — it needs a membership-reconciliation repository
- * method plus a per-row `updateUser` path for password/name. Until then update rows are reported as
- * a per-row failure rather than silently mishandled.
+ * **Update bin** (profile + auth implemented): updates an existing user's profile fields and syncs
+ * Firebase Auth (displayName / password) when they changed. Membership reconciliation
+ * (replace-semantics per the legacy) is the remaining piece — see `processUpdateBin`.
  *
  * Authorization mirrors single-create and is applied per row: super admin, or `can_create_users` on
  * every membership target (the legacy uses the same coarse permission for all three bins).
@@ -501,6 +501,84 @@ export function UserImportService({
   }
 
   /**
+   * Map an import row to the user-table fields an update writes. Import rows always carry the full
+   * name; other profile fields are written only when provided (an omitted field is left unchanged).
+   */
+  function toUpdateUserFields(row: ImportUserRowInput) {
+    return {
+      nameFirst: row.name.first,
+      nameMiddle: row.name.middle ?? null,
+      nameLast: row.name.last,
+      ...(row.dob !== undefined && { dob: row.dob ?? null }),
+      ...(row.grade !== undefined && { grade: row.grade ?? null }),
+      ...(row.demographics && {
+        statusEll: row.demographics.statusEll ?? null,
+        statusFrl: row.demographics.statusFrl ?? null,
+        statusIep: row.demographics.statusIep ?? null,
+        gender: row.demographics.gender ?? null,
+        race: row.demographics.race ?? null,
+        hispanicEthnicity: row.demographics.hispanicEthnicity ?? null,
+        homeLanguage: row.demographics.homeLanguage ?? null,
+      }),
+      ...(row.identifiers?.stateId !== undefined && { stateId: row.identifiers.stateId }),
+    };
+  }
+
+  /**
+   * Build the Firebase Auth update for an update row, or null if nothing auth-related changed.
+   * `displayName` is synced only when the name actually changed; the password is set when provided.
+   * This keeps update-bin Firebase writes off the per-row path for pure profile/demographic updates.
+   */
+  function buildAuthUpdate(row: ImportUserRowInput, user: User): { displayName?: string; password?: string } | null {
+    const update: { displayName?: string; password?: string } = {};
+
+    const nameChanged =
+      row.name.first !== user.nameFirst ||
+      row.name.last !== user.nameLast ||
+      (row.name.middle ?? null) !== (user.nameMiddle ?? null);
+    if (nameChanged) {
+      update.displayName = [row.name.first, row.name.last].filter(Boolean).join(' ');
+    }
+    if (row.password) {
+      update.password = row.password;
+    }
+
+    return Object.keys(update).length > 0 ? update : null;
+  }
+
+  /**
+   * Process the update bin: update each existing user's profile fields, and sync Firebase Auth
+   * (displayName / password) only when those actually changed.
+   *
+   * NOTE: membership reconciliation is intentionally NOT performed yet. The legacy replaces a user's
+   * membership set per provided entity type (ending removed memberships, adding new ones), which
+   * needs a reconciliation repository method plus FGA tuple add/delete sync — it's the remaining
+   * update-bin work and is access-control-sensitive enough to warrant its own reviewed change. Until
+   * then an update row's memberships are left unchanged; profile and auth fields are updated. The
+   * dominant re-import case (refreshing profile fields with unchanged memberships) is fully handled.
+   */
+  async function processUpdateBin(
+    rows: { index: number; row: ImportUserRowInput; user: User }[],
+    outcomes: ImportRowOutcome[],
+  ): Promise<void> {
+    for (const { index, row, user } of rows) {
+      try {
+        await userRepository.update({ id: user.id, data: toUpdateUserFields(row) });
+
+        const authUpdate = buildAuthUpdate(row, user);
+        if (authUpdate && user.authId) {
+          await firebaseAuth.updateUser(user.authId, authUpdate);
+        }
+
+        outcomes[index] = ok(index, CLASSIFICATION.UPDATED, user.id);
+      } catch (error) {
+        logger.error({ err: error, context: { userId: user.id } }, 'Update failed during import');
+        outcomes[index] = toFailedOutcome(index, CLASSIFICATION.UPDATED, error);
+      }
+    }
+  }
+
+  /**
    * Classify each row into create / update / unenroll and process each bin.
    *
    * @param authContext - The requesting user's auth context.
@@ -564,17 +642,9 @@ export function UserImportService({
     // ── Phase 4: unenroll bin ────────────────────────────────────────────────────
     await processUnenrollBin(unenrollRows, outcomes);
 
-    // ── Phase 5: update bin (next increment) ─────────────────────────────────────
-    // Requires a membership-reconciliation repository method plus a per-row updateUser path for
-    // password/name. Until then, report rather than silently mishandle.
-    for (const entry of updateRows) {
-      outcomes[entry.index] = failed(
-        entry.index,
-        CLASSIFICATION.UPDATED,
-        ApiErrorCode.INTERNAL,
-        'Update of existing users is not yet supported by this endpoint',
-      );
-    }
+    // ── Phase 5: update bin ──────────────────────────────────────────────────────
+    // Updates profile + auth fields. Membership reconciliation is deferred (see processUpdateBin).
+    await processUpdateBin(updateRows, outcomes);
 
     return outcomes;
   }

--- a/apps/backend/src/services/user/user-import.service.ts
+++ b/apps/backend/src/services/user/user-import.service.ts
@@ -639,13 +639,21 @@ export function UserImportService({
           },
         });
 
-        // Sync FGA after the DB commit: write tuples for added memberships (carrying the
-        // active_membership condition), best-effort delete tuples for removed ones.
-        if (reconciled.added.length > 0) {
-          await authorizationService.writeTuplesOrThrow(buildMembershipAdditionTuples(user.id, reconciled.added));
+        // Sync FGA after the DB commit. Revoke first, then grant: deleteTuples is best-effort (never
+        // throws), while writeTuplesOrThrow throws on failure. Running the revocation first means a
+        // failed grant-write can only ever leave the user under-granted (the DB membership exists but
+        // FGA hasn't caught up yet — the backfill job reconciles it), never over-granted with a stale
+        // tuple for a membership that was just removed. Added tuples carry the active_membership
+        // condition, identical to single-create. Build first, then guard on the tuple count: an
+        // admin-tier class membership reconciles in the DB but maps to zero FGA tuples (it cascades
+        // via the org hierarchy), so add and delete stay symmetric — neither touches FGA.
+        const removalTuples = buildMembershipDeletionTuples(user.id, reconciled.removed);
+        if (removalTuples.length > 0) {
+          await authorizationService.deleteTuples(removalTuples);
         }
-        if (reconciled.removed.length > 0) {
-          await authorizationService.deleteTuples(buildMembershipDeletionTuples(user.id, reconciled.removed));
+        const additionTuples = buildMembershipAdditionTuples(user.id, reconciled.added);
+        if (additionTuples.length > 0) {
+          await authorizationService.writeTuplesOrThrow(additionTuples);
         }
 
         // The DB writes commit before the Firebase auth sync. If the auth call fails the row is

--- a/apps/backend/src/services/user/user-import.service.ts
+++ b/apps/backend/src/services/user/user-import.service.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from 'node:crypto';
 import { StatusCodes } from 'http-status-codes';
 import type { UserImportRecord, UserImportResult } from 'firebase-admin/auth';
-import type { TupleKeyWithoutCondition } from '@openfga/sdk';
+import type { TupleKey, TupleKeyWithoutCondition } from '@openfga/sdk';
 import type { User } from '../../db/schema';
 import type { AuthContext } from '../../types/auth-context';
 import type { UserType } from '../../enums/user-type.enum';
@@ -21,6 +21,13 @@ import { FIREBASE_ERROR_CODES } from '../../constants/firebase-error-codes';
 import { generateAssessmentPid } from '../../utils/assessment-pid.util';
 import { AuthorizationService } from '../authorization/authorization.service';
 import { FgaType, FgaRelation, FGA_CLASS_VALID_ROLES } from '../authorization/fga-constants';
+import {
+  districtMembershipTuple,
+  schoolMembershipTuple,
+  classMembershipTuple,
+  groupMembershipTuple,
+  familyMembershipTuple,
+} from '../authorization/helpers/fga-tuples';
 import { UserService } from './user.service';
 import {
   hashPasswordForImport,
@@ -45,9 +52,9 @@ import {
  * **Unenroll bin** (implemented): ends all of a user's enrollments and archives them
  * (`rosteringEnded`) in one transaction, then best-effort deletes their FGA membership tuples.
  *
- * **Update bin** (profile + auth implemented): updates an existing user's profile fields and syncs
- * Firebase Auth (displayName / password) when they changed. Membership reconciliation
- * (replace-semantics per the legacy) is the remaining piece — see `processUpdateBin`.
+ * **Update bin** (implemented): updates an existing user's profile fields, reconciles their
+ * memberships (replace-semantics per the legacy, with FGA tuple add/delete sync), and syncs Firebase
+ * Auth (displayName / password) when they changed.
  *
  * Authorization mirrors single-create and is applied per row: super admin, or `can_create_users` on
  * every membership target (the legacy uses the same coarse permission for all three bins).
@@ -119,40 +126,6 @@ function toFailedOutcome(index: number, classification: Classification, error: u
 /** Best-effort classification for a row that fails before bin routing (e.g. authorization). */
 function preRoutingClassification(row: ImportUserRowInput): Classification {
   return row.unenroll ? CLASSIFICATION.UNENROLLED : CLASSIFICATION.CREATED;
-}
-
-/**
- * Returns true if an update row implies a membership change the update bin does not yet apply — i.e.
- * for any entity type the row lists, its set of entity IDs differs from the user's current active set
- * for that type. Entity types the row omits are ignored (the legacy leaves them untouched). Used to
- * fail such rows explicitly rather than report a misleading `ok` while silently dropping the change.
- */
-function hasMembershipDelta(
-  rowMemberships: ImportRowMembership[],
-  current: { entityType: EntityType; entityId: string }[],
-): boolean {
-  const currentByType = new Map<EntityType, Set<string>>();
-  for (const m of current) {
-    const set = currentByType.get(m.entityType) ?? new Set<string>();
-    set.add(m.entityId);
-    currentByType.set(m.entityType, set);
-  }
-
-  const rowByType = new Map<EntityType, Set<string>>();
-  for (const m of rowMemberships) {
-    const set = rowByType.get(m.entityType) ?? new Set<string>();
-    set.add(m.entityId);
-    rowByType.set(m.entityType, set);
-  }
-
-  for (const [entityType, rowIds] of rowByType) {
-    const currentIds = currentByType.get(entityType) ?? new Set<string>();
-    if (rowIds.size !== currentIds.size) return true;
-    for (const id of rowIds) {
-      if (!currentIds.has(id)) return true;
-    }
-  }
-  return false;
 }
 
 export function UserImportService({
@@ -496,6 +469,42 @@ export function UserImportService({
   }
 
   /**
+   * Build the FGA membership tuples to write for newly-added memberships, carrying the
+   * `active_membership` condition (grant window starting now). Mirrors single-create's
+   * buildMembershipTuples — class tuples are only written for FGA-valid roles.
+   */
+  function buildMembershipAdditionTuples(
+    userId: string,
+    memberships: { entityType: EntityType; entityId: string; role: string }[],
+  ): TupleKey[] {
+    const validClassRoles = FGA_CLASS_VALID_ROLES as ReadonlySet<string>;
+    const tuples: TupleKey[] = [];
+    const start = new Date();
+    for (const m of memberships) {
+      switch (m.entityType) {
+        case EntityType.DISTRICT:
+          tuples.push(districtMembershipTuple(userId, m.entityId, m.role as UserRole, start, null));
+          break;
+        case EntityType.SCHOOL:
+          tuples.push(schoolMembershipTuple(userId, m.entityId, m.role as UserRole, start, null));
+          break;
+        case EntityType.CLASS:
+          if (validClassRoles.has(m.role)) {
+            tuples.push(classMembershipTuple(userId, m.entityId, m.role as UserRole, start, null));
+          }
+          break;
+        case EntityType.GROUP:
+          tuples.push(groupMembershipTuple(userId, m.entityId, m.role as UserRole, start, null));
+          break;
+        case EntityType.FAMILY:
+          tuples.push(familyMembershipTuple(userId, m.entityId, m.role as UserFamilyRole, start, null));
+          break;
+      }
+    }
+    return tuples;
+  }
+
+  /**
    * Process the unenroll bin: per row, end ALL of the user's enrollments and archive them
    * (`rosteringEnded`) in one transaction, then best-effort delete their FGA membership tuples.
    *
@@ -583,17 +592,13 @@ export function UserImportService({
   }
 
   /**
-   * Process the update bin: update each existing user's profile fields, and sync Firebase Auth
-   * (displayName / password) only when those actually changed.
+   * Process the update bin: update each existing user's profile fields, reconcile their memberships
+   * (replace-semantics per provided entity type — end removed, add/reactivate new, leave unchanged),
+   * and sync Firebase Auth (displayName / password) only when those actually changed.
    *
-   * Rostering-ended (archived) users are rejected (not-found), matching the canonical single-update.
-   *
-   * NOTE: membership reconciliation is intentionally NOT performed yet — the legacy replaces a user's
-   * membership set per provided entity type (ending removed memberships, adding new ones), which needs
-   * a reconciliation repository method plus FGA tuple add/delete sync and is access-control-sensitive
-   * enough to warrant its own reviewed change. To avoid a misleading `ok`, a row whose memberships
-   * differ from the user's current set is failed explicitly; rows that only refresh profile fields
-   * (the dominant re-import case) succeed.
+   * Profile fields and membership reconciliation run in one transaction; FGA tuples are then synced
+   * (written for added memberships, best-effort deleted for removed). Rostering-ended (archived) users
+   * are rejected (not-found), matching the canonical single-update.
    */
   async function processUpdateBin(
     rows: { index: number; row: ImportUserRowInput; user: User }[],
@@ -613,24 +618,38 @@ export function UserImportService({
           continue;
         }
 
-        // Membership reconciliation is deferred (see the JSDoc above). Rather than report a
-        // misleading `ok` for a row that implies a membership change we don't apply, fail it
-        // explicitly when the row's memberships differ from the user's current set.
-        const currentMemberships = await userRepository.getUserEntityMemberships(user.id);
-        if (hasMembershipDelta(row.memberships, currentMemberships)) {
-          outcomes[index] = failed(
-            index,
-            CLASSIFICATION.UPDATED,
-            ApiErrorCode.RESOURCE_UNPROCESSABLE,
-            'Membership changes on update are not yet supported; re-import without membership changes',
-          );
-          continue;
+        // Reconcile memberships with replace-semantics per provided entity type. Read the current
+        // set first (snapshot), then update profile fields + reconcile in one transaction.
+        const currentMemberships = await userRepository.getActiveMembershipsWithRoles(user.id);
+        const desiredMemberships = row.memberships.map((m) => ({
+          entityType: m.entityType,
+          entityId: m.entityId,
+          role: String(m.role),
+        }));
+
+        let reconciled: {
+          added: { entityType: EntityType; entityId: string; role: string }[];
+          removed: { entityType: EntityType; entityId: string; role: string }[];
+        } = { added: [], removed: [] };
+
+        await userRepository.runTransaction({
+          fn: async (tx) => {
+            await userRepository.update({ id: user.id, data: toUpdateUserFields(row), transaction: tx });
+            reconciled = await userRepository.reconcileMemberships(user.id, desiredMemberships, currentMemberships, tx);
+          },
+        });
+
+        // Sync FGA after the DB commit: write tuples for added memberships (carrying the
+        // active_membership condition), best-effort delete tuples for removed ones.
+        if (reconciled.added.length > 0) {
+          await authorizationService.writeTuplesOrThrow(buildMembershipAdditionTuples(user.id, reconciled.added));
+        }
+        if (reconciled.removed.length > 0) {
+          await authorizationService.deleteTuples(buildMembershipDeletionTuples(user.id, reconciled.removed));
         }
 
-        await userRepository.update({ id: user.id, data: toUpdateUserFields(row) });
-
-        // The DB profile write commits before the Firebase auth sync. If the auth call fails the row
-        // is reported failed even though the profile write persisted — no orphan, just a stale
+        // The DB writes commit before the Firebase auth sync. If the auth call fails the row is
+        // reported failed even though the DB writes persisted — no orphan, just a stale
         // displayName/password the operator can fix by retrying the row. Acceptable for an update
         // (unlike create, there's no account to compensate).
         const authUpdate = buildAuthUpdate(row, user);
@@ -638,7 +657,10 @@ export function UserImportService({
           await firebaseAuth.updateUser(user.authId, authUpdate);
         }
 
-        logger.info({ userId: user.id }, 'Updated user (import)');
+        logger.info(
+          { userId: user.id, added: reconciled.added.length, removed: reconciled.removed.length },
+          'Updated user (import)',
+        );
         outcomes[index] = ok(index, CLASSIFICATION.UPDATED, user.id);
       } catch (error) {
         logger.error({ err: error, context: { userId: user.id } }, 'Update failed during import');

--- a/apps/backend/src/services/user/user-import.service.ts
+++ b/apps/backend/src/services/user/user-import.service.ts
@@ -42,9 +42,12 @@ import {
  * persisted via {@link UserService.createWithImportedAuth}, which runs the same DB+FGA saga and
  * compensation as single-create. Passwords are SCRYPT-hashed for `importUsers`.
  *
- * **Update / unenroll bins**: tracked as the next increment — they require new repository support
- * for enrollment-ending, `rosteringEnded` archiving, and membership reconciliation. Until then, such
- * rows are reported as a per-row failure rather than silently mishandled.
+ * **Unenroll bin** (implemented): ends all of a user's enrollments and archives them
+ * (`rosteringEnded`) in one transaction, then best-effort deletes their FGA membership tuples.
+ *
+ * **Update bin**: tracked as the next increment — it needs a membership-reconciliation repository
+ * method plus a per-row `updateUser` path for password/name. Until then update rows are reported as
+ * a per-row failure rather than silently mishandled.
  *
  * Authorization mirrors single-create and is applied per row: super admin, or `can_create_users` on
  * every membership target (the legacy uses the same coarse permission for all three bins).

--- a/apps/backend/src/services/user/user-import.service.ts
+++ b/apps/backend/src/services/user/user-import.service.ts
@@ -1,0 +1,474 @@
+import { randomUUID } from 'node:crypto';
+import { StatusCodes } from 'http-status-codes';
+import type { UserImportRecord, UserImportResult } from 'firebase-admin/auth';
+import type { AuthContext } from '../../types/auth-context';
+import type { UserType } from '../../enums/user-type.enum';
+import type { Grade } from '../../enums/grade.enum';
+import type { FreeReducedLunchStatus } from '../../enums/frl-status.enum';
+import { UserRole } from '../../enums/user-role.enum';
+import type { UserFamilyRole } from '../../enums/user-family-role.enum';
+import { EntityType } from '../../types/entity-type';
+import { ApiError } from '../../errors/api-error';
+import { ApiErrorCode } from '../../enums/api-error-code.enum';
+import { ApiErrorMessage } from '../../enums/api-error-message.enum';
+import { logger } from '../../logger';
+import { UserRepository } from '../../repositories/user.repository';
+import { FirebaseAuthClient } from '../../clients/firebase-auth.clients';
+import { isFirebaseError } from '../../types/firebase';
+import { FIREBASE_ERROR_CODES } from '../../constants/firebase-error-codes';
+import { generateAssessmentPid } from '../../utils/assessment-pid.util';
+import { AuthorizationService } from '../authorization/authorization.service';
+import { FgaType, FgaRelation } from '../authorization/fga-constants';
+import { UserService } from './user.service';
+import {
+  hashPasswordForImport,
+  getFirebaseScryptParamsFromEnv,
+  type FirebaseScryptParams,
+} from './utils/firebase-password-hash';
+
+/**
+ * UserImportService
+ *
+ * Bulk create / update / unenroll users from a single request, the backend replacement for the
+ * legacy `batchImportUpdate` cloud function that backs the dashboard's CSV upload. Each row is
+ * classified by email into one of three bins and processed against Firebase Auth, Postgres, and
+ * OpenFGA with per-row atomicity — a failure on one row never affects the others, and every row's
+ * outcome is reported individually.
+ *
+ * **Create bin** (implemented): all rows' Firebase accounts are created in a single `importUsers`
+ * call (one round-trip, no per-account rate limit — the reason this endpoint exists), then each is
+ * persisted via {@link UserService.createWithImportedAuth}, which runs the same DB+FGA saga and
+ * compensation as single-create. Passwords are SCRYPT-hashed for `importUsers`.
+ *
+ * **Update / unenroll bins**: tracked as the next increment — they require new repository support
+ * for enrollment-ending, `rosteringEnded` archiving, and membership reconciliation. Until then, such
+ * rows are reported as a per-row failure rather than silently mishandled.
+ *
+ * Authorization mirrors single-create and is applied per row: super admin, or `can_create_users` on
+ * every membership target (the legacy uses the same coarse permission for all three bins).
+ */
+
+const CLASSIFICATION = {
+  CREATED: 'created',
+  UPDATED: 'updated',
+  UNENROLLED: 'unenrolled',
+} as const;
+
+type Classification = (typeof CLASSIFICATION)[keyof typeof CLASSIFICATION];
+
+interface ImportRowMembership {
+  entityType: EntityType;
+  entityId: string;
+  // Org roles use UserRole; family memberships use UserFamilyRole (parent/child). The flat union
+  // mirrors how the contract's discriminated membership union is inferred at the service boundary.
+  role: UserRole | UserFamilyRole;
+  enrollmentStart?: string | undefined;
+  enrollmentEnd?: string | undefined;
+}
+
+/** A single import row. Mirrors the single-create payload plus `unenroll` and an optional password. */
+export interface ImportUserRowInput {
+  email: string;
+  password?: string | undefined;
+  name: { first: string; middle?: string | null | undefined; last: string };
+  userType: UserType;
+  dob?: string | null | undefined;
+  grade?: Grade | null | undefined;
+  demographics?:
+    | {
+        statusEll?: string | null | undefined;
+        statusFrl?: FreeReducedLunchStatus | null | undefined;
+        statusIep?: string | null | undefined;
+        gender?: string | null | undefined;
+        race?: string | null | undefined;
+        hispanicEthnicity?: boolean | null | undefined;
+        homeLanguage?: string | null | undefined;
+      }
+    | undefined;
+  identifiers?: { stateId?: string | undefined; pid?: string | undefined } | undefined;
+  unenroll?: boolean | undefined;
+  memberships: ImportRowMembership[];
+}
+
+/** Per-row outcome. Successful rows carry the resulting user id; failed rows carry a safe code/message. */
+export type ImportRowOutcome =
+  | { index: number; classification: Classification; status: 'ok'; id: string }
+  | { index: number; classification: Classification; status: 'failed'; error: { code: string; message: string } };
+
+function ok(index: number, classification: Classification, id: string): ImportRowOutcome {
+  return { index, classification, status: 'ok', id };
+}
+
+function failed(index: number, classification: Classification, code: string, message: string): ImportRowOutcome {
+  return { index, classification, status: 'failed', error: { code, message } };
+}
+
+/** Map an ApiError (or unknown error) to a safe per-row failure outcome. */
+function toFailedOutcome(index: number, classification: Classification, error: unknown): ImportRowOutcome {
+  if (error instanceof ApiError) {
+    return failed(index, classification, error.code, error.message);
+  }
+  return failed(index, classification, ApiErrorCode.INTERNAL, ApiErrorMessage.INTERNAL_SERVER_ERROR);
+}
+
+/** Best-effort classification for a row that fails before bin routing (e.g. authorization). */
+function preRoutingClassification(row: ImportUserRowInput): Classification {
+  return row.unenroll ? CLASSIFICATION.UNENROLLED : CLASSIFICATION.CREATED;
+}
+
+export function UserImportService({
+  userService = UserService(),
+  userRepository = new UserRepository(),
+  authorizationService = AuthorizationService(),
+  firebaseAuth = FirebaseAuthClient,
+  scryptParams,
+}: {
+  userService?: ReturnType<typeof UserService>;
+  userRepository?: UserRepository;
+  authorizationService?: ReturnType<typeof AuthorizationService>;
+  firebaseAuth?: typeof FirebaseAuthClient;
+  scryptParams?: FirebaseScryptParams;
+} = {}) {
+  const ENTITY_TYPE_TO_FGA_TYPE: Record<EntityType, FgaType> = {
+    district: FgaType.DISTRICT,
+    school: FgaType.SCHOOL,
+    class: FgaType.CLASS,
+    group: FgaType.GROUP,
+    family: FgaType.FAMILY,
+  };
+
+  // Read scrypt params lazily so importing this module (or constructing the service in a test that
+  // never reaches the create bin) doesn't require the secrets to be present.
+  function getScryptParams(): FirebaseScryptParams {
+    return scryptParams ?? getFirebaseScryptParamsFromEnv();
+  }
+
+  /**
+   * Authorize a row's memberships, mirroring single-create's authorization. Super admins bypass FGA;
+   * non-super-admins must hold `can_create_users` on every membership target (class memberships are
+   * checked against the parent school). Throws `ApiError` (FORBIDDEN / UNPROCESSABLE_ENTITY) on deny.
+   *
+   * The same permission gates create, update, and unenroll — matching the legacy cloud function,
+   * which validates the requester's org coverage identically for all three.
+   */
+  async function authorizeRow(authContext: AuthContext, memberships: ImportRowMembership[]): Promise<void> {
+    const { userId, isSuperAdmin } = authContext;
+
+    if (isSuperAdmin) return;
+
+    // Guard against a non-super-admin creating a platform_admin.
+    for (const m of memberships) {
+      if (m.entityType !== EntityType.FAMILY && m.role === UserRole.PLATFORM_ADMIN) {
+        logger.warn({ userId, attemptedRole: m.role }, 'Non-super-admin attempted to import a platform_admin');
+        throw new ApiError(ApiErrorMessage.FORBIDDEN, {
+          statusCode: StatusCodes.FORBIDDEN,
+          code: ApiErrorCode.AUTH_FORBIDDEN,
+          context: { userId },
+        });
+      }
+    }
+
+    for (const membership of memberships) {
+      if (membership.entityType === EntityType.CLASS) {
+        const schoolId = await userRepository.findClassParentSchool(membership.entityId);
+        if (!schoolId) {
+          throw new ApiError(ApiErrorMessage.UNPROCESSABLE_ENTITY, {
+            statusCode: StatusCodes.UNPROCESSABLE_ENTITY,
+            code: ApiErrorCode.RESOURCE_NOT_FOUND,
+            context: { userId, classId: membership.entityId },
+          });
+        }
+        await authorizationService.requirePermission(
+          userId,
+          FgaRelation.CAN_CREATE_USERS,
+          `${FgaType.SCHOOL}:${schoolId}`,
+        );
+      } else if (membership.entityType !== EntityType.FAMILY) {
+        await authorizationService.requirePermission(
+          userId,
+          FgaRelation.CAN_CREATE_USERS,
+          `${ENTITY_TYPE_TO_FGA_TYPE[membership.entityType]}:${membership.entityId}`,
+        );
+      }
+      // FAMILY memberships intentionally skip the FGA check here, matching single-create's
+      // outstanding authorization gap (roar-project-management#1774).
+    }
+  }
+
+  /** Returns true if a Firebase Auth account already exists for the email. */
+  async function firebaseEmailExists(email: string): Promise<boolean> {
+    try {
+      await firebaseAuth.getUserByEmail(email);
+      return true;
+    } catch (error) {
+      if (isFirebaseError(error) && error.code === FIREBASE_ERROR_CODES.AUTH.USER_NOT_FOUND) {
+        return false;
+      }
+      throw error;
+    }
+  }
+
+  /** Map a Firebase `importUsers` FailedAccount error to a safe per-row error code. */
+  function mapImportError(error: unknown): string {
+    if (isFirebaseError(error) && error.code === FIREBASE_ERROR_CODES.AUTH.EMAIL_ALREADY_EXISTS) {
+      return ApiErrorCode.RESOURCE_CONFLICT;
+    }
+    return ApiErrorCode.EXTERNAL_SERVICE_FAILED;
+  }
+
+  /** Build the {@link UserService.createWithImportedAuth} payload for a create row. */
+  function toCreateUserData(row: ImportUserRowInput, assessmentPid: string) {
+    return {
+      email: row.email,
+      // Unused by createWithImportedAuth (the account is already created); kept for type shape.
+      password: row.password ?? '',
+      name: { first: row.name.first, middle: row.name.middle ?? undefined, last: row.name.last },
+      userType: row.userType,
+      dob: row.dob ?? undefined,
+      grade: row.grade ?? undefined,
+      demographics: row.demographics ?? undefined,
+      identifiers: { ...row.identifiers, pid: assessmentPid },
+      memberships: row.memberships,
+    };
+  }
+
+  /**
+   * Process the create bin: within-batch + Postgres + Firebase uniqueness pre-checks, then one
+   * `importUsers` call, then per-row persistence with compensation. Writes each row's outcome into
+   * `outcomes` by its original index.
+   */
+  async function processCreateBin(
+    authContext: AuthContext,
+    rows: { index: number; row: ImportUserRowInput }[],
+    outcomes: ImportRowOutcome[],
+  ): Promise<void> {
+    if (rows.length === 0) return;
+
+    // Within-batch email uniqueness — importUsers does not validate it.
+    const seenEmails = new Set<string>();
+    const candidates: { index: number; row: ImportUserRowInput }[] = [];
+    for (const candidate of rows) {
+      const key = candidate.row.email.toLowerCase();
+      if (seenEmails.has(key)) {
+        outcomes[candidate.index] = failed(
+          candidate.index,
+          CLASSIFICATION.CREATED,
+          ApiErrorCode.RESOURCE_CONFLICT,
+          ApiErrorMessage.CONFLICT,
+        );
+        continue;
+      }
+      seenEmails.add(key);
+      candidates.push(candidate);
+    }
+
+    const params = getScryptParams();
+
+    // Pre-flight each candidate: password required, PID + Postgres/Firebase uniqueness, then hash.
+    const prepared: {
+      index: number;
+      row: ImportUserRowInput;
+      firebaseUid: string;
+      assessmentPid: string;
+      passwordHash: Buffer;
+      passwordSalt: Buffer;
+    }[] = [];
+
+    for (const candidate of candidates) {
+      const { index, row } = candidate;
+
+      if (!row.password) {
+        outcomes[index] = failed(
+          index,
+          CLASSIFICATION.CREATED,
+          ApiErrorCode.REQUEST_VALIDATION_FAILED,
+          'Password is required to create a user',
+        );
+        continue;
+      }
+
+      const assessmentPid = row.identifiers?.pid ?? generateAssessmentPid({ userId: row.email });
+
+      try {
+        const exists = await userRepository.existsByUniqueFields({ email: row.email, assessmentPid });
+        if (exists || (await firebaseEmailExists(row.email))) {
+          outcomes[index] = failed(
+            index,
+            CLASSIFICATION.CREATED,
+            ApiErrorCode.RESOURCE_CONFLICT,
+            ApiErrorMessage.CONFLICT,
+          );
+          continue;
+        }
+      } catch (error) {
+        logger.error({ err: error, context: { email: row.email } }, 'Uniqueness pre-check failed during import');
+        outcomes[index] = failed(
+          index,
+          CLASSIFICATION.CREATED,
+          ApiErrorCode.EXTERNAL_SERVICE_FAILED,
+          ApiErrorMessage.INTERNAL_SERVER_ERROR,
+        );
+        continue;
+      }
+
+      const { passwordHash, passwordSalt } = await hashPasswordForImport(row.password, params);
+      prepared.push({ index, row, firebaseUid: randomUUID(), assessmentPid, passwordHash, passwordSalt });
+    }
+
+    if (prepared.length === 0) return;
+
+    // One batched importUsers call for every prepared row.
+    const records: UserImportRecord[] = prepared.map((p) => ({
+      uid: p.firebaseUid,
+      email: p.row.email,
+      displayName: [p.row.name.first, p.row.name.last].filter(Boolean).join(' '),
+      passwordHash: p.passwordHash,
+      passwordSalt: p.passwordSalt,
+    }));
+
+    let result: UserImportResult;
+    try {
+      result = await firebaseAuth.importUsers(records, {
+        hash: {
+          algorithm: 'SCRYPT' as const,
+          key: params.signerKey,
+          saltSeparator: params.saltSeparator,
+          rounds: params.rounds,
+          memoryCost: params.memoryCost,
+        },
+      });
+    } catch (error) {
+      // The whole importUsers call failed (e.g. Admin SDK unavailable). Fail every prepared row;
+      // nothing was persisted, so there is nothing to compensate.
+      logger.error({ err: error, context: { count: prepared.length } }, 'importUsers call failed');
+      for (const p of prepared) {
+        outcomes[p.index] = failed(
+          p.index,
+          CLASSIFICATION.CREATED,
+          ApiErrorCode.EXTERNAL_SERVICE_FAILED,
+          ApiErrorMessage.INTERNAL_SERVER_ERROR,
+        );
+      }
+      return;
+    }
+
+    // Mark rows that Firebase rejected (by their position in the records array).
+    const failedRecordIndexes = new Set<number>();
+    for (const failure of result.errors ?? []) {
+      failedRecordIndexes.add(failure.index);
+      const p = prepared[failure.index];
+      if (p) {
+        outcomes[p.index] = failed(
+          p.index,
+          CLASSIFICATION.CREATED,
+          mapImportError(failure.error),
+          ApiErrorMessage.CONFLICT,
+        );
+      }
+    }
+
+    // Persist each successfully-imported row. createWithImportedAuth compensates (incl. deleting the
+    // imported Firebase account) on any DB/FGA failure, so a failed row leaves no orphan.
+    for (let i = 0; i < prepared.length; i++) {
+      if (failedRecordIndexes.has(i)) continue;
+      const p = prepared[i]!;
+      try {
+        const { id } = await userService.createWithImportedAuth(
+          authContext,
+          toCreateUserData(p.row, p.assessmentPid),
+          p.firebaseUid,
+        );
+        outcomes[p.index] = ok(p.index, CLASSIFICATION.CREATED, id);
+      } catch (error) {
+        outcomes[p.index] = toFailedOutcome(p.index, CLASSIFICATION.CREATED, error);
+      }
+    }
+  }
+
+  /**
+   * Classify each row into create / update / unenroll and process each bin.
+   *
+   * @param authContext - The requesting user's auth context.
+   * @param rows - The import rows, in request order.
+   * @returns Per-row outcomes, one per input row, in request order.
+   */
+  async function bulkImport(authContext: AuthContext, rows: ImportUserRowInput[]): Promise<ImportRowOutcome[]> {
+    const outcomes: ImportRowOutcome[] = new Array(rows.length);
+
+    // ── Phase 1: per-row authorization (before any external writes) ──────────────
+    const authorized: { index: number; row: ImportUserRowInput }[] = [];
+    for (let index = 0; index < rows.length; index++) {
+      const row = rows[index]!;
+      try {
+        await authorizeRow(authContext, row.memberships);
+        authorized.push({ index, row });
+      } catch (error) {
+        outcomes[index] = toFailedOutcome(index, preRoutingClassification(row), error);
+      }
+    }
+
+    if (authorized.length === 0) return outcomes;
+
+    // ── Phase 2: classify by email existence (single batched lookup) ─────────────
+    const existing = await userRepository.findByEmails(authorized.map((a) => a.row.email));
+    const existingByEmail = new Map<string, (typeof existing)[number]>();
+    for (const user of existing) {
+      if (user.email) existingByEmail.set(user.email.toLowerCase(), user);
+    }
+
+    const createRows: { index: number; row: ImportUserRowInput }[] = [];
+    const updateRows: { index: number; row: ImportUserRowInput }[] = [];
+    const unenrollRows: { index: number; row: ImportUserRowInput }[] = [];
+
+    for (const entry of authorized) {
+      const found = existingByEmail.has(entry.row.email.toLowerCase());
+      const unenroll = Boolean(entry.row.unenroll);
+
+      if (found && unenroll) {
+        unenrollRows.push(entry);
+      } else if (found) {
+        updateRows.push(entry);
+      } else if (unenroll) {
+        // Unenroll requested for a user that does not exist.
+        // NOTE: the legacy cloud function routes this to the unenroll bin as a no-op rather than
+        // rejecting. We reject per the ticket spec; revisit if strict parity is preferred.
+        outcomes[entry.index] = failed(
+          entry.index,
+          CLASSIFICATION.UNENROLLED,
+          ApiErrorCode.RESOURCE_NOT_FOUND,
+          ApiErrorMessage.UNPROCESSABLE_ENTITY,
+        );
+      } else {
+        createRows.push(entry);
+      }
+    }
+
+    // ── Phase 3: create bin ──────────────────────────────────────────────────────
+    await processCreateBin(authContext, createRows, outcomes);
+
+    // ── Phases 4–5: update + unenroll bins (next increment) ──────────────────────
+    // These require new repository support (enrollment-ending, rosteringEnded archiving, membership
+    // reconciliation) and a per-row updateUser path for password/name. Until then, report rather
+    // than silently mishandle.
+    for (const entry of updateRows) {
+      outcomes[entry.index] = failed(
+        entry.index,
+        CLASSIFICATION.UPDATED,
+        ApiErrorCode.INTERNAL,
+        'Update of existing users is not yet supported by this endpoint',
+      );
+    }
+    for (const entry of unenrollRows) {
+      outcomes[entry.index] = failed(
+        entry.index,
+        CLASSIFICATION.UNENROLLED,
+        ApiErrorCode.INTERNAL,
+        'Unenrollment is not yet supported by this endpoint',
+      );
+    }
+
+    return outcomes;
+  }
+
+  return { bulkImport };
+}

--- a/apps/backend/src/services/user/user.service.ts
+++ b/apps/backend/src/services/user/user.service.ts
@@ -782,6 +782,204 @@ export function UserService({
   }
 
   /**
+   * Persist a user whose Firebase Auth account already exists.
+   *
+   * Runs the identical DB-transaction + FGA-tuple saga as `create()` steps 4–5, but takes a
+   * pre-created `firebaseUid` instead of calling `createUser`. This lets the bulk-import create bin
+   * create all Firebase accounts in a single `importUsers` call (one round-trip, no per-account
+   * rate limit) and then persist each one here, reusing the same compensation guarantees.
+   *
+   * The caller owns authorization, uniqueness pre-checks, and Firebase account creation. On any DB
+   * or FGA failure this compensates by deleting the FGA tuples, the DB rows, and — since the caller
+   * created it — the Firebase account, so a failed row leaves no orphan in any system.
+   *
+   * @param authContext - Requesting user's auth context (for logging/compensation context).
+   * @param body - The user fields + memberships (same shape as `create`).
+   * @param firebaseUid - The pre-created Firebase Auth UID to store as the user's authId.
+   * @returns The new user's id.
+   * @throws {ApiError} CONFLICT on a unique-field collision, UNPROCESSABLE_ENTITY on a bad
+   *   membership reference, or INTERNAL_SERVER_ERROR on DB/FGA failure — after compensation.
+   */
+  async function createWithImportedAuth(
+    authContext: AuthContext,
+    body: CreateUserData,
+    firebaseUid: string,
+  ): Promise<{ id: string }> {
+    const { demographics, dob, grade, email, identifiers, memberships, name, userType } = body;
+    const { userId } = authContext;
+
+    const assessmentPid = identifiers?.pid ?? generateAssessmentPid({ userId: email });
+
+    let newUserId!: string;
+    try {
+      const enrollmentStart = new Date();
+
+      const orgMemberships: Omit<NewUserOrg, 'userId'>[] = memberships
+        .filter(isOrgMembership)
+        .filter((m) => m.entityType === EntityType.DISTRICT || m.entityType === EntityType.SCHOOL)
+        .map((m) => ({
+          orgId: m.entityId,
+          role: m.role,
+          enrollmentStart: m.enrollmentStart ? new Date(m.enrollmentStart) : enrollmentStart,
+          enrollmentEnd: m.enrollmentEnd ? new Date(m.enrollmentEnd) : null,
+        }));
+
+      const classMemberships: Omit<NewUserClass, 'userId'>[] = memberships
+        .filter(isOrgMembership)
+        .filter((m) => m.entityType === EntityType.CLASS)
+        .map((m) => ({
+          classId: m.entityId,
+          role: m.role,
+          enrollmentStart: m.enrollmentStart ? new Date(m.enrollmentStart) : enrollmentStart,
+          enrollmentEnd: m.enrollmentEnd ? new Date(m.enrollmentEnd) : null,
+        }));
+
+      const groupMemberships: Omit<NewUserGroup, 'userId'>[] = memberships
+        .filter(isOrgMembership)
+        .filter((m) => m.entityType === EntityType.GROUP)
+        .map((m) => ({
+          groupId: m.entityId,
+          role: m.role,
+          enrollmentStart: m.enrollmentStart ? new Date(m.enrollmentStart) : enrollmentStart,
+          enrollmentEnd: m.enrollmentEnd ? new Date(m.enrollmentEnd) : null,
+        }));
+
+      const familyMemberships: Omit<NewUserFamily, 'userId'>[] = memberships.filter(isFamilyMembership).map((m) => ({
+        familyId: m.entityId,
+        role: m.role,
+        joinedOn: m.enrollmentStart ? new Date(m.enrollmentStart) : enrollmentStart,
+        leftOn: m.enrollmentEnd ? new Date(m.enrollmentEnd) : null,
+      }));
+
+      const resolvedRootOrgProvider = await resolveRootOrgProviderFromMemberships(memberships);
+
+      newUserId = await userRepository.runTransaction({
+        fn: async (tx) => {
+          const result = await userRepository.createWithMemberships(
+            {
+              authId: firebaseUid,
+              authProvider: [AuthProvider.PASSWORD],
+              email: email,
+              nameFirst: name.first,
+              nameMiddle: name.middle ?? null,
+              nameLast: name.last,
+              dob: dob ?? null,
+              grade: grade ?? null,
+              assessmentPid,
+              userType: userType,
+              statusEll: demographics?.statusEll ?? null,
+              statusFrl: demographics?.statusFrl ?? null,
+              statusIep: demographics?.statusIep ?? null,
+              gender: demographics?.gender ?? null,
+              race: demographics?.race ?? null,
+              hispanicEthnicity: demographics?.hispanicEthnicity ?? null,
+              homeLanguage: demographics?.homeLanguage ?? null,
+              stateId: identifiers?.stateId ?? null,
+              isSuperAdmin: false,
+            },
+            orgMemberships,
+            classMemberships,
+            groupMemberships,
+            familyMemberships,
+            tx,
+          );
+
+          await rosterProviderIdRepository.create({
+            data: {
+              providerType: RosteringProvider.DASHBOARD,
+              providerId: result.id,
+              partnerId: resolvedRootOrgProvider,
+              entityType: RosteringEntityType.USER,
+              entityId: result.id,
+            },
+            transaction: tx,
+          });
+
+          return result.id;
+        },
+      });
+    } catch (error) {
+      // The DB transaction rolled back atomically; only the caller-created Firebase account needs
+      // compensating deletion.
+      await compensateDeleteFirebaseUser(firebaseUid, userId, email, 'import persistence DB failure');
+
+      if (error instanceof ApiError) throw error;
+
+      const dbError = unwrapDrizzleError(error);
+
+      if (isUniqueViolation(dbError)) {
+        throw new ApiError(ApiErrorMessage.CONFLICT, {
+          statusCode: StatusCodes.CONFLICT,
+          code: ApiErrorCode.RESOURCE_CONFLICT,
+          context: { userId, email },
+          cause: error,
+        });
+      }
+
+      if (isForeignKeyViolation(dbError)) {
+        throw new ApiError(ApiErrorMessage.UNPROCESSABLE_ENTITY, {
+          statusCode: StatusCodes.UNPROCESSABLE_ENTITY,
+          code: ApiErrorCode.RESOURCE_NOT_FOUND,
+          context: { userId, email },
+          cause: error,
+        });
+      }
+
+      logger.error({ err: error, context: { userId, email } }, 'DB write failed during imported-auth user create');
+      throw new ApiError('Failed to create user record', {
+        statusCode: StatusCodes.INTERNAL_SERVER_ERROR,
+        code: ApiErrorCode.DATABASE_QUERY_FAILED,
+        context: { userId, email, firebaseUid },
+        cause: error,
+      });
+    }
+
+    const fgaTuples = buildMembershipTuples(newUserId, memberships);
+
+    try {
+      await authorizationService.writeTuplesOrThrow(fgaTuples);
+    } catch (error) {
+      logger.error(
+        { err: error, context: { userId, newUserId, email, firebaseUid } },
+        'FGA write failed during imported-auth user create — beginning compensation',
+      );
+
+      const deleteTuples: TupleKeyWithoutCondition[] = fgaTuples.map(({ user, relation, object }) => ({
+        user,
+        relation,
+        object,
+      }));
+      await authorizationService.deleteTuples(deleteTuples);
+
+      try {
+        await userRepository.runTransaction({
+          fn: async (tx) => {
+            await rosterProviderIdRepository.deleteByEntityId(newUserId, tx);
+            await userRepository.delete({ id: newUserId, transaction: tx });
+          },
+        });
+      } catch (dbDeleteError) {
+        logger.error(
+          { err: dbDeleteError, context: { userId, newUserId, firebaseUid } },
+          'DB delete compensation failed after FGA write failure — manual cleanup required',
+        );
+      }
+
+      await compensateDeleteFirebaseUser(firebaseUid, userId, email, 'import FGA write failure');
+
+      throw new ApiError(ApiErrorMessage.EXTERNAL_SERVICE_UNAVAILABLE, {
+        statusCode: StatusCodes.INTERNAL_SERVER_ERROR,
+        code: ApiErrorCode.EXTERNAL_SERVICE_FAILED,
+        context: { userId, newUserId, email, firebaseUid },
+        cause: error,
+      });
+    }
+
+    logger.info({ userId, newUserId, email }, 'Created user (imported auth)');
+    return { id: newUserId };
+  }
+
+  /**
    * Verifies that a membership entity exists and is active (not rostered out).
    *
    * @param entityType The type of the membership entity to verify.
@@ -1471,5 +1669,14 @@ export function UserService({
     }
   }
 
-  return { findByAuthId, getById, create, update, recordUserAgreement, getUnsignedTosAgreements, createAnonymousUser };
+  return {
+    findByAuthId,
+    getById,
+    create,
+    createWithImportedAuth,
+    update,
+    recordUserAgreement,
+    getUnsignedTosAgreements,
+    createAnonymousUser,
+  };
 }

--- a/apps/backend/src/services/user/utils/firebase-password-hash.test.ts
+++ b/apps/backend/src/services/user/utils/firebase-password-hash.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from 'vitest';
+import { firebaseScryptHash, hashPasswordForImport, getFirebaseScryptParamsFromEnv } from './firebase-password-hash';
+
+/**
+ * Official Firebase scrypt test vector, published at https://github.com/firebase/scrypt.
+ * Hashing `password` with `salt` under these parameters MUST yield `expectedHash`. This is the
+ * ground-truth proof that our implementation matches Firebase's — if it drifts, imported users
+ * cannot sign in.
+ */
+const VECTOR = {
+  signerKey: 'jxspr8Ki0RYycVU8zykbdLGjFQ3McFUH0uiiTvC8pVMXAn210wjLNmdZJzxUECKbm0QsEmYUSDzZvpjeJ9WmXA==',
+  saltSeparator: 'Bw==',
+  rounds: 8,
+  memoryCost: 14,
+  salt: '42xEC+ixf3L2lw==',
+  password: 'user1password',
+  expectedHash: 'lSrfV15cpx95/sZS2W9c9Kp6i/LVgQNDNC/qzrCnh1SAyZvqmZqAjTdn3aoItz+VHjoZilo78198JAdRuid5lQ==',
+} as const;
+
+const vectorParams = () => ({
+  signerKey: Buffer.from(VECTOR.signerKey, 'base64'),
+  saltSeparator: Buffer.from(VECTOR.saltSeparator, 'base64'),
+  rounds: VECTOR.rounds,
+  memoryCost: VECTOR.memoryCost,
+});
+
+describe('firebaseScryptHash', () => {
+  it('matches the official Firebase scrypt test vector', async () => {
+    const hash = await firebaseScryptHash(VECTOR.password, Buffer.from(VECTOR.salt, 'base64'), vectorParams());
+    expect(hash.toString('base64')).toBe(VECTOR.expectedHash);
+  });
+
+  it('produces a different hash for a different password', async () => {
+    const hash = await firebaseScryptHash('not-the-password', Buffer.from(VECTOR.salt, 'base64'), vectorParams());
+    expect(hash.toString('base64')).not.toBe(VECTOR.expectedHash);
+  });
+});
+
+describe('hashPasswordForImport', () => {
+  it('generates a 16-byte salt and a hash reproducible from that salt', async () => {
+    const { passwordHash, passwordSalt } = await hashPasswordForImport(VECTOR.password, vectorParams());
+    expect(passwordSalt).toHaveLength(16);
+    // Re-hashing with the same salt reproduces the hash (deterministic given the salt).
+    const rehash = await firebaseScryptHash(VECTOR.password, passwordSalt, vectorParams());
+    expect(rehash.equals(passwordHash)).toBe(true);
+  });
+
+  it('uses a fresh random salt on each call', async () => {
+    const a = await hashPasswordForImport(VECTOR.password, vectorParams());
+    const b = await hashPasswordForImport(VECTOR.password, vectorParams());
+    expect(a.passwordSalt.equals(b.passwordSalt)).toBe(false);
+  });
+});
+
+describe('getFirebaseScryptParamsFromEnv', () => {
+  const validEnv = {
+    FIREBASE_SCRYPT_SIGNER_KEY: VECTOR.signerKey,
+    FIREBASE_SCRYPT_SALT_SEPARATOR: VECTOR.saltSeparator,
+    FIREBASE_SCRYPT_ROUNDS: String(VECTOR.rounds),
+    FIREBASE_SCRYPT_MEM_COST: String(VECTOR.memoryCost),
+  };
+
+  it('parses and base64-decodes the configured params', () => {
+    const params = getFirebaseScryptParamsFromEnv(validEnv);
+    expect(params.rounds).toBe(8);
+    expect(params.memoryCost).toBe(14);
+    expect(params.signerKey.equals(Buffer.from(VECTOR.signerKey, 'base64'))).toBe(true);
+    expect(params.saltSeparator.equals(Buffer.from(VECTOR.saltSeparator, 'base64'))).toBe(true);
+  });
+
+  it('throws listing the missing variables', () => {
+    expect(() => getFirebaseScryptParamsFromEnv({})).toThrow(/FIREBASE_SCRYPT_SIGNER_KEY/);
+  });
+
+  it('throws when rounds or mem_cost are not integers', () => {
+    expect(() => getFirebaseScryptParamsFromEnv({ ...validEnv, FIREBASE_SCRYPT_ROUNDS: 'abc' })).toThrow(/integers/);
+  });
+});

--- a/apps/backend/src/services/user/utils/firebase-password-hash.ts
+++ b/apps/backend/src/services/user/utils/firebase-password-hash.ts
@@ -1,0 +1,135 @@
+import { createCipheriv, randomBytes, scrypt as scryptCb } from 'node:crypto';
+import type { BinaryLike, ScryptOptions } from 'node:crypto';
+import { promisify } from 'node:util';
+
+/**
+ * Firebase Authentication hashes passwords with an internally modified scrypt. The bulk
+ * `importUsers` path requires each record to carry an already-computed `passwordHash` +
+ * `passwordSalt`, plus the project's hash parameters in `UserImportOptions.hash` so Firebase can
+ * verify the password at sign-in. This module computes that hash.
+ *
+ * Algorithm (mirrors https://github.com/firebase/scrypt and its language ports):
+ *   1. derivedKey = scrypt(password, passwordSalt ‖ saltSeparator, N = 2**memoryCost, r = rounds, p = 1, len = 64)
+ *   2. passwordHash = AES-256-CTR( key = derivedKey[0..32], iv = 16 zero bytes ).encrypt(signerKey)
+ *
+ * Correctness is pinned by a known-answer test against Firebase's published vector
+ * (see firebase-password-hash.test.ts).
+ */
+
+const scryptAsync = promisify(scryptCb) as (
+  password: BinaryLike,
+  salt: BinaryLike,
+  keylen: number,
+  options: ScryptOptions,
+) => Promise<Buffer>;
+
+const DERIVED_KEY_LENGTH = 64;
+const AES_KEY_LENGTH = 32;
+// Firebase's scrypt variant encrypts the signer key with a 16-byte all-zero IV.
+const AES_IV = Buffer.alloc(16);
+const PASSWORD_SALT_LENGTH = 16;
+
+/**
+ * Parameters for Firebase's modified scrypt. Every Firebase project has a unique set, found in the
+ * console under Authentication → Users → ⋮ → "Password hash parameters". Provision them as backend
+ * secrets — they must not live in source.
+ */
+export interface FirebaseScryptParams {
+  /** base64-decoded `base64_signer_key`. */
+  signerKey: Buffer;
+  /** base64-decoded `base64_salt_separator`. */
+  saltSeparator: Buffer;
+  /** `rounds` parameter (scrypt block size `r`). */
+  rounds: number;
+  /** `mem_cost` parameter; the scrypt CPU/memory cost is `N = 2 ** memoryCost`. */
+  memoryCost: number;
+}
+
+/**
+ * Computes Firebase's modified-scrypt password hash for a known salt.
+ *
+ * @param password - The plaintext password.
+ * @param passwordSalt - The per-user salt (raw bytes).
+ * @param params - The Firebase project's scrypt parameters.
+ * @returns The password hash as raw bytes (base64-encode for `importUsers` or comparison).
+ */
+export async function firebaseScryptHash(
+  password: string,
+  passwordSalt: Buffer,
+  params: FirebaseScryptParams,
+): Promise<Buffer> {
+  const { signerKey, saltSeparator, rounds, memoryCost } = params;
+  const cost = 2 ** memoryCost;
+  const salt = Buffer.concat([passwordSalt, saltSeparator]);
+  // scrypt needs ~128 * N * r bytes; give 2x headroom so larger mem_cost values don't trip maxmem.
+  const maxmem = 128 * cost * rounds * 2;
+
+  const derivedKey = await scryptAsync(Buffer.from(password), salt, DERIVED_KEY_LENGTH, {
+    N: cost,
+    r: rounds,
+    p: 1,
+    maxmem,
+  });
+
+  const cipher = createCipheriv('aes-256-ctr', derivedKey.subarray(0, AES_KEY_LENGTH), AES_IV);
+  return Buffer.concat([cipher.update(signerKey), cipher.final()]);
+}
+
+/**
+ * Generates a random per-user salt and returns the `{ passwordHash, passwordSalt }` pair for a
+ * Firebase `importUsers` `UserImportRecord`. The caller must pass the same `params` to
+ * `importUsers` via `UserImportOptions.hash` so Firebase can verify the password at sign-in.
+ *
+ * @param password - The plaintext password.
+ * @param params - The Firebase project's scrypt parameters.
+ * @returns The import-ready hash and salt buffers.
+ */
+export async function hashPasswordForImport(
+  password: string,
+  params: FirebaseScryptParams,
+): Promise<{ passwordHash: Buffer; passwordSalt: Buffer }> {
+  const passwordSalt = randomBytes(PASSWORD_SALT_LENGTH);
+  const passwordHash = await firebaseScryptHash(password, passwordSalt, params);
+  return { passwordHash, passwordSalt };
+}
+
+/**
+ * Reads the Firebase scrypt parameters from the environment, base64-decoding the signer key and
+ * salt separator. Throws a descriptive error if any are missing or malformed so a misconfigured
+ * deployment fails loudly rather than silently producing unverifiable hashes.
+ *
+ * @param env - The environment to read from (defaults to `process.env`; injectable for tests).
+ * @returns The parsed scrypt parameters.
+ * @throws {Error} If any required variable is missing or `rounds`/`mem_cost` are not integers.
+ */
+export function getFirebaseScryptParamsFromEnv(env: NodeJS.ProcessEnv = process.env): FirebaseScryptParams {
+  const signerKeyB64 = env.FIREBASE_SCRYPT_SIGNER_KEY;
+  const saltSeparatorB64 = env.FIREBASE_SCRYPT_SALT_SEPARATOR;
+  const roundsRaw = env.FIREBASE_SCRYPT_ROUNDS;
+  const memoryCostRaw = env.FIREBASE_SCRYPT_MEM_COST;
+
+  if (!signerKeyB64 || !saltSeparatorB64 || !roundsRaw || !memoryCostRaw) {
+    const missing = [
+      ['FIREBASE_SCRYPT_SIGNER_KEY', signerKeyB64],
+      ['FIREBASE_SCRYPT_SALT_SEPARATOR', saltSeparatorB64],
+      ['FIREBASE_SCRYPT_ROUNDS', roundsRaw],
+      ['FIREBASE_SCRYPT_MEM_COST', memoryCostRaw],
+    ]
+      .filter(([, value]) => !value)
+      .map(([name]) => name);
+    throw new Error(`Missing Firebase scrypt configuration: ${missing.join(', ')}`);
+  }
+
+  const rounds = Number(roundsRaw);
+  const memoryCost = Number(memoryCostRaw);
+  if (!Number.isInteger(rounds) || !Number.isInteger(memoryCost)) {
+    throw new Error('FIREBASE_SCRYPT_ROUNDS and FIREBASE_SCRYPT_MEM_COST must be integers');
+  }
+
+  return {
+    signerKey: Buffer.from(signerKeyB64, 'base64'),
+    saltSeparator: Buffer.from(saltSeparatorB64, 'base64'),
+    rounds,
+    memoryCost,
+  };
+}

--- a/apps/backend/src/test-support/mocks/firebase-admin.mock.ts
+++ b/apps/backend/src/test-support/mocks/firebase-admin.mock.ts
@@ -30,5 +30,6 @@ vi.mock('firebase-admin/auth', () => ({
     createCustomToken: vi.fn(),
     listUsers: vi.fn(),
     updateUser: vi.fn(),
+    importUsers: vi.fn(),
   })),
 }));

--- a/apps/backend/src/test-support/mocks/firebase-admin.mock.ts
+++ b/apps/backend/src/test-support/mocks/firebase-admin.mock.ts
@@ -25,6 +25,7 @@ vi.mock('firebase-admin/auth', () => ({
     verifyIdToken: vi.fn(),
     createUser: vi.fn(),
     getUserByEmail: vi.fn(),
+    getUsers: vi.fn(),
     deleteUser: vi.fn(),
     setCustomUserClaims: vi.fn(),
     createCustomToken: vi.fn(),

--- a/apps/backend/src/test-support/repositories/user.repository.ts
+++ b/apps/backend/src/test-support/repositories/user.repository.ts
@@ -18,6 +18,8 @@ export function createMockUserRepository(): MockedObject<UserRepository> {
     existsByUniqueFields: vi.fn(),
     findByEmails: vi.fn(),
     endAllEnrollments: vi.fn(),
+    getActiveMembershipsWithRoles: vi.fn(),
+    archiveUser: vi.fn(),
   } as MockedObject<UserRepository>;
 }
 

--- a/apps/backend/src/test-support/repositories/user.repository.ts
+++ b/apps/backend/src/test-support/repositories/user.repository.ts
@@ -17,6 +17,7 @@ export function createMockUserRepository(): MockedObject<UserRepository> {
     createWithMemberships: vi.fn(),
     existsByUniqueFields: vi.fn(),
     findByEmails: vi.fn(),
+    endAllEnrollments: vi.fn(),
   } as MockedObject<UserRepository>;
 }
 

--- a/apps/backend/src/test-support/repositories/user.repository.ts
+++ b/apps/backend/src/test-support/repositories/user.repository.ts
@@ -20,6 +20,7 @@ export function createMockUserRepository(): MockedObject<UserRepository> {
     endAllEnrollments: vi.fn(),
     getActiveMembershipsWithRoles: vi.fn(),
     archiveUser: vi.fn(),
+    reconcileMemberships: vi.fn(),
   } as MockedObject<UserRepository>;
 }
 

--- a/apps/backend/src/test-support/repositories/user.repository.ts
+++ b/apps/backend/src/test-support/repositories/user.repository.ts
@@ -16,6 +16,7 @@ export function createMockUserRepository(): MockedObject<UserRepository> {
     findClassParentSchool: vi.fn(),
     createWithMemberships: vi.fn(),
     existsByUniqueFields: vi.fn(),
+    findByEmails: vi.fn(),
   } as MockedObject<UserRepository>;
 }
 

--- a/apps/backend/src/test-support/services/user.service.ts
+++ b/apps/backend/src/test-support/services/user.service.ts
@@ -11,6 +11,7 @@ export function createMockUserService(): MockedObject<ReturnType<typeof UserServ
     findByAuthId: vi.fn(),
     getById: vi.fn(),
     create: vi.fn(),
+    createWithImportedAuth: vi.fn(),
     update: vi.fn(),
     recordUserAgreement: vi.fn(),
     getUnsignedTosAgreements: vi.fn(),

--- a/apps/dashboard/cypress/e2e/smoke/users-import.cy.js
+++ b/apps/dashboard/cypress/e2e/smoke/users-import.cy.js
@@ -1,0 +1,208 @@
+/**
+ * Backend-only e2e proofs for POST /v1/users/import against the seeded local
+ * stack (Postgres + OpenFGA + Firebase Auth emulator + server-test.ts). These
+ * exercise the two things the unit/integration suites and mocks structurally
+ * cannot prove:
+ *
+ *   1. The SCRYPT password hash written via `importUsers` actually verifies at
+ *      sign-in (the "every imported student is locked out" risk). The
+ *      known-answer unit test proves our hash matches Firebase's published
+ *      vector; only a real importUsers → signInWithPassword round-trip proves
+ *      the payload wiring.
+ *   2. Membership reconciliation on the update bin flips real OpenFGA
+ *      authorization in BOTH directions — an added membership grants access, a
+ *      removed one revokes it. Unit tests assert the tuples we *send*; only a
+ *      live FGA `check` proves they *evaluate* to the right allow/deny.
+ *
+ * The dashboard UI is not exercised here. See `.ai/rules/frontend-e2e-testing-pattern.md`.
+ */
+
+const FIXTURE_FILE = Cypress.env('FIXTURE_FILE') ?? '/tmp/roar-cypress-fixture.json';
+const EMULATOR_HOST = Cypress.env('FIREBASE_AUTH_EMULATOR_HOST') ?? '127.0.0.1:9099';
+const ROAR_API_BASE_URL = Cypress.env('ROAR_API_BASE_URL') ?? 'http://127.0.0.1:4000';
+
+// The emulator accepts any non-empty `key`; its tokens aren't signed.
+const EMULATOR_API_KEY = 'fake-api-key';
+
+/** Sign in via the Auth emulator and yield the ID token. */
+function signInToken(email, password) {
+  return cy
+    .request({
+      method: 'POST',
+      url: `http://${EMULATOR_HOST}/identitytoolkit.googleapis.com/v1/accounts:signInWithPassword?key=${EMULATOR_API_KEY}`,
+      body: { email, password, returnSecureToken: true },
+      failOnStatusCode: false,
+    })
+    .then((res) => {
+      expect(res.status, `emulator sign-in for ${email}`).to.eq(200);
+      expect(res.body.idToken, 'idToken').to.be.a('string').and.not.empty;
+      return res.body.idToken;
+    });
+}
+
+/** POST /v1/users/import with a bearer token. */
+function importUsers(token, rows) {
+  return cy.request({
+    method: 'POST',
+    url: `${ROAR_API_BASE_URL}/v1/users/import`,
+    headers: { Authorization: `Bearer ${token}` },
+    body: { users: rows },
+    failOnStatusCode: false,
+  });
+}
+
+/** GET a backend resource with a bearer token, without failing on 4xx. */
+function authGet(token, path) {
+  return cy.request({
+    method: 'GET',
+    url: `${ROAR_API_BASE_URL}${path}`,
+    headers: { Authorization: `Bearer ${token}` },
+    failOnStatusCode: false,
+  });
+}
+
+describe('Smoke: bulk import → emulator sign-in (SCRYPT hash verifies)', () => {
+  // Unique per run so a re-run against a non-reset emulator can't collide.
+  const newUser = {
+    email: `import-signin-${Date.now()}@example.org`,
+    password: 'ImportProof123',
+    nameFirst: 'Imported',
+    nameLast: 'Student',
+  };
+  let superToken;
+  let createdUserId;
+
+  before(() => {
+    cy.readFile(FIXTURE_FILE)
+      .then((fixture) => {
+        // Super admin can call the import endpoint (bypasses FGA).
+        return signInToken(fixture.users.superAdmin.email, fixture.users.superAdmin.password);
+      })
+      .then((token) => {
+        superToken = token;
+        // The create row requires ≥1 membership — borrow any real school id.
+        return authGet(superToken, '/v1/schools?perPage=1');
+      })
+      .then((res) => {
+        expect(res.status, 'list schools').to.eq(200);
+        const schoolId = res.body.data.items[0].id;
+        return importUsers(superToken, [
+          {
+            email: newUser.email,
+            password: newUser.password,
+            name: { first: newUser.nameFirst, last: newUser.nameLast },
+            userType: 'student',
+            memberships: [{ entityType: 'school', entityId: schoolId, role: 'student' }],
+          },
+        ]);
+      })
+      .then((res) => {
+        expect(res.status, 'import status').to.eq(200);
+        expect(res.body.data.summary.created, 'created count').to.eq(1);
+        const row = res.body.data.results[0];
+        expect(row.status, `row outcome: ${JSON.stringify(row.error ?? {})}`).to.eq('ok');
+        expect(row.classification).to.eq('created');
+        createdUserId = row.id;
+      });
+  });
+
+  it('creates the Firebase + DB records (verified via a super-admin read)', () => {
+    // Guaranteed regardless of the emulator's SCRYPT support: proves the
+    // importUsers payload wiring + DB persistence end-to-end.
+    authGet(superToken, `/v1/users/${createdUserId}`).then((res) => {
+      expect(res.status, 'GET imported user').to.eq(200);
+      expect(res.body.data.email).to.eq(newUser.email);
+    });
+  });
+
+  it('the imported password verifies end-to-end (emulator sign-in + /me)', () => {
+    // Headline lock-out proof: the SCRYPT hash written via importUsers must
+    // verify at sign-in. If this reds with a 4xx sign-in, the Firebase Auth
+    // emulator does not recompute Firebase-scrypt for imported users (the
+    // existing emulator seeder uses plaintext createUser, so this is the first
+    // place importUsers-against-emulator is exercised). The hashing algorithm
+    // itself stays pinned by the firebase-password-hash known-answer unit test;
+    // if the emulator is the limitation, downgrade this to an emulator
+    // account-existence check rather than treating it as an import regression.
+    signInToken(newUser.email, newUser.password)
+      .then((token) => authGet(token, '/v1/me'))
+      .then((meRes) => {
+        expect(meRes.status, 'GET /v1/me as the imported user').to.eq(200);
+        expect(meRes.body.data.id, 'me.id matches the imported user').to.eq(createdUserId);
+      });
+  });
+});
+
+describe('Smoke: bulk import update → membership reconcile → OpenFGA reflects access', () => {
+  let superToken;
+  let adminToken;
+  let admin; // the schoolAAdmin fixture user (plaintext-seeded — emulator-scrypt-independent)
+  let schoolX; // the school the admin currently belongs to
+  let schoolY; // a different school the admin will be reconciled into
+
+  before(() => {
+    cy.readFile(FIXTURE_FILE)
+      .then((fixture) => {
+        admin = fixture.users.schoolAAdmin;
+        return signInToken(fixture.users.superAdmin.email, fixture.users.superAdmin.password);
+      })
+      .then((token) => {
+        superToken = token;
+        return signInToken(admin.email, admin.password);
+      })
+      .then((token) => {
+        adminToken = token;
+        // A school admin can read exactly the school(s) they belong to.
+        return authGet(adminToken, '/v1/schools');
+      })
+      .then((res) => {
+        expect(res.status, 'admin lists own schools').to.eq(200);
+        expect(res.body.data.items.length, 'admin belongs to a school').to.be.greaterThan(0);
+        schoolX = res.body.data.items[0].id;
+        // Pick a different school (from the super-admin-wide list) to move into.
+        return authGet(superToken, '/v1/schools');
+      })
+      .then((res) => {
+        expect(res.status, 'super admin lists all schools').to.eq(200);
+        const other = res.body.data.items.find((s) => s.id !== schoolX);
+        expect(other, 'a second school exists to reconcile into').to.exist;
+        schoolY = other.id;
+      });
+  });
+
+  it('baseline: the admin can read their school but is denied the target school', () => {
+    authGet(adminToken, `/v1/schools/${schoolX}`).then((res) => expect(res.status, 'reads own school').to.eq(200));
+    authGet(adminToken, `/v1/schools/${schoolY}`).then((res) =>
+      expect(res.status, 'denied on the not-yet-member school').to.eq(403),
+    );
+  });
+
+  it('reconcile moves the admin from schoolX to schoolY and OpenFGA reflects both directions', () => {
+    // Replace-semantics update: providing only schoolY for the school entity
+    // type ends the schoolX membership and adds schoolY.
+    importUsers(superToken, [
+      {
+        email: admin.email,
+        name: { first: admin.nameFirst, last: admin.nameLast },
+        userType: admin.userType,
+        memberships: [{ entityType: 'school', entityId: schoolY, role: 'administrator' }],
+      },
+    ])
+      .then((res) => {
+        expect(res.status, 'import status').to.eq(200);
+        const row = res.body.data.results[0];
+        expect(row.classification, 'routed to the update bin').to.eq('updated');
+        expect(row.status, `update outcome: ${JSON.stringify(row.error ?? {})}`).to.eq('ok');
+        // Removed membership → access revoked in FGA (the delete-tuple path).
+        return authGet(adminToken, `/v1/schools/${schoolX}`);
+      })
+      .then((res) => {
+        expect(res.status, 'revoked on the removed school').to.eq(403);
+        // Added membership → access granted in FGA (the write-tuple path).
+        return authGet(adminToken, `/v1/schools/${schoolY}`);
+      })
+      .then((res) => {
+        expect(res.status, 'granted on the added school').to.eq(200);
+      });
+  });
+});

--- a/packages/api-contract/src/v1/users/contract.ts
+++ b/packages/api-contract/src/v1/users/contract.ts
@@ -6,6 +6,8 @@ import {
   CreateUserRequestBodySchema,
   CreateUserResponseSchema,
   UpdateUserRequestBodySchema,
+  ImportUsersRequestSchema,
+  ImportUsersResponseSchema,
   RecordUserAgreementRequestBodySchema,
   RecordUserAgreementResponseSchema,
 } from './schema';
@@ -76,6 +78,28 @@ export const UsersContract = c.router(
         'Returns a 422 if the request body is well-formed but contains semantically invalid data (e.g., invalid grade level). ' +
         'Returns a 429 if the user creation rate limit has been exceeded. ' +
         'Returns a 500 if an internal server error occurs.',
+    },
+    bulkImport: {
+      method: 'POST',
+      path: '/import',
+      contentType: 'application/json',
+      body: ImportUsersRequestSchema,
+      responses: {
+        200: SuccessEnvelopeSchema(ImportUsersResponseSchema),
+        400: ErrorEnvelopeSchema,
+        401: ErrorEnvelopeSchema,
+        500: ErrorEnvelopeSchema,
+      },
+      strictStatusCodes: true,
+      summary: 'Bulk create, update, and unenroll users',
+      description:
+        'Processes up to 100 rows, classifying each by email into create, update, or unenroll and ' +
+        'applying it against Firebase Auth, Postgres, and OpenFGA with per-row atomicity. ' +
+        'Always returns 200 with a multi-status body for any well-formed, authenticated request — ' +
+        'per-row outcomes (including failures) live in `results`, never in the HTTP status code. ' +
+        'Returns a 400 if the request body is missing, empty, over 100 rows, or malformed. ' +
+        'Returns a 401 if the requesting user is not authenticated. ' +
+        'Returns a 500 if an internal error occurs before per-row processing begins.',
     },
     update: {
       method: 'PATCH',

--- a/packages/api-contract/src/v1/users/schema.ts
+++ b/packages/api-contract/src/v1/users/schema.ts
@@ -127,6 +127,94 @@ export const CreateUserResponseSchema = z.object({
 export type CreateUserResponse = z.infer<typeof CreateUserResponseSchema>;
 
 /**
+ * Per-row body for POST /users/import (bulk create / update / unenroll).
+ *
+ * Intentionally the single-create row shape (`CreateUserRequestBodySchema`) with two changes:
+ * - `password` is optional here and validated per-bin during processing (required for create
+ *   rows, optional for update rows, ignored for unenroll rows). The client cannot know which bin
+ *   a row lands in until the server matches it by email, so the schema cannot require it.
+ * - `unenroll: true` routes an existing user to the unenroll bin.
+ *
+ * The server classifies create / update / unenroll by matching `email` against existing users —
+ * the client never declares the bin.
+ *
+ * @NOTE Parity gap to verify against the legacy `batchImportUpdate` cloud function before merge:
+ *   the single-create schema requires `email` and has no `username`. If the cloud function imports
+ *   username-only students (synthesizing an email), this schema must grow `username` and thread it
+ *   through the create path. Tracked as part of the batchImportUpdate parity review.
+ */
+export const ImportUserRowSchema = CreateUserRequestBodySchema.omit({ password: true })
+  .extend({
+    password: z.string().min(8).optional(),
+    unenroll: z.boolean().optional(),
+  })
+  .strict();
+
+export type ImportUserRow = z.infer<typeof ImportUserRowSchema>;
+
+/**
+ * Request body for POST /users/import. Capped at 100 rows — the dashboard chunks at 50 and
+ * Firebase `importUsers` accepts up to 1,000, so 100 sits comfortably between the two.
+ */
+export const ImportUsersRequestSchema = z.object({
+  users: z.array(ImportUserRowSchema).min(1).max(100),
+});
+
+export type ImportUsersRequest = z.infer<typeof ImportUsersRequestSchema>;
+
+/** The bin the server routed a row to (past tense — reflects the outcome). */
+export const ImportClassificationSchema = z.enum(['created', 'updated', 'unenrolled']);
+
+export type ImportClassification = z.infer<typeof ImportClassificationSchema>;
+
+/**
+ * Per-row result, discriminated on `status`. Successful rows carry the resulting user `id`;
+ * failed rows carry a safe `{ code, message }` (from the `ApiErrorCode` / `ApiErrorMessage`
+ * enums on the server). `classification` is the bin the row was routed to, even on failure, so
+ * the operator can see which path went wrong.
+ */
+export const ImportUserResultSchema = z.discriminatedUnion('status', [
+  z.object({
+    index: z.number().int().nonnegative(),
+    classification: ImportClassificationSchema,
+    status: z.literal('ok'),
+    id: z.string().uuid(),
+  }),
+  z.object({
+    index: z.number().int().nonnegative(),
+    classification: ImportClassificationSchema,
+    status: z.literal('failed'),
+    error: z.object({
+      code: z.string(),
+      message: z.string(),
+    }),
+  }),
+]);
+
+export type ImportUserResult = z.infer<typeof ImportUserResultSchema>;
+
+export const ImportUsersSummarySchema = z.object({
+  total: z.number().int().nonnegative(),
+  created: z.number().int().nonnegative(),
+  updated: z.number().int().nonnegative(),
+  unenrolled: z.number().int().nonnegative(),
+  failed: z.number().int().nonnegative(),
+});
+
+export type ImportUsersSummary = z.infer<typeof ImportUsersSummarySchema>;
+
+/**
+ * Multi-status response for POST /users/import. The endpoint returns 200 for any well-formed,
+ * authenticated request; per-row outcomes live in `results`, and `summary` totals each bin.
+ */
+export const ImportUsersResponseSchema = z.object({
+  results: z.array(ImportUserResultSchema),
+  summary: ImportUsersSummarySchema,
+});
+
+export type ImportUsersResponse = z.infer<typeof ImportUsersResponseSchema>;
+
+/**
  * Request body schema for PATCH /users/:id
  *
  * All fields are optional — only provided fields are updated (partial update semantics).


### PR DESCRIPTION
> [!IMPORTANT]
> This is work I completed **before I left Stanford but never pushed.** It is being published now, **as-is**, for the team to pick up. It is **not mergeable in its current form** and is intentionally opened as a **draft**:
> - It was branched from `project/backend-refactor` at commit `880ddeeda` (_"Migrate the administrations list view to the backend API (#1868)"_, **2026-06-22**), which is now **~150+ commits behind** the current `project/backend-refactor`. It has **not** been rebased onto the latest branch.
> - **A Stanford developer will need to adopt it**: rebase/adapt onto the current `project/backend-refactor` (expect conflicts — see _Adoption / rebase surface_ below) and close the one open parity check before merge.
> - The implementation itself is complete and was taken through several review rounds and end-to-end proofs; what's missing is the rebase and one verification. Details below so whoever picks it up has full context.

## What this adds

A single endpoint — **`POST /v1/users/import`** — that bulk **creates, updates, and unenrolls** users in one call, backed by Firebase Auth, Postgres, and OpenFGA with per-row atomicity.

The central design idea is the **"bin" model**: the client sends a flat list of rows and never declares the operation. The server classifies each row by matching its `email` against existing users and routes it to one of three bins:

- **create** — email not found → provision a Firebase Auth user (scrypt-hashed password via `importUsers`) + persist to Postgres + write FGA membership tuples, reusing the single-create saga and its compensation.
- **update** — email found → update profile + auth fields (only what changed) and reconcile memberships (replace-semantics per entity type) with FGA tuple add/delete sync, in one transaction.
- **unenroll** — row carries `unenroll: true` → end all of the user's enrollments + archive (rostering-ended) + best-effort delete their FGA membership tuples.

**Request:** `{ users: ImportUserRow[] }`, 1–100 rows (the dashboard chunks at 50). **Response:** always HTTP 200 for a well-formed, authenticated request — per-row outcomes (including failures) live in a multi-status body (`{ results, summary }`), never in the status code. 400 for a missing/empty/oversized/malformed body; 401 unauthenticated; 500 only for a whole-request failure before per-row processing.

## Commits (13)

Backend endpoint (10):
- `8fc152d54` Add `POST /v1/users/import` contract (bulk create/update/unenroll)
- `73001f107` Add Firebase scrypt hashing util, `findByEmails`, and `importUsers` mock
- `10dc7ca74` Add the service (create bin), route, and controller
- `3478f0403` Review nits: batch Firebase `getUsers`, within-batch PID dedupe
- `2dfc9a22d` Document `FIREBASE_SCRYPT_*` env vars
- `8227739d4` Add `UserRepository.endAllEnrollments`
- `cf7b8fdb1` Implement the unenroll bin
- `876de4e67` Unenroll-bin review nits (admin-tier class tuple skip, groups coverage)
- `e4284234b` Implement the update bin (profile + auth fields)
- `20417f22d` Update-bin review fixes (reject archived users, flag membership deltas, fix nameMiddle)

Reconciliation + proofs (3):
- `56d8d2e90` Implement update-bin membership reconciliation with FGA sync
- `31f43edb7` Reconciliation review fixes: transactional update + fail-safe FGA order
- `df9125b12` Add e2e proofs for import sign-in and reconcile→FGA against the local stack

## Adoption / rebase surface

The intervening ~150 commits churned the shared user layer, so a straight rebase will conflict. Expect to hand-resolve these:

- `apps/backend/src/services/user/user.service.ts` — adds `createWithImportedAuth`
- `apps/backend/src/repositories/user.repository.ts` — adds `findByEmails`, `endAllEnrollments`, `getActiveMembershipsWithRoles`, `archiveUser`, `reconcileMemberships`
- `apps/backend/src/repositories/user.repository.integration.test.ts`
- `apps/backend/src/repositories/base.repository.ts` — **shared change:** `update()` now honors `params.transaction` (it was silently dropped). Verify no other caller depended on the old behavior.

New files (apply cleanly): `services/user/user-import.service.ts` (+test), `services/user/utils/firebase-password-hash.ts` (+test). Contract/schema/route/controller changes are localized additions.

## Open pre-merge item — `batchImportUpdate` parity

The one deliberately-unfinished check, documented as an `@NOTE` in `packages/api-contract/src/v1/users/schema.ts`: verify the create-path identity contract against the legacy `batchImportUpdate` cloud function. The single-create schema requires `email` and has no `username`; if the legacy function imports **username-only students** (synthesizing an email), `ImportUserRowSchema` must grow `username` and thread it through the create path (which currently classifies on email via `findByEmails`). If everything is email-keyed, this closes with a verification note.

## Testing

- **Unit:** `user-import.service.test.ts` (classification, authorization, all three bins, per-row failure isolation, batched `getUsers`, PID dedupe, FGA sync); `firebase-password-hash.test.ts` (known-answer test pinned to Firebase's published vector).
- **Integration:** `user.repository.integration.test.ts` (`findByEmails`, `endAllEnrollments`, reconcile per-type + upsert reactivation).
- **E2E** (`apps/dashboard/cypress/e2e/smoke/users-import.cy.js`, backend-only): a sign-in proof (import-create → Auth-emulator sign-in → `/me`, proving the SCRYPT hash verifies end-to-end) and a reconcile→FGA proof (import-update swaps a school admin's membership; asserts OpenFGA flips access both ways).

## Config

Requires four env vars for the create bin (added to `apps/backend/.env.example`): `FIREBASE_SCRYPT_SIGNER_KEY`, `FIREBASE_SCRYPT_SALT_SEPARATOR`, `FIREBASE_SCRYPT_ROUNDS`, `FIREBASE_SCRYPT_MEM_COST` (Firebase console → Authentication → Users → ⋮ → Password hash parameters; the Auth emulator accepts any consistent set). The `ci.yml` change wires the public KAT vector (non-secret) into the e2e job.

## Provenance

Authored 2026-06-23; recovered from a local branch that was never pushed. Base commit `880ddeeda`. This PR's head branch is `enh/users-bulk-import/import-e2e-proofs` (the full backend line). Companion frontend PR: the CSV cutover from `enh/csv-import-cutover`.
