### PR TITLE
RegisterStudents CSV upload -> POST /v1/users/import (needs rebase/adoption)

### DIFF
--- a/apps/backend/.env.example
+++ b/apps/backend/.env.example
@@ -36,3 +36,16 @@ FGA_MODEL_ID=
 #   When set, the FGA client uses Google identity tokens for authentication.
 #   Leave blank for local development (FGA runs without auth locally).
 FGA_OIDC_AUDIENCE=
+
+# Bulk user import (POST /v1/users/import)
+# - Firebase's modified-scrypt password-hash parameters for the Firebase project this backend
+#   authenticates against. Required by the bulk-import create bin: importUsers needs pre-hashed
+#   passwords. Find them in the Firebase console: Authentication → Users → ⋮ (top-right of the
+#   users table) → "Password hash parameters". SIGNER_KEY and SALT_SEPARATOR are base64 strings;
+#   ROUNDS and MEM_COST are integers. Each Firebase project (dev/staging/prod) has its own values.
+#   Against the Auth emulator any consistent values work (e.g. the public Firebase test vector),
+#   since the emulator verifies sign-in against the hash config the import call carries.
+FIREBASE_SCRYPT_SIGNER_KEY=
+FIREBASE_SCRYPT_SALT_SEPARATOR=
+FIREBASE_SCRYPT_ROUNDS=
+FIREBASE_SCRYPT_MEM_COST=

--- a/apps/backend/src/controllers/users.controller.ts
+++ b/apps/backend/src/controllers/users.controller.ts
@@ -4,12 +4,13 @@ import type {
   UserResponse,
   CreateUserRequestBody,
   UpdateUserRequestBody,
+  ImportUsersRequest,
   RecordUserAgreementRequestBody,
   GuardianStudentReportResponse,
   AdministrationsListQuery,
 } from '@roar-platform/api-contract';
 import { StatusCodes } from 'http-status-codes';
-import { UserService } from '../services/user';
+import { UserService, UserImportService } from '../services/user';
 import { ReportService } from '../services/report/report.service';
 import type { GuardianStudentReportResult } from '../services/report/report.types';
 import { AdministrationService } from '../services/administration/administration.service';
@@ -18,6 +19,7 @@ import { toErrorResponse } from '../utils/to-error-response.util';
 import { transformAdministration, transformAdministrationBase } from './utils/administration.transform';
 
 const userService = UserService();
+const userImportService = UserImportService();
 const administrationService = AdministrationService();
 const reportService = ReportService();
 
@@ -134,6 +136,37 @@ export const UsersController = {
           StatusCodes.TOO_MANY_REQUESTS,
           StatusCodes.INTERNAL_SERVER_ERROR,
         ]);
+      }
+      throw error;
+    }
+  },
+
+  /**
+   * Bulk create / update / unenroll users.
+   *
+   * Always returns 200 with a multi-status body for a well-formed, authenticated request — per-row
+   * outcomes (including failures) live in `results`, never in the HTTP status code. The `summary`
+   * totals each bin. Only a failure of the whole request before per-row processing maps to a 500.
+   */
+  bulkImport: async (authContext: AuthContext, body: ImportUsersRequest) => {
+    try {
+      const results = await userImportService.bulkImport(authContext, body.users);
+
+      const summary = {
+        total: results.length,
+        created: results.filter((r) => r.status === 'ok' && r.classification === 'created').length,
+        updated: results.filter((r) => r.status === 'ok' && r.classification === 'updated').length,
+        unenrolled: results.filter((r) => r.status === 'ok' && r.classification === 'unenrolled').length,
+        failed: results.filter((r) => r.status === 'failed').length,
+      };
+
+      return {
+        status: StatusCodes.OK as const,
+        body: { data: { results, summary } },
+      };
+    } catch (error) {
+      if (error instanceof ApiError) {
+        return toErrorResponse(error, [StatusCodes.INTERNAL_SERVER_ERROR]);
       }
       throw error;
     }

--- a/apps/backend/src/repositories/user.repository.integration.test.ts
+++ b/apps/backend/src/repositories/user.repository.integration.test.ts
@@ -155,6 +155,49 @@ describe('UserRepository', () => {
     });
   });
 
+  describe('findByEmails', () => {
+    it('returns users matching the emails, case-insensitively', async () => {
+      const user = await UserFactory.create({ email: 'Found.User@example.org' });
+
+      const result = await repository.findByEmails(['found.user@EXAMPLE.org', 'missing@example.org']);
+
+      expect(result).toHaveLength(1);
+      expect(result[0]!.id).toBe(user.id);
+    });
+
+    it('returns an empty array for empty input', async () => {
+      expect(await repository.findByEmails([])).toEqual([]);
+    });
+  });
+
+  describe('endAllEnrollments', () => {
+    it('ends every active org, class, and family enrollment for the user', async () => {
+      const user = await UserFactory.create();
+      const family = await FamilyFactory.create();
+      await UserOrgFactory.create({ userId: user.id, orgId: baseFixture.district.id, role: UserRole.ADMINISTRATOR });
+      await UserClassFactory.create({
+        userId: user.id,
+        classId: baseFixture.classInSchoolA.id,
+        role: UserRole.TEACHER,
+      });
+      await UserFamilyFactory.create({ userId: user.id, familyId: family.id, role: 'parent' });
+
+      expect(await repository.getUserEntityMemberships(user.id)).not.toHaveLength(0);
+
+      await repository.endAllEnrollments(user.id);
+
+      // Every enrollment is now ended, so none are active.
+      expect(await repository.getUserEntityMemberships(user.id)).toHaveLength(0);
+    });
+
+    it('is a no-op for a user with no enrollments', async () => {
+      const user = await UserFactory.create();
+
+      await expect(repository.endAllEnrollments(user.id)).resolves.toBeUndefined();
+      expect(await repository.getUserEntityMemberships(user.id)).toHaveLength(0);
+    });
+  });
+
   describe('findClassParentSchool', () => {
     it('returns the parent school id for a class that exists', async () => {
       const result = await repository.findClassParentSchool(baseFixture.classInSchoolA.id);

--- a/apps/backend/src/repositories/user.repository.integration.test.ts
+++ b/apps/backend/src/repositories/user.repository.integration.test.ts
@@ -10,6 +10,7 @@ import { baseFixture } from '../test-support/fixtures';
 import { UserFactory } from '../test-support/factories/user.factory';
 import { UserOrgFactory } from '../test-support/factories/user-org.factory';
 import { UserClassFactory } from '../test-support/factories/user-class.factory';
+import { UserGroupFactory } from '../test-support/factories/user-group.factory';
 import { GroupFactory } from '../test-support/factories/group.factory';
 import { FamilyFactory } from '../test-support/factories/family.factory';
 import { UserFamilyFactory } from '../test-support/factories/user-family.factory';
@@ -171,10 +172,12 @@ describe('UserRepository', () => {
   });
 
   describe('endAllEnrollments', () => {
-    it('ends every active org, class, and family enrollment for the user', async () => {
+    it('ends every active org, class, group, and family enrollment for the user', async () => {
       const user = await UserFactory.create();
       const family = await FamilyFactory.create();
+      const group = await GroupFactory.create();
       await UserOrgFactory.create({ userId: user.id, orgId: baseFixture.district.id, role: UserRole.ADMINISTRATOR });
+      await UserGroupFactory.create({ userId: user.id, groupId: group.id, role: UserRole.STUDENT });
       await UserClassFactory.create({
         userId: user.id,
         classId: baseFixture.classInSchoolA.id,

--- a/apps/backend/src/repositories/user.repository.integration.test.ts
+++ b/apps/backend/src/repositories/user.repository.integration.test.ts
@@ -198,6 +198,37 @@ describe('UserRepository', () => {
     });
   });
 
+  describe('getActiveMembershipsWithRoles', () => {
+    it('returns active memberships with their roles', async () => {
+      const user = await UserFactory.create();
+      await UserOrgFactory.create({ userId: user.id, orgId: baseFixture.district.id, role: UserRole.ADMINISTRATOR });
+
+      const result = await repository.getActiveMembershipsWithRoles(user.id);
+
+      const districtMembership = result.find((m) => m.entityId === baseFixture.district.id);
+      expect(districtMembership).toMatchObject({ entityType: 'district', role: UserRole.ADMINISTRATOR });
+    });
+
+    it('excludes ended enrollments', async () => {
+      const user = await UserFactory.create();
+      await UserOrgFactory.create({ userId: user.id, orgId: baseFixture.district.id, role: UserRole.ADMINISTRATOR });
+      await repository.endAllEnrollments(user.id);
+
+      expect(await repository.getActiveMembershipsWithRoles(user.id)).toHaveLength(0);
+    });
+  });
+
+  describe('archiveUser', () => {
+    it('stamps rosteringEnded on the user', async () => {
+      const user = await UserFactory.create();
+      expect((await repository.getById({ id: user.id }))!.rosteringEnded).toBeNull();
+
+      await repository.archiveUser(user.id);
+
+      expect((await repository.getById({ id: user.id }))!.rosteringEnded).not.toBeNull();
+    });
+  });
+
   describe('findClassParentSchool', () => {
     it('returns the parent school id for a class that exists', async () => {
       const result = await repository.findClassParentSchool(baseFixture.classInSchoolA.id);

--- a/apps/backend/src/repositories/user.repository.ts
+++ b/apps/backend/src/repositories/user.repository.ts
@@ -1,4 +1,4 @@
-import { eq, and, or, isNull } from 'drizzle-orm';
+import { eq, and, or, isNull, inArray, sql } from 'drizzle-orm';
 import type { NodePgDatabase } from 'drizzle-orm/node-postgres';
 import type { User, NewUser, NewUserOrg, NewUserClass, NewUserGroup, NewUserFamily } from '../db/schema';
 import { EntityType } from '../types/entity-type';
@@ -220,5 +220,32 @@ export class UserRepository extends BaseRepository<User, typeof users> {
       .limit(1);
 
     return row !== undefined;
+  }
+
+  /**
+   * Find all users whose email matches any in the provided list, case-insensitively.
+   *
+   * Used by the bulk-import pre-flight to classify each row as create vs. update/unenroll by
+   * existence. Matching is case-insensitive to mirror the legacy classification (Firebase Auth
+   * treats emails case-insensitively) and to avoid misclassifying a cased variant as a new create
+   * that would then collide at Firebase. Rostered-out users are included — their email still
+   * occupies the unique field — so a re-import resolves to the existing user rather than a create.
+   *
+   * @param emails - The emails to look up.
+   * @returns The matching user records (may be fewer than the input when some don't exist).
+   *
+   * @NOTE The `lower(email)` predicate won't use the plain email index. For the bulk-import batch
+   *   size (≤100) against admin-initiated requests this is acceptable; a functional index on
+   *   `lower(email)` (or normalizing emails to lowercase on write) would remove the scan at scale.
+   */
+  async findByEmails(emails: string[]): Promise<User[]> {
+    if (emails.length === 0) return [];
+
+    const lowered = emails.map((email) => email.toLowerCase());
+
+    return this.db
+      .select()
+      .from(users)
+      .where(inArray(sql<string>`lower(${users.email})`, lowered));
   }
 }

--- a/apps/backend/src/repositories/user.repository.ts
+++ b/apps/backend/src/repositories/user.repository.ts
@@ -283,4 +283,66 @@ export class UserRepository extends BaseRepository<User, typeof users> {
       .set({ leftOn: endedAt })
       .where(and(eq(userFamilies.userId, userId), isNull(userFamilies.leftOn)));
   }
+
+  /**
+   * Return a user's active memberships with their roles, across orgs, classes, groups, and families.
+   *
+   * Mirrors {@link getUserEntityMemberships} (same active-enrollment filtering and org-type mapping)
+   * but additionally returns the role, which the unenroll flow needs to reconstruct the FGA tuples to
+   * delete. Org memberships with FGA-unsupported org types are dropped (logged by
+   * {@link getUserEntityMemberships}).
+   *
+   * @param userId - The user to look up.
+   * @returns Active memberships as `{ entityType, entityId, role }`.
+   */
+  async getActiveMembershipsWithRoles(
+    userId: string,
+  ): Promise<{ entityType: EntityType; entityId: string; role: string }[]> {
+    const [orgRows, classRows, groupRows, familyRows] = await Promise.all([
+      this.db
+        .select({ entityId: userOrgs.orgId, orgType: orgs.orgType, role: userOrgs.role })
+        .from(userOrgs)
+        .innerJoin(orgs, eq(userOrgs.orgId, orgs.id))
+        .where(and(eq(userOrgs.userId, userId), isEnrollmentActive(userOrgs))),
+      this.db
+        .select({ entityId: userClasses.classId, role: userClasses.role })
+        .from(userClasses)
+        .where(and(eq(userClasses.userId, userId), isEnrollmentActive(userClasses))),
+      this.db
+        .select({ entityId: userGroups.groupId, role: userGroups.role })
+        .from(userGroups)
+        .where(and(eq(userGroups.userId, userId), isEnrollmentActive(userGroups))),
+      this.db
+        .select({ entityId: userFamilies.familyId, role: userFamilies.role })
+        .from(userFamilies)
+        .where(and(eq(userFamilies.userId, userId), isActiveInFamily(userFamilies))),
+    ]);
+
+    const FGA_SUPPORTED_ORG_TYPES: ReadonlySet<string> = new Set([EntityType.DISTRICT, EntityType.SCHOOL]);
+    const orgMemberships: { entityType: EntityType; entityId: string; role: string }[] = [];
+    for (const row of orgRows) {
+      if (FGA_SUPPORTED_ORG_TYPES.has(row.orgType)) {
+        orgMemberships.push({ entityType: row.orgType as EntityType, entityId: row.entityId, role: row.role });
+      }
+    }
+
+    return [
+      ...orgMemberships,
+      ...classRows.map((r) => ({ entityType: EntityType.CLASS, entityId: r.entityId, role: r.role })),
+      ...groupRows.map((r) => ({ entityType: EntityType.GROUP, entityId: r.entityId, role: r.role })),
+      ...familyRows.map((r) => ({ entityType: EntityType.FAMILY, entityId: r.entityId, role: r.role })),
+    ];
+  }
+
+  /**
+   * Archive a user by stamping `rosteringEnded`. Used by the bulk-import unenroll bin alongside
+   * {@link endAllEnrollments}; pass the same transaction so both land atomically.
+   *
+   * @param userId - The user to archive.
+   * @param transaction - Optional transaction to run within.
+   */
+  async archiveUser(userId: string, transaction?: CoreTransaction): Promise<void> {
+    const db = transaction ?? this.db;
+    await db.update(users).set({ rosteringEnded: new Date() }).where(eq(users.id, userId));
+  }
 }

--- a/apps/backend/src/repositories/user.repository.ts
+++ b/apps/backend/src/repositories/user.repository.ts
@@ -248,4 +248,39 @@ export class UserRepository extends BaseRepository<User, typeof users> {
       .from(users)
       .where(inArray(sql<string>`lower(${users.email})`, lowered));
   }
+
+  /**
+   * End all of a user's currently-active enrollments by stamping the end date on every open junction
+   * row across orgs, classes, groups, and families.
+   *
+   * Used by the bulk-import unenroll bin, which — matching the legacy `batchImportUpdate` — ends ALL
+   * of a user's enrollments (not just the memberships named in the request). Already-ended rows are
+   * left untouched so their original end date is preserved.
+   *
+   * @param userId - The user whose enrollments to end.
+   * @param transaction - Optional transaction so the caller can archive the user and clean up FGA in
+   *   the same unit of work.
+   */
+  async endAllEnrollments(userId: string, transaction?: CoreTransaction): Promise<void> {
+    const db = transaction ?? this.db;
+    const endedAt = new Date();
+
+    // Sequential (not Promise.all) so this is safe inside a single transaction/connection.
+    await db
+      .update(userOrgs)
+      .set({ enrollmentEnd: endedAt })
+      .where(and(eq(userOrgs.userId, userId), isNull(userOrgs.enrollmentEnd)));
+    await db
+      .update(userClasses)
+      .set({ enrollmentEnd: endedAt })
+      .where(and(eq(userClasses.userId, userId), isNull(userClasses.enrollmentEnd)));
+    await db
+      .update(userGroups)
+      .set({ enrollmentEnd: endedAt })
+      .where(and(eq(userGroups.userId, userId), isNull(userGroups.enrollmentEnd)));
+    await db
+      .update(userFamilies)
+      .set({ leftOn: endedAt })
+      .where(and(eq(userFamilies.userId, userId), isNull(userFamilies.leftOn)));
+  }
 }

--- a/apps/backend/src/routes/users.ts
+++ b/apps/backend/src/routes/users.ts
@@ -23,6 +23,10 @@ export function registerUserRoutes(routerInstance: Router) {
       middleware: [AuthGuardMiddleware],
       handler: async ({ req: { user }, body }) => UsersController.create(user!, body),
     },
+    bulkImport: {
+      middleware: [AuthGuardMiddleware],
+      handler: async ({ req: { user }, body }) => UsersController.bulkImport(user!, body),
+    },
     update: {
       middleware: [AuthGuardMiddleware],
       handler: async ({ req: { user }, params: { id }, body }) => UsersController.update(user!, id, body),

--- a/apps/backend/src/services/user/index.ts
+++ b/apps/backend/src/services/user/index.ts
@@ -1,1 +1,2 @@
 export { UserService } from './user.service';
+export { UserImportService } from './user-import.service';

--- a/apps/backend/src/services/user/user-import.service.test.ts
+++ b/apps/backend/src/services/user/user-import.service.test.ts
@@ -75,6 +75,10 @@ describe('UserImportService.bulkImport', () => {
     mockUserService.createWithImportedAuth.mockImplementation(async () => ({ id: `new-user-${counter++}` }));
     mockUserRepository.runTransaction.mockImplementation(async ({ fn }) => fn({} as CoreTransaction));
     mockUserRepository.getActiveMembershipsWithRoles.mockResolvedValue([]);
+    // Default the update-bin membership-delta check to "no change" (matches makeRow's school-1).
+    mockUserRepository.getUserEntityMemberships.mockResolvedValue([
+      { entityType: EntityType.SCHOOL, entityId: 'school-1' },
+    ]);
   });
 
   describe('create bin', () => {
@@ -448,6 +452,47 @@ describe('UserImportService.bulkImport', () => {
 
       expect(results[0]!.status).toBe('failed');
       expect(results[1]!.status).toBe('ok');
+    });
+
+    it('does not write nameMiddle when the row omits it (no clobber)', async () => {
+      await buildService().bulkImport(superAdmin, [makeRow({ email: 'updatee@example.org' })]);
+
+      const updateData = mockUserRepository.update.mock.calls[0]![0].data;
+      expect(updateData).not.toHaveProperty('nameMiddle');
+    });
+
+    it('rejects an update to a rostering-ended (archived) user without writing anything', async () => {
+      mockUserRepository.findByEmails.mockResolvedValue([existing({ rosteringEnded: new Date() })]);
+
+      const results = await buildService().bulkImport(superAdmin, [makeRow({ email: 'updatee@example.org' })]);
+
+      expect(results[0]!).toMatchObject({
+        classification: 'updated',
+        status: 'failed',
+        error: { code: ApiErrorCode.RESOURCE_NOT_FOUND },
+      });
+      expect(mockUserRepository.update).not.toHaveBeenCalled();
+      expect(updateUser).not.toHaveBeenCalled();
+    });
+
+    it('fails (rather than silently ok) a row whose memberships differ from the current set', async () => {
+      mockUserRepository.getUserEntityMemberships.mockResolvedValue([
+        { entityType: EntityType.SCHOOL, entityId: 'school-1' },
+      ]);
+
+      const results = await buildService().bulkImport(superAdmin, [
+        makeRow({
+          email: 'updatee@example.org',
+          memberships: [{ entityType: EntityType.SCHOOL, entityId: 'school-2', role: UserRole.STUDENT }],
+        }),
+      ]);
+
+      expect(results[0]!).toMatchObject({
+        classification: 'updated',
+        status: 'failed',
+        error: { code: ApiErrorCode.RESOURCE_UNPROCESSABLE },
+      });
+      expect(mockUserRepository.update).not.toHaveBeenCalled();
     });
   });
 });

--- a/apps/backend/src/services/user/user-import.service.test.ts
+++ b/apps/backend/src/services/user/user-import.service.test.ts
@@ -1,0 +1,262 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { UserImportService, type ImportUserRowInput } from './user-import.service';
+import { createMockUserRepository } from '../../test-support/repositories/user.repository';
+import { createMockUserService } from '../../test-support/services/user.service';
+import { createMockAuthorizationService } from '../../test-support/services/authorization.service';
+import { UserFactory, AuthContextFactory } from '../../test-support/factories/user.factory';
+import { FirebaseAuthClient } from '../../clients/firebase-auth.clients';
+import { ApiError } from '../../errors/api-error';
+import { ApiErrorCode } from '../../enums/api-error-code.enum';
+import { ApiErrorMessage } from '../../enums/api-error-message.enum';
+import { FIREBASE_ERROR_CODES } from '../../constants/firebase-error-codes';
+import { UserRole } from '../../enums/user-role.enum';
+import { UserType } from '../../enums/user-type.enum';
+import { EntityType } from '../../types/entity-type';
+import type { FirebaseScryptParams } from './utils/firebase-password-hash';
+
+// Public Firebase scrypt test-vector params — fine for tests (no real secrets needed).
+const SCRYPT_PARAMS: FirebaseScryptParams = {
+  signerKey: Buffer.from(
+    'jxspr8Ki0RYycVU8zykbdLGjFQ3McFUH0uiiTvC8pVMXAn210wjLNmdZJzxUECKbm0QsEmYUSDzZvpjeJ9WmXA==',
+    'base64',
+  ),
+  saltSeparator: Buffer.from('Bw==', 'base64'),
+  rounds: 8,
+  memoryCost: 14,
+};
+
+const firebaseUserNotFound = Object.assign(new Error('no user'), { code: FIREBASE_ERROR_CODES.AUTH.USER_NOT_FOUND });
+
+const makeRow = (overrides: Partial<ImportUserRowInput> = {}): ImportUserRowInput => ({
+  email: 'student@example.org',
+  password: 'password123',
+  name: { first: 'Ada', last: 'Lovelace' },
+  userType: UserType.STUDENT,
+  memberships: [{ entityType: EntityType.SCHOOL, entityId: 'school-1', role: UserRole.STUDENT }],
+  ...overrides,
+});
+
+const forbidden = () => new ApiError(ApiErrorMessage.FORBIDDEN, { statusCode: 403, code: ApiErrorCode.AUTH_FORBIDDEN });
+
+describe('UserImportService.bulkImport', () => {
+  let mockUserRepository: ReturnType<typeof createMockUserRepository>;
+  let mockUserService: ReturnType<typeof createMockUserService>;
+  let mockAuthz: ReturnType<typeof createMockAuthorizationService>;
+  const getUserByEmail = vi.fn();
+  const importUsers = vi.fn();
+  const mockFirebaseAuth = { getUserByEmail, importUsers } as unknown as typeof FirebaseAuthClient;
+
+  const superAdmin = AuthContextFactory.build({ isSuperAdmin: true });
+  const partnerAdmin = AuthContextFactory.build({ isSuperAdmin: false });
+
+  const buildService = () =>
+    UserImportService({
+      userService: mockUserService,
+      userRepository: mockUserRepository,
+      authorizationService: mockAuthz,
+      firebaseAuth: mockFirebaseAuth,
+      scryptParams: SCRYPT_PARAMS,
+    });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUserRepository = createMockUserRepository();
+    mockUserService = createMockUserService();
+    mockAuthz = createMockAuthorizationService();
+
+    // Happy-path defaults: nobody exists yet, nothing collides, persistence succeeds.
+    mockUserRepository.findByEmails.mockResolvedValue([]);
+    mockUserRepository.existsByUniqueFields.mockResolvedValue(false);
+    mockUserRepository.findClassParentSchool.mockResolvedValue('school-parent');
+    mockAuthz.requirePermission.mockResolvedValue(undefined);
+    getUserByEmail.mockRejectedValue(firebaseUserNotFound);
+    importUsers.mockResolvedValue({ successCount: 0, failureCount: 0, errors: [] });
+    let counter = 0;
+    mockUserService.createWithImportedAuth.mockImplementation(async () => ({ id: `new-user-${counter++}` }));
+  });
+
+  describe('create bin', () => {
+    it('creates every row in a single importUsers call and persists each one', async () => {
+      const rows = [makeRow({ email: 'a@example.org' }), makeRow({ email: 'b@example.org' })];
+
+      const results = await buildService().bulkImport(superAdmin, rows);
+
+      expect(importUsers).toHaveBeenCalledTimes(1);
+      expect(importUsers.mock.calls[0]![0]).toHaveLength(2);
+      expect(mockUserService.createWithImportedAuth).toHaveBeenCalledTimes(2);
+      expect(results.every((r) => r.status === 'ok' && r.classification === 'created')).toBe(true);
+    });
+
+    it('passes the SCRYPT hash options to importUsers', async () => {
+      await buildService().bulkImport(superAdmin, [makeRow()]);
+
+      const options = importUsers.mock.calls[0]![1];
+      expect(options.hash.algorithm).toBe('SCRYPT');
+      expect(options.hash.rounds).toBe(8);
+      expect(options.hash.memoryCost).toBe(14);
+    });
+
+    it('marks a within-batch duplicate email as a conflict, processing the first occurrence', async () => {
+      const rows = [makeRow({ email: 'dup@example.org' }), makeRow({ email: 'DUP@example.org' })];
+
+      const results = await buildService().bulkImport(superAdmin, rows);
+
+      expect(results[0]!.status).toBe('ok');
+      expect(results[1]!).toMatchObject({ status: 'failed', error: { code: ApiErrorCode.RESOURCE_CONFLICT } });
+      expect(importUsers.mock.calls[0]![0]).toHaveLength(1);
+    });
+
+    it('fails a create row that is missing a password and excludes it from importUsers', async () => {
+      const results = await buildService().bulkImport(superAdmin, [makeRow({ password: undefined })]);
+
+      expect(results[0]!).toMatchObject({
+        status: 'failed',
+        classification: 'created',
+        error: { code: ApiErrorCode.REQUEST_VALIDATION_FAILED },
+      });
+      expect(importUsers).not.toHaveBeenCalled();
+    });
+
+    it('fails a create row that already exists in Postgres', async () => {
+      mockUserRepository.existsByUniqueFields.mockResolvedValue(true);
+
+      const results = await buildService().bulkImport(superAdmin, [makeRow()]);
+
+      expect(results[0]!).toMatchObject({ status: 'failed', error: { code: ApiErrorCode.RESOURCE_CONFLICT } });
+      expect(importUsers).not.toHaveBeenCalled();
+    });
+
+    it('fails a create row whose email already exists in Firebase Auth', async () => {
+      getUserByEmail.mockResolvedValue({ uid: 'existing' });
+
+      const results = await buildService().bulkImport(superAdmin, [makeRow()]);
+
+      expect(results[0]!).toMatchObject({ status: 'failed', error: { code: ApiErrorCode.RESOURCE_CONFLICT } });
+      expect(importUsers).not.toHaveBeenCalled();
+    });
+
+    it('fails only the row Firebase rejected in importUsers and persists the rest', async () => {
+      importUsers.mockResolvedValue({
+        successCount: 1,
+        failureCount: 1,
+        errors: [{ index: 0, error: { code: FIREBASE_ERROR_CODES.AUTH.EMAIL_ALREADY_EXISTS, message: 'exists' } }],
+      });
+
+      const rows = [makeRow({ email: 'a@example.org' }), makeRow({ email: 'b@example.org' })];
+      const results = await buildService().bulkImport(superAdmin, rows);
+
+      expect(results[0]!).toMatchObject({ status: 'failed', error: { code: ApiErrorCode.RESOURCE_CONFLICT } });
+      expect(results[1]!.status).toBe('ok');
+      // Only the surviving row is persisted.
+      expect(mockUserService.createWithImportedAuth).toHaveBeenCalledTimes(1);
+    });
+
+    it('fails only the row whose persistence throws, leaving the others successful', async () => {
+      mockUserService.createWithImportedAuth
+        .mockRejectedValueOnce(
+          new ApiError(ApiErrorMessage.CONFLICT, { statusCode: 409, code: ApiErrorCode.RESOURCE_CONFLICT }),
+        )
+        .mockResolvedValueOnce({ id: 'new-user-ok' });
+
+      const rows = [makeRow({ email: 'a@example.org' }), makeRow({ email: 'b@example.org' })];
+      const results = await buildService().bulkImport(superAdmin, rows);
+
+      expect(results[0]!).toMatchObject({ status: 'failed', error: { code: ApiErrorCode.RESOURCE_CONFLICT } });
+      expect(results[1]!).toMatchObject({ status: 'ok', id: 'new-user-ok' });
+    });
+
+    it('fails every prepared row when the whole importUsers call throws', async () => {
+      importUsers.mockRejectedValue(new Error('admin sdk unavailable'));
+
+      const results = await buildService().bulkImport(superAdmin, [makeRow()]);
+
+      expect(results[0]!).toMatchObject({ status: 'failed', error: { code: ApiErrorCode.EXTERNAL_SERVICE_FAILED } });
+      expect(mockUserService.createWithImportedAuth).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('classification', () => {
+    it('routes an existing user with no unenroll flag to the update bin', async () => {
+      mockUserRepository.findByEmails.mockResolvedValue([UserFactory.build({ email: 'exists@example.org' })]);
+
+      const results = await buildService().bulkImport(superAdmin, [makeRow({ email: 'exists@example.org' })]);
+
+      expect(results[0]!.classification).toBe('updated');
+      expect(results[0]!.status).toBe('failed'); // update bin not yet implemented
+      expect(importUsers).not.toHaveBeenCalled();
+    });
+
+    it('routes an existing user with unenroll=true to the unenroll bin', async () => {
+      mockUserRepository.findByEmails.mockResolvedValue([UserFactory.build({ email: 'exists@example.org' })]);
+
+      const results = await buildService().bulkImport(superAdmin, [
+        makeRow({ email: 'exists@example.org', unenroll: true }),
+      ]);
+
+      expect(results[0]!.classification).toBe('unenrolled');
+      expect(results[0]!.status).toBe('failed'); // unenroll bin not yet implemented
+    });
+
+    it('fails an unenroll request for a non-existent user', async () => {
+      const results = await buildService().bulkImport(superAdmin, [makeRow({ unenroll: true })]);
+
+      expect(results[0]!).toMatchObject({
+        status: 'failed',
+        classification: 'unenrolled',
+        error: { code: ApiErrorCode.RESOURCE_NOT_FOUND },
+      });
+    });
+
+    it('is case-insensitive when matching against existing users', async () => {
+      mockUserRepository.findByEmails.mockResolvedValue([UserFactory.build({ email: 'mixed@example.org' })]);
+
+      const results = await buildService().bulkImport(superAdmin, [makeRow({ email: 'MIXED@example.org' })]);
+
+      // Matched the existing user (routed to update), rather than treated as a new create.
+      expect(results[0]!.classification).toBe('updated');
+    });
+  });
+
+  describe('authorization', () => {
+    it('fails a row the partner admin cannot create, but continues the batch', async () => {
+      mockAuthz.requirePermission.mockRejectedValueOnce(forbidden()).mockResolvedValue(undefined);
+
+      const rows = [makeRow({ email: 'denied@example.org' }), makeRow({ email: 'allowed@example.org' })];
+      const results = await buildService().bulkImport(partnerAdmin, rows);
+
+      expect(results[0]!).toMatchObject({ status: 'failed', error: { code: ApiErrorCode.AUTH_FORBIDDEN } });
+      expect(results[1]!.status).toBe('ok');
+    });
+
+    it('bypasses FGA for super admins', async () => {
+      await buildService().bulkImport(superAdmin, [makeRow()]);
+
+      expect(mockAuthz.requirePermission).not.toHaveBeenCalled();
+    });
+
+    it('skips classification and import entirely when every row fails authorization', async () => {
+      mockAuthz.requirePermission.mockRejectedValue(forbidden());
+
+      const results = await buildService().bulkImport(partnerAdmin, [makeRow(), makeRow({ email: 'b@example.org' })]);
+
+      expect(results.every((r) => r.status === 'failed' && r.error.code === ApiErrorCode.AUTH_FORBIDDEN)).toBe(true);
+      expect(mockUserRepository.findByEmails).not.toHaveBeenCalled();
+      expect(importUsers).not.toHaveBeenCalled();
+    });
+
+    it('checks can_create_users against the parent school for class memberships', async () => {
+      const rows = [
+        makeRow({ memberships: [{ entityType: EntityType.CLASS, entityId: 'class-9', role: UserRole.STUDENT }] }),
+      ];
+
+      await buildService().bulkImport(partnerAdmin, rows);
+
+      expect(mockUserRepository.findClassParentSchool).toHaveBeenCalledWith('class-9');
+      expect(mockAuthz.requirePermission).toHaveBeenCalledWith(
+        partnerAdmin.userId,
+        expect.any(String),
+        'school:school-parent',
+      );
+    });
+  });
+});

--- a/apps/backend/src/services/user/user-import.service.test.ts
+++ b/apps/backend/src/services/user/user-import.service.test.ts
@@ -13,6 +13,7 @@ import { UserRole } from '../../enums/user-role.enum';
 import { UserType } from '../../enums/user-type.enum';
 import { EntityType } from '../../types/entity-type';
 import type { FirebaseScryptParams } from './utils/firebase-password-hash';
+import type { CoreTransaction } from '../../db/clients';
 
 // Public Firebase scrypt test-vector params — fine for tests (no real secrets needed).
 const SCRYPT_PARAMS: FirebaseScryptParams = {
@@ -71,6 +72,8 @@ describe('UserImportService.bulkImport', () => {
     importUsers.mockResolvedValue({ successCount: 0, failureCount: 0, errors: [] });
     let counter = 0;
     mockUserService.createWithImportedAuth.mockImplementation(async () => ({ id: `new-user-${counter++}` }));
+    mockUserRepository.runTransaction.mockImplementation(async ({ fn }) => fn({} as CoreTransaction));
+    mockUserRepository.getActiveMembershipsWithRoles.mockResolvedValue([]);
   });
 
   describe('create bin', () => {
@@ -306,9 +309,61 @@ describe('UserImportService.bulkImport', () => {
       const results = await buildService().bulkImport(superAdmin, rows);
 
       expect(results[0]!).toMatchObject({ classification: 'created', status: 'ok' });
-      // update + unenroll bins are not yet implemented, but routing is verified by classification.
+      // Update bin is not yet implemented; create + unenroll route and process independently.
       expect(results[1]!).toMatchObject({ classification: 'updated', status: 'failed' });
-      expect(results[2]!).toMatchObject({ classification: 'unenrolled', status: 'failed' });
+      expect(results[2]!).toMatchObject({ classification: 'unenrolled', status: 'ok' });
+    });
+  });
+
+  describe('unenroll bin', () => {
+    const existingUser = (email: string) => UserFactory.build({ email });
+
+    beforeEach(() => {
+      mockUserRepository.findByEmails.mockResolvedValue([existingUser('leaver@example.org')]);
+    });
+
+    it('ends enrollments, archives, and deletes the FGA membership tuples, returning ok', async () => {
+      mockUserRepository.getActiveMembershipsWithRoles.mockResolvedValue([
+        { entityType: EntityType.SCHOOL, entityId: 'school-9', role: UserRole.STUDENT },
+      ]);
+
+      const results = await buildService().bulkImport(superAdmin, [
+        makeRow({ email: 'leaver@example.org', unenroll: true }),
+      ]);
+
+      expect(mockUserRepository.endAllEnrollments).toHaveBeenCalled();
+      expect(mockUserRepository.archiveUser).toHaveBeenCalled();
+      expect(mockAuthz.deleteTuples).toHaveBeenCalledWith([
+        { user: expect.stringMatching(/^user:/), relation: UserRole.STUDENT, object: 'school:school-9' },
+      ]);
+      expect(results[0]!).toMatchObject({ classification: 'unenrolled', status: 'ok' });
+    });
+
+    it('skips deleteTuples when the user has no active memberships', async () => {
+      mockUserRepository.getActiveMembershipsWithRoles.mockResolvedValue([]);
+
+      const results = await buildService().bulkImport(superAdmin, [
+        makeRow({ email: 'leaver@example.org', unenroll: true }),
+      ]);
+
+      expect(mockAuthz.deleteTuples).not.toHaveBeenCalled();
+      expect(results[0]!.status).toBe('ok');
+    });
+
+    it('fails the row and continues the batch when the unenroll transaction throws', async () => {
+      mockUserRepository.findByEmails.mockResolvedValue([
+        existingUser('leaver@example.org'),
+        existingUser('other@example.org'),
+      ]);
+      mockUserRepository.runTransaction.mockRejectedValueOnce(new Error('db down'));
+
+      const results = await buildService().bulkImport(superAdmin, [
+        makeRow({ email: 'leaver@example.org', unenroll: true }),
+        makeRow({ email: 'other@example.org', unenroll: true }),
+      ]);
+
+      expect(results[0]!.status).toBe('failed');
+      expect(results[1]!.status).toBe('ok');
     });
   });
 });

--- a/apps/backend/src/services/user/user-import.service.test.ts
+++ b/apps/backend/src/services/user/user-import.service.test.ts
@@ -43,7 +43,8 @@ describe('UserImportService.bulkImport', () => {
   let mockAuthz: ReturnType<typeof createMockAuthorizationService>;
   const getUsers = vi.fn();
   const importUsers = vi.fn();
-  const mockFirebaseAuth = { getUsers, importUsers } as unknown as typeof FirebaseAuthClient;
+  const updateUser = vi.fn();
+  const mockFirebaseAuth = { getUsers, importUsers, updateUser } as unknown as typeof FirebaseAuthClient;
 
   const superAdmin = AuthContextFactory.build({ isSuperAdmin: true });
   const partnerAdmin = AuthContextFactory.build({ isSuperAdmin: false });
@@ -204,7 +205,7 @@ describe('UserImportService.bulkImport', () => {
       const results = await buildService().bulkImport(superAdmin, [makeRow({ email: 'exists@example.org' })]);
 
       expect(results[0]!.classification).toBe('updated');
-      expect(results[0]!.status).toBe('failed'); // update bin not yet implemented
+      expect(results[0]!.status).toBe('ok');
       expect(importUsers).not.toHaveBeenCalled();
     });
 
@@ -310,8 +311,8 @@ describe('UserImportService.bulkImport', () => {
       const results = await buildService().bulkImport(superAdmin, rows);
 
       expect(results[0]!).toMatchObject({ classification: 'created', status: 'ok' });
-      // Update bin is not yet implemented; create + unenroll route and process independently.
-      expect(results[1]!).toMatchObject({ classification: 'updated', status: 'failed' });
+      // Each bin routes and processes independently in one request.
+      expect(results[1]!).toMatchObject({ classification: 'updated', status: 'ok' });
       expect(results[2]!).toMatchObject({ classification: 'unenrolled', status: 'ok' });
     });
   });
@@ -376,6 +377,73 @@ describe('UserImportService.bulkImport', () => {
       const results = await buildService().bulkImport(superAdmin, [
         makeRow({ email: 'leaver@example.org', unenroll: true }),
         makeRow({ email: 'other@example.org', unenroll: true }),
+      ]);
+
+      expect(results[0]!.status).toBe('failed');
+      expect(results[1]!.status).toBe('ok');
+    });
+  });
+
+  describe('update bin', () => {
+    const existing = (overrides = {}) =>
+      UserFactory.build({
+        email: 'updatee@example.org',
+        nameFirst: 'Old',
+        nameMiddle: null,
+        nameLast: 'Name',
+        ...overrides,
+      });
+
+    beforeEach(() => {
+      mockUserRepository.findByEmails.mockResolvedValue([existing()]);
+    });
+
+    it('updates the profile fields and returns ok without touching importUsers', async () => {
+      const results = await buildService().bulkImport(superAdmin, [makeRow({ email: 'updatee@example.org' })]);
+
+      expect(mockUserRepository.update).toHaveBeenCalledWith(
+        expect.objectContaining({ data: expect.objectContaining({ nameFirst: 'Ada', nameLast: 'Lovelace' }) }),
+      );
+      expect(results[0]!).toMatchObject({ classification: 'updated', status: 'ok' });
+      expect(importUsers).not.toHaveBeenCalled();
+    });
+
+    it('syncs the Firebase displayName when the name changed', async () => {
+      await buildService().bulkImport(superAdmin, [makeRow({ email: 'updatee@example.org' })]);
+
+      expect(updateUser).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ displayName: 'Ada Lovelace' }),
+      );
+    });
+
+    it('resets the Firebase password when one is supplied', async () => {
+      await buildService().bulkImport(superAdmin, [makeRow({ email: 'updatee@example.org', password: 'newpass123' })]);
+
+      expect(updateUser).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({ password: 'newpass123' }));
+    });
+
+    it('skips the Firebase write when neither name nor password changed', async () => {
+      // The existing user already matches the row's name (Ada Lovelace), and no password is sent.
+      mockUserRepository.findByEmails.mockResolvedValue([
+        existing({ nameFirst: 'Ada', nameMiddle: null, nameLast: 'Lovelace' }),
+      ]);
+
+      await buildService().bulkImport(superAdmin, [makeRow({ email: 'updatee@example.org', password: undefined })]);
+
+      expect(updateUser).not.toHaveBeenCalled();
+    });
+
+    it('fails the row and continues the batch when the profile update throws', async () => {
+      mockUserRepository.findByEmails.mockResolvedValue([
+        existing({ email: 'a@example.org' }),
+        existing({ email: 'b@example.org' }),
+      ]);
+      mockUserRepository.update.mockRejectedValueOnce(new Error('db down'));
+
+      const results = await buildService().bulkImport(superAdmin, [
+        makeRow({ email: 'a@example.org' }),
+        makeRow({ email: 'b@example.org' }),
       ]);
 
       expect(results[0]!.status).toBe('failed');

--- a/apps/backend/src/services/user/user-import.service.test.ts
+++ b/apps/backend/src/services/user/user-import.service.test.ts
@@ -25,8 +25,6 @@ const SCRYPT_PARAMS: FirebaseScryptParams = {
   memoryCost: 14,
 };
 
-const firebaseUserNotFound = Object.assign(new Error('no user'), { code: FIREBASE_ERROR_CODES.AUTH.USER_NOT_FOUND });
-
 const makeRow = (overrides: Partial<ImportUserRowInput> = {}): ImportUserRowInput => ({
   email: 'student@example.org',
   password: 'password123',
@@ -42,9 +40,9 @@ describe('UserImportService.bulkImport', () => {
   let mockUserRepository: ReturnType<typeof createMockUserRepository>;
   let mockUserService: ReturnType<typeof createMockUserService>;
   let mockAuthz: ReturnType<typeof createMockAuthorizationService>;
-  const getUserByEmail = vi.fn();
+  const getUsers = vi.fn();
   const importUsers = vi.fn();
-  const mockFirebaseAuth = { getUserByEmail, importUsers } as unknown as typeof FirebaseAuthClient;
+  const mockFirebaseAuth = { getUsers, importUsers } as unknown as typeof FirebaseAuthClient;
 
   const superAdmin = AuthContextFactory.build({ isSuperAdmin: true });
   const partnerAdmin = AuthContextFactory.build({ isSuperAdmin: false });
@@ -69,7 +67,7 @@ describe('UserImportService.bulkImport', () => {
     mockUserRepository.existsByUniqueFields.mockResolvedValue(false);
     mockUserRepository.findClassParentSchool.mockResolvedValue('school-parent');
     mockAuthz.requirePermission.mockResolvedValue(undefined);
-    getUserByEmail.mockRejectedValue(firebaseUserNotFound);
+    getUsers.mockResolvedValue({ users: [], notFound: [] });
     importUsers.mockResolvedValue({ successCount: 0, failureCount: 0, errors: [] });
     let counter = 0;
     mockUserService.createWithImportedAuth.mockImplementation(async () => ({ id: `new-user-${counter++}` }));
@@ -127,12 +125,33 @@ describe('UserImportService.bulkImport', () => {
     });
 
     it('fails a create row whose email already exists in Firebase Auth', async () => {
-      getUserByEmail.mockResolvedValue({ uid: 'existing' });
+      getUsers.mockResolvedValue({ users: [{ email: 'student@example.org' }], notFound: [] });
 
       const results = await buildService().bulkImport(superAdmin, [makeRow()]);
 
       expect(results[0]!).toMatchObject({ status: 'failed', error: { code: ApiErrorCode.RESOURCE_CONFLICT } });
       expect(importUsers).not.toHaveBeenCalled();
+    });
+
+    it('checks Firebase existence with a single batched getUsers call', async () => {
+      const rows = [makeRow({ email: 'a@example.org' }), makeRow({ email: 'b@example.org' })];
+
+      await buildService().bulkImport(superAdmin, rows);
+
+      expect(getUsers).toHaveBeenCalledTimes(1);
+      expect(getUsers).toHaveBeenCalledWith([{ email: 'a@example.org' }, { email: 'b@example.org' }]);
+    });
+
+    it('fails a within-batch duplicate assessmentPid', async () => {
+      const rows = [
+        makeRow({ email: 'a@example.org', identifiers: { pid: 'shared-pid' } }),
+        makeRow({ email: 'b@example.org', identifiers: { pid: 'shared-pid' } }),
+      ];
+
+      const results = await buildService().bulkImport(superAdmin, rows);
+
+      expect(results[0]!.status).toBe('ok');
+      expect(results[1]!).toMatchObject({ status: 'failed', error: { code: ApiErrorCode.RESOURCE_CONFLICT } });
     });
 
     it('fails only the row Firebase rejected in importUsers and persists the rest', async () => {
@@ -257,6 +276,39 @@ describe('UserImportService.bulkImport', () => {
         expect.any(String),
         'school:school-parent',
       );
+    });
+
+    it('skips the FGA check for family memberships (matching single-create)', async () => {
+      const rows = [
+        makeRow({ memberships: [{ entityType: EntityType.FAMILY, entityId: 'fam-1', role: UserRole.STUDENT }] }),
+      ];
+
+      const results = await buildService().bulkImport(partnerAdmin, rows);
+
+      expect(mockAuthz.requirePermission).not.toHaveBeenCalled();
+      expect(results[0]!.status).toBe('ok');
+    });
+  });
+
+  describe('mixed batch', () => {
+    it('routes create, update, and unenroll rows independently in one request', async () => {
+      mockUserRepository.findByEmails.mockResolvedValue([
+        UserFactory.build({ email: 'update-me@example.org' }),
+        UserFactory.build({ email: 'unenroll-me@example.org' }),
+      ]);
+
+      const rows = [
+        makeRow({ email: 'new@example.org' }),
+        makeRow({ email: 'update-me@example.org' }),
+        makeRow({ email: 'unenroll-me@example.org', unenroll: true }),
+      ];
+
+      const results = await buildService().bulkImport(superAdmin, rows);
+
+      expect(results[0]!).toMatchObject({ classification: 'created', status: 'ok' });
+      // update + unenroll bins are not yet implemented, but routing is verified by classification.
+      expect(results[1]!).toMatchObject({ classification: 'updated', status: 'failed' });
+      expect(results[2]!).toMatchObject({ classification: 'unenrolled', status: 'failed' });
     });
   });
 });

--- a/apps/backend/src/services/user/user-import.service.test.ts
+++ b/apps/backend/src/services/user/user-import.service.test.ts
@@ -216,7 +216,8 @@ describe('UserImportService.bulkImport', () => {
       ]);
 
       expect(results[0]!.classification).toBe('unenrolled');
-      expect(results[0]!.status).toBe('failed'); // unenroll bin not yet implemented
+      expect(results[0]!.status).toBe('ok');
+      expect(importUsers).not.toHaveBeenCalled();
     });
 
     it('fails an unenroll request for a non-existent user', async () => {
@@ -348,6 +349,21 @@ describe('UserImportService.bulkImport', () => {
 
       expect(mockAuthz.deleteTuples).not.toHaveBeenCalled();
       expect(results[0]!.status).toBe('ok');
+    });
+
+    it('does not delete class tuples for FGA-invalid (admin-tier) roles', async () => {
+      mockUserRepository.getActiveMembershipsWithRoles.mockResolvedValue([
+        { entityType: EntityType.SCHOOL, entityId: 'school-9', role: UserRole.STUDENT },
+        { entityType: EntityType.CLASS, entityId: 'class-9', role: UserRole.ADMINISTRATOR },
+      ]);
+
+      await buildService().bulkImport(superAdmin, [makeRow({ email: 'leaver@example.org', unenroll: true })]);
+
+      // The admin-tier class tuple was never written (it cascades via the org hierarchy), so deletion
+      // must skip it — only the school tuple is removed.
+      const deleted = mockAuthz.deleteTuples.mock.calls[0]![0];
+      expect(deleted).toHaveLength(1);
+      expect(deleted[0]).toMatchObject({ object: 'school:school-9' });
     });
 
     it('fails the row and continues the batch when the unenroll transaction throws', async () => {

--- a/apps/backend/src/services/user/user-import.service.ts
+++ b/apps/backend/src/services/user/user-import.service.ts
@@ -121,6 +121,40 @@ function preRoutingClassification(row: ImportUserRowInput): Classification {
   return row.unenroll ? CLASSIFICATION.UNENROLLED : CLASSIFICATION.CREATED;
 }
 
+/**
+ * Returns true if an update row implies a membership change the update bin does not yet apply — i.e.
+ * for any entity type the row lists, its set of entity IDs differs from the user's current active set
+ * for that type. Entity types the row omits are ignored (the legacy leaves them untouched). Used to
+ * fail such rows explicitly rather than report a misleading `ok` while silently dropping the change.
+ */
+function hasMembershipDelta(
+  rowMemberships: ImportRowMembership[],
+  current: { entityType: EntityType; entityId: string }[],
+): boolean {
+  const currentByType = new Map<EntityType, Set<string>>();
+  for (const m of current) {
+    const set = currentByType.get(m.entityType) ?? new Set<string>();
+    set.add(m.entityId);
+    currentByType.set(m.entityType, set);
+  }
+
+  const rowByType = new Map<EntityType, Set<string>>();
+  for (const m of rowMemberships) {
+    const set = rowByType.get(m.entityType) ?? new Set<string>();
+    set.add(m.entityId);
+    rowByType.set(m.entityType, set);
+  }
+
+  for (const [entityType, rowIds] of rowByType) {
+    const currentIds = currentByType.get(entityType) ?? new Set<string>();
+    if (rowIds.size !== currentIds.size) return true;
+    for (const id of rowIds) {
+      if (!currentIds.has(id)) return true;
+    }
+  }
+  return false;
+}
+
 export function UserImportService({
   userService = UserService(),
   userRepository = new UserRepository(),
@@ -507,8 +541,10 @@ export function UserImportService({
   function toUpdateUserFields(row: ImportUserRowInput) {
     return {
       nameFirst: row.name.first,
-      nameMiddle: row.name.middle ?? null,
       nameLast: row.name.last,
+      // Middle name is optional — only write it when the row carries it, so an omitted middle
+      // doesn't clobber an existing stored value.
+      ...(row.name.middle !== undefined && { nameMiddle: row.name.middle }),
       ...(row.dob !== undefined && { dob: row.dob ?? null }),
       ...(row.grade !== undefined && { grade: row.grade ?? null }),
       ...(row.demographics && {
@@ -550,12 +586,14 @@ export function UserImportService({
    * Process the update bin: update each existing user's profile fields, and sync Firebase Auth
    * (displayName / password) only when those actually changed.
    *
-   * NOTE: membership reconciliation is intentionally NOT performed yet. The legacy replaces a user's
-   * membership set per provided entity type (ending removed memberships, adding new ones), which
-   * needs a reconciliation repository method plus FGA tuple add/delete sync — it's the remaining
-   * update-bin work and is access-control-sensitive enough to warrant its own reviewed change. Until
-   * then an update row's memberships are left unchanged; profile and auth fields are updated. The
-   * dominant re-import case (refreshing profile fields with unchanged memberships) is fully handled.
+   * Rostering-ended (archived) users are rejected (not-found), matching the canonical single-update.
+   *
+   * NOTE: membership reconciliation is intentionally NOT performed yet — the legacy replaces a user's
+   * membership set per provided entity type (ending removed memberships, adding new ones), which needs
+   * a reconciliation repository method plus FGA tuple add/delete sync and is access-control-sensitive
+   * enough to warrant its own reviewed change. To avoid a misleading `ok`, a row whose memberships
+   * differ from the user's current set is failed explicitly; rows that only refresh profile fields
+   * (the dominant re-import case) succeed.
    */
   async function processUpdateBin(
     rows: { index: number; row: ImportUserRowInput; user: User }[],
@@ -563,13 +601,44 @@ export function UserImportService({
   ): Promise<void> {
     for (const { index, row, user } of rows) {
       try {
+        // Rostering-ended (archived) users are not-found for updates, matching the canonical
+        // single-update (404). Never resurrect profile/auth state on an archived account.
+        if (user.rosteringEnded) {
+          outcomes[index] = failed(
+            index,
+            CLASSIFICATION.UPDATED,
+            ApiErrorCode.RESOURCE_NOT_FOUND,
+            ApiErrorMessage.NOT_FOUND,
+          );
+          continue;
+        }
+
+        // Membership reconciliation is deferred (see the JSDoc above). Rather than report a
+        // misleading `ok` for a row that implies a membership change we don't apply, fail it
+        // explicitly when the row's memberships differ from the user's current set.
+        const currentMemberships = await userRepository.getUserEntityMemberships(user.id);
+        if (hasMembershipDelta(row.memberships, currentMemberships)) {
+          outcomes[index] = failed(
+            index,
+            CLASSIFICATION.UPDATED,
+            ApiErrorCode.RESOURCE_UNPROCESSABLE,
+            'Membership changes on update are not yet supported; re-import without membership changes',
+          );
+          continue;
+        }
+
         await userRepository.update({ id: user.id, data: toUpdateUserFields(row) });
 
+        // The DB profile write commits before the Firebase auth sync. If the auth call fails the row
+        // is reported failed even though the profile write persisted — no orphan, just a stale
+        // displayName/password the operator can fix by retrying the row. Acceptable for an update
+        // (unlike create, there's no account to compensate).
         const authUpdate = buildAuthUpdate(row, user);
         if (authUpdate && user.authId) {
           await firebaseAuth.updateUser(user.authId, authUpdate);
         }
 
+        logger.info({ userId: user.id }, 'Updated user (import)');
         outcomes[index] = ok(index, CLASSIFICATION.UPDATED, user.id);
       } catch (error) {
         logger.error({ err: error, context: { userId: user.id } }, 'Update failed during import');

--- a/apps/backend/src/services/user/user-import.service.ts
+++ b/apps/backend/src/services/user/user-import.service.ts
@@ -1,6 +1,8 @@
 import { randomUUID } from 'node:crypto';
 import { StatusCodes } from 'http-status-codes';
 import type { UserImportRecord, UserImportResult } from 'firebase-admin/auth';
+import type { TupleKeyWithoutCondition } from '@openfga/sdk';
+import type { User } from '../../db/schema';
 import type { AuthContext } from '../../types/auth-context';
 import type { UserType } from '../../enums/user-type.enum';
 import type { Grade } from '../../enums/grade.enum';
@@ -18,7 +20,7 @@ import { isFirebaseError } from '../../types/firebase';
 import { FIREBASE_ERROR_CODES } from '../../constants/firebase-error-codes';
 import { generateAssessmentPid } from '../../utils/assessment-pid.util';
 import { AuthorizationService } from '../authorization/authorization.service';
-import { FgaType, FgaRelation } from '../authorization/fga-constants';
+import { FgaType, FgaRelation, FGA_CLASS_VALID_ROLES } from '../authorization/fga-constants';
 import { UserService } from './user.service';
 import {
   hashPasswordForImport,
@@ -434,6 +436,68 @@ export function UserImportService({
   }
 
   /**
+   * Build the FGA membership tuples to delete when unenrolling a user. Mirrors the relations
+   * single-create wrote — a `user:<id>` → `<role>` → `<type>:<id>` tuple per membership — skipping
+   * class memberships whose role isn't FGA-valid (those cascade via the org hierarchy and were never
+   * written to the class type). Conditions are omitted: FGA deletes by tuple key.
+   */
+  function buildMembershipDeletionTuples(
+    userId: string,
+    memberships: { entityType: EntityType; entityId: string; role: string }[],
+  ): TupleKeyWithoutCondition[] {
+    const validClassRoles = FGA_CLASS_VALID_ROLES as ReadonlySet<string>;
+    const tuples: TupleKeyWithoutCondition[] = [];
+    for (const m of memberships) {
+      if (m.entityType === EntityType.CLASS && !validClassRoles.has(m.role)) continue;
+      tuples.push({
+        user: `user:${userId}`,
+        relation: m.role,
+        object: `${ENTITY_TYPE_TO_FGA_TYPE[m.entityType]}:${m.entityId}`,
+      });
+    }
+    return tuples;
+  }
+
+  /**
+   * Process the unenroll bin: per row, end ALL of the user's enrollments and archive them
+   * (`rosteringEnded`) in one transaction, then best-effort delete their FGA membership tuples.
+   *
+   * Ending the DB enrollment does not expire the FGA tuple's stored grant window, so explicit cleanup
+   * is required for the user to actually lose access. Matches the legacy `batchImportUpdate`, which
+   * unenrolls a user from every org and archives them regardless of which memberships the row names.
+   */
+  async function processUnenrollBin(
+    rows: { index: number; user: User }[],
+    outcomes: ImportRowOutcome[],
+  ): Promise<void> {
+    for (const { index, user } of rows) {
+      try {
+        // Capture the tuples to delete before ending the enrollments (afterward they read inactive).
+        const memberships = await userRepository.getActiveMembershipsWithRoles(user.id);
+
+        await userRepository.runTransaction({
+          fn: async (tx) => {
+            await userRepository.endAllEnrollments(user.id, tx);
+            await userRepository.archiveUser(user.id, tx);
+          },
+        });
+
+        // Best-effort: deleteTuples is fire-and-forget (logs on failure, never throws), so a stale
+        // tuple can't fail the row after the DB state has already committed.
+        const tuples = buildMembershipDeletionTuples(user.id, memberships);
+        if (tuples.length > 0) {
+          await authorizationService.deleteTuples(tuples);
+        }
+
+        outcomes[index] = ok(index, CLASSIFICATION.UNENROLLED, user.id);
+      } catch (error) {
+        logger.error({ err: error, context: { userId: user.id } }, 'Unenroll failed during import');
+        outcomes[index] = toFailedOutcome(index, CLASSIFICATION.UNENROLLED, error);
+      }
+    }
+  }
+
+  /**
    * Classify each row into create / update / unenroll and process each bin.
    *
    * @param authContext - The requesting user's auth context.
@@ -465,17 +529,17 @@ export function UserImportService({
     }
 
     const createRows: { index: number; row: ImportUserRowInput }[] = [];
-    const updateRows: { index: number; row: ImportUserRowInput }[] = [];
-    const unenrollRows: { index: number; row: ImportUserRowInput }[] = [];
+    const updateRows: { index: number; row: ImportUserRowInput; user: User }[] = [];
+    const unenrollRows: { index: number; row: ImportUserRowInput; user: User }[] = [];
 
     for (const entry of authorized) {
-      const found = existingByEmail.has(entry.row.email.toLowerCase());
+      const user = existingByEmail.get(entry.row.email.toLowerCase());
       const unenroll = Boolean(entry.row.unenroll);
 
-      if (found && unenroll) {
-        unenrollRows.push(entry);
-      } else if (found) {
-        updateRows.push(entry);
+      if (user && unenroll) {
+        unenrollRows.push({ ...entry, user });
+      } else if (user) {
+        updateRows.push({ ...entry, user });
       } else if (unenroll) {
         // Unenroll requested for a user that does not exist.
         // NOTE: the legacy cloud function routes this to the unenroll bin as a no-op rather than
@@ -494,24 +558,18 @@ export function UserImportService({
     // ── Phase 3: create bin ──────────────────────────────────────────────────────
     await processCreateBin(authContext, createRows, outcomes);
 
-    // ── Phases 4–5: update + unenroll bins (next increment) ──────────────────────
-    // These require new repository support (enrollment-ending, rosteringEnded archiving, membership
-    // reconciliation) and a per-row updateUser path for password/name. Until then, report rather
-    // than silently mishandle.
+    // ── Phase 4: unenroll bin ────────────────────────────────────────────────────
+    await processUnenrollBin(unenrollRows, outcomes);
+
+    // ── Phase 5: update bin (next increment) ─────────────────────────────────────
+    // Requires a membership-reconciliation repository method plus a per-row updateUser path for
+    // password/name. Until then, report rather than silently mishandle.
     for (const entry of updateRows) {
       outcomes[entry.index] = failed(
         entry.index,
         CLASSIFICATION.UPDATED,
         ApiErrorCode.INTERNAL,
         'Update of existing users is not yet supported by this endpoint',
-      );
-    }
-    for (const entry of unenrollRows) {
-      outcomes[entry.index] = failed(
-        entry.index,
-        CLASSIFICATION.UNENROLLED,
-        ApiErrorCode.INTERNAL,
-        'Unenrollment is not yet supported by this endpoint',
       );
     }
 

--- a/apps/backend/src/services/user/user-import.service.ts
+++ b/apps/backend/src/services/user/user-import.service.ts
@@ -195,17 +195,18 @@ export function UserImportService({
     }
   }
 
-  /** Returns true if a Firebase Auth account already exists for the email. */
-  async function firebaseEmailExists(email: string): Promise<boolean> {
-    try {
-      await firebaseAuth.getUserByEmail(email);
-      return true;
-    } catch (error) {
-      if (isFirebaseError(error) && error.code === FIREBASE_ERROR_CODES.AUTH.USER_NOT_FOUND) {
-        return false;
-      }
-      throw error;
-    }
+  /**
+   * Batch-check which of the given emails already have a Firebase Auth account. Uses the Admin SDK's
+   * `getUsers` (one call for up to 100 identifiers — the batch cap) instead of a per-row
+   * `getUserByEmail`, keeping Firebase round-trips to one regardless of batch size
+   * (performance-avoid-quadratic).
+   *
+   * @returns A set of the lowercased emails that already exist in Firebase Auth.
+   */
+  async function getExistingFirebaseEmails(emails: string[]): Promise<Set<string>> {
+    if (emails.length === 0) return new Set();
+    const { users } = await firebaseAuth.getUsers(emails.map((email) => ({ email })));
+    return new Set(users.map((user) => user.email?.toLowerCase()).filter((email): email is string => Boolean(email)));
   }
 
   /** Map a Firebase `importUsers` FailedAccount error to a safe per-row error code. */
@@ -264,7 +265,30 @@ export function UserImportService({
 
     const params = getScryptParams();
 
-    // Pre-flight each candidate: password required, PID + Postgres/Firebase uniqueness, then hash.
+    // Batch Firebase existence check — one getUsers call for the whole batch (≤100). importUsers
+    // bypasses uniqueness validation, so we must pre-check; batching avoids per-row round-trips.
+    let firebaseExistingEmails: Set<string>;
+    try {
+      firebaseExistingEmails = await getExistingFirebaseEmails(candidates.map((candidate) => candidate.row.email));
+    } catch (error) {
+      logger.error({ err: error, context: { count: candidates.length } }, 'Firebase getUsers pre-check failed');
+      for (const candidate of candidates) {
+        outcomes[candidate.index] = failed(
+          candidate.index,
+          CLASSIFICATION.CREATED,
+          ApiErrorCode.EXTERNAL_SERVICE_FAILED,
+          ApiErrorMessage.INTERNAL_SERVER_ERROR,
+        );
+      }
+      return;
+    }
+
+    // Pre-flight each candidate: password required, within-batch PID + Postgres/Firebase uniqueness,
+    // then hash. Note: super admins skip the explicit membership-existence pre-flight that
+    // single-create performs; an invalid entity instead fails at the FK constraint inside
+    // createWithImportedAuth, which compensates by deleting the just-imported Firebase account
+    // (no orphan, just slightly more create+delete churn for that row).
+    const seenPids = new Set<string>();
     const prepared: {
       index: number;
       row: ImportUserRowInput;
@@ -289,9 +313,30 @@ export function UserImportService({
 
       const assessmentPid = row.identifiers?.pid ?? generateAssessmentPid({ userId: row.email });
 
+      // Within-batch PID uniqueness (email is already deduped above; importUsers validates neither).
+      if (seenPids.has(assessmentPid)) {
+        outcomes[index] = failed(
+          index,
+          CLASSIFICATION.CREATED,
+          ApiErrorCode.RESOURCE_CONFLICT,
+          ApiErrorMessage.CONFLICT,
+        );
+        continue;
+      }
+      seenPids.add(assessmentPid);
+
+      if (firebaseExistingEmails.has(row.email.toLowerCase())) {
+        outcomes[index] = failed(
+          index,
+          CLASSIFICATION.CREATED,
+          ApiErrorCode.RESOURCE_CONFLICT,
+          ApiErrorMessage.CONFLICT,
+        );
+        continue;
+      }
+
       try {
-        const exists = await userRepository.existsByUniqueFields({ email: row.email, assessmentPid });
-        if (exists || (await firebaseEmailExists(row.email))) {
+        if (await userRepository.existsByUniqueFields({ email: row.email, assessmentPid })) {
           outcomes[index] = failed(
             index,
             CLASSIFICATION.CREATED,
@@ -301,7 +346,10 @@ export function UserImportService({
           continue;
         }
       } catch (error) {
-        logger.error({ err: error, context: { email: row.email } }, 'Uniqueness pre-check failed during import');
+        logger.error(
+          { err: error, context: { email: row.email } },
+          'Postgres uniqueness pre-check failed during import',
+        );
         outcomes[index] = failed(
           index,
           CLASSIFICATION.CREATED,
@@ -354,7 +402,7 @@ export function UserImportService({
 
     // Mark rows that Firebase rejected (by their position in the records array).
     const failedRecordIndexes = new Set<number>();
-    for (const failure of result.errors ?? []) {
+    for (const failure of result.errors) {
       failedRecordIndexes.add(failure.index);
       const p = prepared[failure.index];
       if (p) {

--- a/apps/backend/src/services/user/user-import.service.ts
+++ b/apps/backend/src/services/user/user-import.service.ts
@@ -45,9 +45,9 @@ import {
  * **Unenroll bin** (implemented): ends all of a user's enrollments and archives them
  * (`rosteringEnded`) in one transaction, then best-effort deletes their FGA membership tuples.
  *
- * **Update bin**: tracked as the next increment — it needs a membership-reconciliation repository
- * method plus a per-row `updateUser` path for password/name. Until then update rows are reported as
- * a per-row failure rather than silently mishandled.
+ * **Update bin** (profile + auth implemented): updates an existing user's profile fields and syncs
+ * Firebase Auth (displayName / password) when they changed. Membership reconciliation
+ * (replace-semantics per the legacy) is the remaining piece — see `processUpdateBin`.
  *
  * Authorization mirrors single-create and is applied per row: super admin, or `can_create_users` on
  * every membership target (the legacy uses the same coarse permission for all three bins).
@@ -501,6 +501,84 @@ export function UserImportService({
   }
 
   /**
+   * Map an import row to the user-table fields an update writes. Import rows always carry the full
+   * name; other profile fields are written only when provided (an omitted field is left unchanged).
+   */
+  function toUpdateUserFields(row: ImportUserRowInput) {
+    return {
+      nameFirst: row.name.first,
+      nameMiddle: row.name.middle ?? null,
+      nameLast: row.name.last,
+      ...(row.dob !== undefined && { dob: row.dob ?? null }),
+      ...(row.grade !== undefined && { grade: row.grade ?? null }),
+      ...(row.demographics && {
+        statusEll: row.demographics.statusEll ?? null,
+        statusFrl: row.demographics.statusFrl ?? null,
+        statusIep: row.demographics.statusIep ?? null,
+        gender: row.demographics.gender ?? null,
+        race: row.demographics.race ?? null,
+        hispanicEthnicity: row.demographics.hispanicEthnicity ?? null,
+        homeLanguage: row.demographics.homeLanguage ?? null,
+      }),
+      ...(row.identifiers?.stateId !== undefined && { stateId: row.identifiers.stateId }),
+    };
+  }
+
+  /**
+   * Build the Firebase Auth update for an update row, or null if nothing auth-related changed.
+   * `displayName` is synced only when the name actually changed; the password is set when provided.
+   * This keeps update-bin Firebase writes off the per-row path for pure profile/demographic updates.
+   */
+  function buildAuthUpdate(row: ImportUserRowInput, user: User): { displayName?: string; password?: string } | null {
+    const update: { displayName?: string; password?: string } = {};
+
+    const nameChanged =
+      row.name.first !== user.nameFirst ||
+      row.name.last !== user.nameLast ||
+      (row.name.middle ?? null) !== (user.nameMiddle ?? null);
+    if (nameChanged) {
+      update.displayName = [row.name.first, row.name.last].filter(Boolean).join(' ');
+    }
+    if (row.password) {
+      update.password = row.password;
+    }
+
+    return Object.keys(update).length > 0 ? update : null;
+  }
+
+  /**
+   * Process the update bin: update each existing user's profile fields, and sync Firebase Auth
+   * (displayName / password) only when those actually changed.
+   *
+   * NOTE: membership reconciliation is intentionally NOT performed yet. The legacy replaces a user's
+   * membership set per provided entity type (ending removed memberships, adding new ones), which
+   * needs a reconciliation repository method plus FGA tuple add/delete sync — it's the remaining
+   * update-bin work and is access-control-sensitive enough to warrant its own reviewed change. Until
+   * then an update row's memberships are left unchanged; profile and auth fields are updated. The
+   * dominant re-import case (refreshing profile fields with unchanged memberships) is fully handled.
+   */
+  async function processUpdateBin(
+    rows: { index: number; row: ImportUserRowInput; user: User }[],
+    outcomes: ImportRowOutcome[],
+  ): Promise<void> {
+    for (const { index, row, user } of rows) {
+      try {
+        await userRepository.update({ id: user.id, data: toUpdateUserFields(row) });
+
+        const authUpdate = buildAuthUpdate(row, user);
+        if (authUpdate && user.authId) {
+          await firebaseAuth.updateUser(user.authId, authUpdate);
+        }
+
+        outcomes[index] = ok(index, CLASSIFICATION.UPDATED, user.id);
+      } catch (error) {
+        logger.error({ err: error, context: { userId: user.id } }, 'Update failed during import');
+        outcomes[index] = toFailedOutcome(index, CLASSIFICATION.UPDATED, error);
+      }
+    }
+  }
+
+  /**
    * Classify each row into create / update / unenroll and process each bin.
    *
    * @param authContext - The requesting user's auth context.
@@ -564,17 +642,9 @@ export function UserImportService({
     // ── Phase 4: unenroll bin ────────────────────────────────────────────────────
     await processUnenrollBin(unenrollRows, outcomes);
 
-    // ── Phase 5: update bin (next increment) ─────────────────────────────────────
-    // Requires a membership-reconciliation repository method plus a per-row updateUser path for
-    // password/name. Until then, report rather than silently mishandle.
-    for (const entry of updateRows) {
-      outcomes[entry.index] = failed(
-        entry.index,
-        CLASSIFICATION.UPDATED,
-        ApiErrorCode.INTERNAL,
-        'Update of existing users is not yet supported by this endpoint',
-      );
-    }
+    // ── Phase 5: update bin ──────────────────────────────────────────────────────
+    // Updates profile + auth fields. Membership reconciliation is deferred (see processUpdateBin).
+    await processUpdateBin(updateRows, outcomes);
 
     return outcomes;
   }

--- a/apps/backend/src/services/user/user-import.service.ts
+++ b/apps/backend/src/services/user/user-import.service.ts
@@ -42,9 +42,12 @@ import {
  * persisted via {@link UserService.createWithImportedAuth}, which runs the same DB+FGA saga and
  * compensation as single-create. Passwords are SCRYPT-hashed for `importUsers`.
  *
- * **Update / unenroll bins**: tracked as the next increment — they require new repository support
- * for enrollment-ending, `rosteringEnded` archiving, and membership reconciliation. Until then, such
- * rows are reported as a per-row failure rather than silently mishandled.
+ * **Unenroll bin** (implemented): ends all of a user's enrollments and archives them
+ * (`rosteringEnded`) in one transaction, then best-effort deletes their FGA membership tuples.
+ *
+ * **Update bin**: tracked as the next increment — it needs a membership-reconciliation repository
+ * method plus a per-row `updateUser` path for password/name. Until then update rows are reported as
+ * a per-row failure rather than silently mishandled.
  *
  * Authorization mirrors single-create and is applied per row: super admin, or `can_create_users` on
  * every membership target (the legacy uses the same coarse permission for all three bins).

--- a/apps/backend/src/services/user/user-import.service.ts
+++ b/apps/backend/src/services/user/user-import.service.ts
@@ -1,0 +1,474 @@
+import { randomUUID } from 'node:crypto';
+import { StatusCodes } from 'http-status-codes';
+import type { UserImportRecord, UserImportResult } from 'firebase-admin/auth';
+import type { AuthContext } from '../../types/auth-context';
+import type { UserType } from '../../enums/user-type.enum';
+import type { Grade } from '../../enums/grade.enum';
+import type { FreeReducedLunchStatus } from '../../enums/frl-status.enum';
+import { UserRole } from '../../enums/user-role.enum';
+import type { UserFamilyRole } from '../../enums/user-family-role.enum';
+import { EntityType } from '../../types/entity-type';
+import { ApiError } from '../../errors/api-error';
+import { ApiErrorCode } from '../../enums/api-error-code.enum';
+import { ApiErrorMessage } from '../../enums/api-error-message.enum';
+import { logger } from '../../logger';
+import { UserRepository } from '../../repositories/user.repository';
+import { FirebaseAuthClient } from '../../clients/firebase-auth.clients';
+import { isFirebaseError } from '../../types/firebase';
+import { FIREBASE_ERROR_CODES } from '../../constants/firebase-error-codes';
+import { generateAssessmentPid } from '../../utils/assessment-pid.util';
+import { AuthorizationService } from '../authorization/authorization.service';
+import { FgaType, FgaRelation } from '../authorization/fga-constants';
+import { UserService } from './user.service';
+import {
+  hashPasswordForImport,
+  getFirebaseScryptParamsFromEnv,
+  type FirebaseScryptParams,
+} from './utils/firebase-password-hash';
+
+/**
+ * UserImportService
+ *
+ * Bulk create / update / unenroll users from a single request, the backend replacement for the
+ * legacy `batchImportUpdate` cloud function that backs the dashboard's CSV upload. Each row is
+ * classified by email into one of three bins and processed against Firebase Auth, Postgres, and
+ * OpenFGA with per-row atomicity — a failure on one row never affects the others, and every row's
+ * outcome is reported individually.
+ *
+ * **Create bin** (implemented): all rows' Firebase accounts are created in a single `importUsers`
+ * call (one round-trip, no per-account rate limit — the reason this endpoint exists), then each is
+ * persisted via {@link UserService.createWithImportedAuth}, which runs the same DB+FGA saga and
+ * compensation as single-create. Passwords are SCRYPT-hashed for `importUsers`.
+ *
+ * **Update / unenroll bins**: tracked as the next increment — they require new repository support
+ * for enrollment-ending, `rosteringEnded` archiving, and membership reconciliation. Until then, such
+ * rows are reported as a per-row failure rather than silently mishandled.
+ *
+ * Authorization mirrors single-create and is applied per row: super admin, or `can_create_users` on
+ * every membership target (the legacy uses the same coarse permission for all three bins).
+ */
+
+const CLASSIFICATION = {
+  CREATED: 'created',
+  UPDATED: 'updated',
+  UNENROLLED: 'unenrolled',
+} as const;
+
+type Classification = (typeof CLASSIFICATION)[keyof typeof CLASSIFICATION];
+
+interface ImportRowMembership {
+  entityType: EntityType;
+  entityId: string;
+  // Org roles use UserRole; family memberships use UserFamilyRole (parent/child). The flat union
+  // mirrors how the contract's discriminated membership union is inferred at the service boundary.
+  role: UserRole | UserFamilyRole;
+  enrollmentStart?: string | undefined;
+  enrollmentEnd?: string | undefined;
+}
+
+/** A single import row. Mirrors the single-create payload plus `unenroll` and an optional password. */
+export interface ImportUserRowInput {
+  email: string;
+  password?: string | undefined;
+  name: { first: string; middle?: string | null | undefined; last: string };
+  userType: UserType;
+  dob?: string | null | undefined;
+  grade?: Grade | null | undefined;
+  demographics?:
+    | {
+        statusEll?: string | null | undefined;
+        statusFrl?: FreeReducedLunchStatus | null | undefined;
+        statusIep?: string | null | undefined;
+        gender?: string | null | undefined;
+        race?: string | null | undefined;
+        hispanicEthnicity?: boolean | null | undefined;
+        homeLanguage?: string | null | undefined;
+      }
+    | undefined;
+  identifiers?: { stateId?: string | undefined; pid?: string | undefined } | undefined;
+  unenroll?: boolean | undefined;
+  memberships: ImportRowMembership[];
+}
+
+/** Per-row outcome. Successful rows carry the resulting user id; failed rows carry a safe code/message. */
+export type ImportRowOutcome =
+  | { index: number; classification: Classification; status: 'ok'; id: string }
+  | { index: number; classification: Classification; status: 'failed'; error: { code: string; message: string } };
+
+function ok(index: number, classification: Classification, id: string): ImportRowOutcome {
+  return { index, classification, status: 'ok', id };
+}
+
+function failed(index: number, classification: Classification, code: string, message: string): ImportRowOutcome {
+  return { index, classification, status: 'failed', error: { code, message } };
+}
+
+/** Map an ApiError (or unknown error) to a safe per-row failure outcome. */
+function toFailedOutcome(index: number, classification: Classification, error: unknown): ImportRowOutcome {
+  if (error instanceof ApiError) {
+    return failed(index, classification, error.code, error.message);
+  }
+  return failed(index, classification, ApiErrorCode.INTERNAL, ApiErrorMessage.INTERNAL_SERVER_ERROR);
+}
+
+/** Best-effort classification for a row that fails before bin routing (e.g. authorization). */
+function preRoutingClassification(row: ImportUserRowInput): Classification {
+  return row.unenroll ? CLASSIFICATION.UNENROLLED : CLASSIFICATION.CREATED;
+}
+
+export function UserImportService({
+  userService = UserService(),
+  userRepository = new UserRepository(),
+  authorizationService = AuthorizationService(),
+  firebaseAuth = FirebaseAuthClient,
+  scryptParams,
+}: {
+  userService?: ReturnType<typeof UserService>;
+  userRepository?: UserRepository;
+  authorizationService?: ReturnType<typeof AuthorizationService>;
+  firebaseAuth?: typeof FirebaseAuthClient;
+  scryptParams?: FirebaseScryptParams;
+} = {}) {
+  const ENTITY_TYPE_TO_FGA_TYPE: Record<EntityType, FgaType> = {
+    district: FgaType.DISTRICT,
+    school: FgaType.SCHOOL,
+    class: FgaType.CLASS,
+    group: FgaType.GROUP,
+    family: FgaType.FAMILY,
+  };
+
+  // Read scrypt params lazily so importing this module (or constructing the service in a test that
+  // never reaches the create bin) doesn't require the secrets to be present.
+  function getScryptParams(): FirebaseScryptParams {
+    return scryptParams ?? getFirebaseScryptParamsFromEnv();
+  }
+
+  /**
+   * Authorize a row's memberships, mirroring single-create's authorization. Super admins bypass FGA;
+   * non-super-admins must hold `can_create_users` on every membership target (class memberships are
+   * checked against the parent school). Throws `ApiError` (FORBIDDEN / UNPROCESSABLE_ENTITY) on deny.
+   *
+   * The same permission gates create, update, and unenroll — matching the legacy cloud function,
+   * which validates the requester's org coverage identically for all three.
+   */
+  async function authorizeRow(authContext: AuthContext, memberships: ImportRowMembership[]): Promise<void> {
+    const { userId, isSuperAdmin } = authContext;
+
+    if (isSuperAdmin) return;
+
+    // Guard against a non-super-admin creating a platform_admin.
+    for (const m of memberships) {
+      if (m.entityType !== EntityType.FAMILY && m.role === UserRole.PLATFORM_ADMIN) {
+        logger.warn({ userId, attemptedRole: m.role }, 'Non-super-admin attempted to import a platform_admin');
+        throw new ApiError(ApiErrorMessage.FORBIDDEN, {
+          statusCode: StatusCodes.FORBIDDEN,
+          code: ApiErrorCode.AUTH_FORBIDDEN,
+          context: { userId },
+        });
+      }
+    }
+
+    for (const membership of memberships) {
+      if (membership.entityType === EntityType.CLASS) {
+        const schoolId = await userRepository.findClassParentSchool(membership.entityId);
+        if (!schoolId) {
+          throw new ApiError(ApiErrorMessage.UNPROCESSABLE_ENTITY, {
+            statusCode: StatusCodes.UNPROCESSABLE_ENTITY,
+            code: ApiErrorCode.RESOURCE_NOT_FOUND,
+            context: { userId, classId: membership.entityId },
+          });
+        }
+        await authorizationService.requirePermission(
+          userId,
+          FgaRelation.CAN_CREATE_USERS,
+          `${FgaType.SCHOOL}:${schoolId}`,
+        );
+      } else if (membership.entityType !== EntityType.FAMILY) {
+        await authorizationService.requirePermission(
+          userId,
+          FgaRelation.CAN_CREATE_USERS,
+          `${ENTITY_TYPE_TO_FGA_TYPE[membership.entityType]}:${membership.entityId}`,
+        );
+      }
+      // FAMILY memberships intentionally skip the FGA check here, matching single-create's
+      // outstanding authorization gap (roar-project-management#1774).
+    }
+  }
+
+  /** Returns true if a Firebase Auth account already exists for the email. */
+  async function firebaseEmailExists(email: string): Promise<boolean> {
+    try {
+      await firebaseAuth.getUserByEmail(email);
+      return true;
+    } catch (error) {
+      if (isFirebaseError(error) && error.code === FIREBASE_ERROR_CODES.AUTH.USER_NOT_FOUND) {
+        return false;
+      }
+      throw error;
+    }
+  }
+
+  /** Map a Firebase `importUsers` FailedAccount error to a safe per-row error code. */
+  function mapImportError(error: unknown): string {
+    if (isFirebaseError(error) && error.code === FIREBASE_ERROR_CODES.AUTH.EMAIL_ALREADY_EXISTS) {
+      return ApiErrorCode.RESOURCE_CONFLICT;
+    }
+    return ApiErrorCode.EXTERNAL_SERVICE_FAILED;
+  }
+
+  /** Build the {@link UserService.createWithImportedAuth} payload for a create row. */
+  function toCreateUserData(row: ImportUserRowInput, assessmentPid: string) {
+    return {
+      email: row.email,
+      // Unused by createWithImportedAuth (the account is already created); kept for type shape.
+      password: row.password ?? '',
+      name: { first: row.name.first, middle: row.name.middle ?? undefined, last: row.name.last },
+      userType: row.userType,
+      dob: row.dob ?? undefined,
+      grade: row.grade ?? undefined,
+      demographics: row.demographics ?? undefined,
+      identifiers: { ...row.identifiers, pid: assessmentPid },
+      memberships: row.memberships,
+    };
+  }
+
+  /**
+   * Process the create bin: within-batch + Postgres + Firebase uniqueness pre-checks, then one
+   * `importUsers` call, then per-row persistence with compensation. Writes each row's outcome into
+   * `outcomes` by its original index.
+   */
+  async function processCreateBin(
+    authContext: AuthContext,
+    rows: { index: number; row: ImportUserRowInput }[],
+    outcomes: ImportRowOutcome[],
+  ): Promise<void> {
+    if (rows.length === 0) return;
+
+    // Within-batch email uniqueness — importUsers does not validate it.
+    const seenEmails = new Set<string>();
+    const candidates: { index: number; row: ImportUserRowInput }[] = [];
+    for (const candidate of rows) {
+      const key = candidate.row.email.toLowerCase();
+      if (seenEmails.has(key)) {
+        outcomes[candidate.index] = failed(
+          candidate.index,
+          CLASSIFICATION.CREATED,
+          ApiErrorCode.RESOURCE_CONFLICT,
+          ApiErrorMessage.CONFLICT,
+        );
+        continue;
+      }
+      seenEmails.add(key);
+      candidates.push(candidate);
+    }
+
+    const params = getScryptParams();
+
+    // Pre-flight each candidate: password required, PID + Postgres/Firebase uniqueness, then hash.
+    const prepared: {
+      index: number;
+      row: ImportUserRowInput;
+      firebaseUid: string;
+      assessmentPid: string;
+      passwordHash: Buffer;
+      passwordSalt: Buffer;
+    }[] = [];
+
+    for (const candidate of candidates) {
+      const { index, row } = candidate;
+
+      if (!row.password) {
+        outcomes[index] = failed(
+          index,
+          CLASSIFICATION.CREATED,
+          ApiErrorCode.REQUEST_VALIDATION_FAILED,
+          'Password is required to create a user',
+        );
+        continue;
+      }
+
+      const assessmentPid = row.identifiers?.pid ?? generateAssessmentPid({ userId: row.email });
+
+      try {
+        const exists = await userRepository.existsByUniqueFields({ email: row.email, assessmentPid });
+        if (exists || (await firebaseEmailExists(row.email))) {
+          outcomes[index] = failed(
+            index,
+            CLASSIFICATION.CREATED,
+            ApiErrorCode.RESOURCE_CONFLICT,
+            ApiErrorMessage.CONFLICT,
+          );
+          continue;
+        }
+      } catch (error) {
+        logger.error({ err: error, context: { email: row.email } }, 'Uniqueness pre-check failed during import');
+        outcomes[index] = failed(
+          index,
+          CLASSIFICATION.CREATED,
+          ApiErrorCode.EXTERNAL_SERVICE_FAILED,
+          ApiErrorMessage.INTERNAL_SERVER_ERROR,
+        );
+        continue;
+      }
+
+      const { passwordHash, passwordSalt } = await hashPasswordForImport(row.password, params);
+      prepared.push({ index, row, firebaseUid: randomUUID(), assessmentPid, passwordHash, passwordSalt });
+    }
+
+    if (prepared.length === 0) return;
+
+    // One batched importUsers call for every prepared row.
+    const records: UserImportRecord[] = prepared.map((p) => ({
+      uid: p.firebaseUid,
+      email: p.row.email,
+      displayName: [p.row.name.first, p.row.name.last].filter(Boolean).join(' '),
+      passwordHash: p.passwordHash,
+      passwordSalt: p.passwordSalt,
+    }));
+
+    let result: UserImportResult;
+    try {
+      result = await firebaseAuth.importUsers(records, {
+        hash: {
+          algorithm: 'SCRYPT' as const,
+          key: params.signerKey,
+          saltSeparator: params.saltSeparator,
+          rounds: params.rounds,
+          memoryCost: params.memoryCost,
+        },
+      });
+    } catch (error) {
+      // The whole importUsers call failed (e.g. Admin SDK unavailable). Fail every prepared row;
+      // nothing was persisted, so there is nothing to compensate.
+      logger.error({ err: error, context: { count: prepared.length } }, 'importUsers call failed');
+      for (const p of prepared) {
+        outcomes[p.index] = failed(
+          p.index,
+          CLASSIFICATION.CREATED,
+          ApiErrorCode.EXTERNAL_SERVICE_FAILED,
+          ApiErrorMessage.INTERNAL_SERVER_ERROR,
+        );
+      }
+      return;
+    }
+
+    // Mark rows that Firebase rejected (by their position in the records array).
+    const failedRecordIndexes = new Set<number>();
+    for (const failure of result.errors ?? []) {
+      failedRecordIndexes.add(failure.index);
+      const p = prepared[failure.index];
+      if (p) {
+        outcomes[p.index] = failed(
+          p.index,
+          CLASSIFICATION.CREATED,
+          mapImportError(failure.error),
+          ApiErrorMessage.CONFLICT,
+        );
+      }
+    }
+
+    // Persist each successfully-imported row. createWithImportedAuth compensates (incl. deleting the
+    // imported Firebase account) on any DB/FGA failure, so a failed row leaves no orphan.
+    for (let i = 0; i < prepared.length; i++) {
+      if (failedRecordIndexes.has(i)) continue;
+      const p = prepared[i]!;
+      try {
+        const { id } = await userService.createWithImportedAuth(
+          authContext,
+          toCreateUserData(p.row, p.assessmentPid),
+          p.firebaseUid,
+        );
+        outcomes[p.index] = ok(p.index, CLASSIFICATION.CREATED, id);
+      } catch (error) {
+        outcomes[p.index] = toFailedOutcome(p.index, CLASSIFICATION.CREATED, error);
+      }
+    }
+  }
+
+  /**
+   * Classify each row into create / update / unenroll and process each bin.
+   *
+   * @param authContext - The requesting user's auth context.
+   * @param rows - The import rows, in request order.
+   * @returns Per-row outcomes, one per input row, in request order.
+   */
+  async function bulkImport(authContext: AuthContext, rows: ImportUserRowInput[]): Promise<ImportRowOutcome[]> {
+    const outcomes: ImportRowOutcome[] = new Array(rows.length);
+
+    // ── Phase 1: per-row authorization (before any external writes) ──────────────
+    const authorized: { index: number; row: ImportUserRowInput }[] = [];
+    for (let index = 0; index < rows.length; index++) {
+      const row = rows[index]!;
+      try {
+        await authorizeRow(authContext, row.memberships);
+        authorized.push({ index, row });
+      } catch (error) {
+        outcomes[index] = toFailedOutcome(index, preRoutingClassification(row), error);
+      }
+    }
+
+    if (authorized.length === 0) return outcomes;
+
+    // ── Phase 2: classify by email existence (single batched lookup) ─────────────
+    const existing = await userRepository.findByEmails(authorized.map((a) => a.row.email));
+    const existingByEmail = new Map<string, (typeof existing)[number]>();
+    for (const user of existing) {
+      if (user.email) existingByEmail.set(user.email.toLowerCase(), user);
+    }
+
+    const createRows: { index: number; row: ImportUserRowInput }[] = [];
+    const updateRows: { index: number; row: ImportUserRowInput }[] = [];
+    const unenrollRows: { index: number; row: ImportUserRowInput }[] = [];
+
+    for (const entry of authorized) {
+      const found = existingByEmail.has(entry.row.email.toLowerCase());
+      const unenroll = Boolean(entry.row.unenroll);
+
+      if (found && unenroll) {
+        unenrollRows.push(entry);
+      } else if (found) {
+        updateRows.push(entry);
+      } else if (unenroll) {
+        // Unenroll requested for a user that does not exist.
+        // NOTE: the legacy cloud function routes this to the unenroll bin as a no-op rather than
+        // rejecting. We reject per the ticket spec; revisit if strict parity is preferred.
+        outcomes[entry.index] = failed(
+          entry.index,
+          CLASSIFICATION.UNENROLLED,
+          ApiErrorCode.RESOURCE_NOT_FOUND,
+          ApiErrorMessage.UNPROCESSABLE_ENTITY,
+        );
+      } else {
+        createRows.push(entry);
+      }
+    }
+
+    // ── Phase 3: create bin ──────────────────────────────────────────────────────
+    await processCreateBin(authContext, createRows, outcomes);
+
+    // ── Phases 4–5: update + unenroll bins (next increment) ──────────────────────
+    // These require new repository support (enrollment-ending, rosteringEnded archiving, membership
+    // reconciliation) and a per-row updateUser path for password/name. Until then, report rather
+    // than silently mishandle.
+    for (const entry of updateRows) {
+      outcomes[entry.index] = failed(
+        entry.index,
+        CLASSIFICATION.UPDATED,
+        ApiErrorCode.INTERNAL,
+        'Update of existing users is not yet supported by this endpoint',
+      );
+    }
+    for (const entry of unenrollRows) {
+      outcomes[entry.index] = failed(
+        entry.index,
+        CLASSIFICATION.UNENROLLED,
+        ApiErrorCode.INTERNAL,
+        'Unenrollment is not yet supported by this endpoint',
+      );
+    }
+
+    return outcomes;
+  }
+
+  return { bulkImport };
+}

--- a/apps/backend/src/services/user/user.service.ts
+++ b/apps/backend/src/services/user/user.service.ts
@@ -782,6 +782,204 @@ export function UserService({
   }
 
   /**
+   * Persist a user whose Firebase Auth account already exists.
+   *
+   * Runs the identical DB-transaction + FGA-tuple saga as `create()` steps 4–5, but takes a
+   * pre-created `firebaseUid` instead of calling `createUser`. This lets the bulk-import create bin
+   * create all Firebase accounts in a single `importUsers` call (one round-trip, no per-account
+   * rate limit) and then persist each one here, reusing the same compensation guarantees.
+   *
+   * The caller owns authorization, uniqueness pre-checks, and Firebase account creation. On any DB
+   * or FGA failure this compensates by deleting the FGA tuples, the DB rows, and — since the caller
+   * created it — the Firebase account, so a failed row leaves no orphan in any system.
+   *
+   * @param authContext - Requesting user's auth context (for logging/compensation context).
+   * @param body - The user fields + memberships (same shape as `create`).
+   * @param firebaseUid - The pre-created Firebase Auth UID to store as the user's authId.
+   * @returns The new user's id.
+   * @throws {ApiError} CONFLICT on a unique-field collision, UNPROCESSABLE_ENTITY on a bad
+   *   membership reference, or INTERNAL_SERVER_ERROR on DB/FGA failure — after compensation.
+   */
+  async function createWithImportedAuth(
+    authContext: AuthContext,
+    body: CreateUserData,
+    firebaseUid: string,
+  ): Promise<{ id: string }> {
+    const { demographics, dob, grade, email, identifiers, memberships, name, userType } = body;
+    const { userId } = authContext;
+
+    const assessmentPid = identifiers?.pid ?? generateAssessmentPid({ userId: email });
+
+    let newUserId!: string;
+    try {
+      const enrollmentStart = new Date();
+
+      const orgMemberships: Omit<NewUserOrg, 'userId'>[] = memberships
+        .filter(isOrgMembership)
+        .filter((m) => m.entityType === EntityType.DISTRICT || m.entityType === EntityType.SCHOOL)
+        .map((m) => ({
+          orgId: m.entityId,
+          role: m.role,
+          enrollmentStart: m.enrollmentStart ? new Date(m.enrollmentStart) : enrollmentStart,
+          enrollmentEnd: m.enrollmentEnd ? new Date(m.enrollmentEnd) : null,
+        }));
+
+      const classMemberships: Omit<NewUserClass, 'userId'>[] = memberships
+        .filter(isOrgMembership)
+        .filter((m) => m.entityType === EntityType.CLASS)
+        .map((m) => ({
+          classId: m.entityId,
+          role: m.role,
+          enrollmentStart: m.enrollmentStart ? new Date(m.enrollmentStart) : enrollmentStart,
+          enrollmentEnd: m.enrollmentEnd ? new Date(m.enrollmentEnd) : null,
+        }));
+
+      const groupMemberships: Omit<NewUserGroup, 'userId'>[] = memberships
+        .filter(isOrgMembership)
+        .filter((m) => m.entityType === EntityType.GROUP)
+        .map((m) => ({
+          groupId: m.entityId,
+          role: m.role,
+          enrollmentStart: m.enrollmentStart ? new Date(m.enrollmentStart) : enrollmentStart,
+          enrollmentEnd: m.enrollmentEnd ? new Date(m.enrollmentEnd) : null,
+        }));
+
+      const familyMemberships: Omit<NewUserFamily, 'userId'>[] = memberships.filter(isFamilyMembership).map((m) => ({
+        familyId: m.entityId,
+        role: m.role,
+        joinedOn: m.enrollmentStart ? new Date(m.enrollmentStart) : enrollmentStart,
+        leftOn: m.enrollmentEnd ? new Date(m.enrollmentEnd) : null,
+      }));
+
+      const resolvedRootOrgProvider = await resolveRootOrgProviderFromMemberships(memberships);
+
+      newUserId = await userRepository.runTransaction({
+        fn: async (tx) => {
+          const result = await userRepository.createWithMemberships(
+            {
+              authId: firebaseUid,
+              authProvider: [AuthProvider.PASSWORD],
+              email: email,
+              nameFirst: name.first,
+              nameMiddle: name.middle ?? null,
+              nameLast: name.last,
+              dob: dob ?? null,
+              grade: grade ?? null,
+              assessmentPid,
+              userType: userType,
+              statusEll: demographics?.statusEll ?? null,
+              statusFrl: demographics?.statusFrl ?? null,
+              statusIep: demographics?.statusIep ?? null,
+              gender: demographics?.gender ?? null,
+              race: demographics?.race ?? null,
+              hispanicEthnicity: demographics?.hispanicEthnicity ?? null,
+              homeLanguage: demographics?.homeLanguage ?? null,
+              stateId: identifiers?.stateId ?? null,
+              isSuperAdmin: false,
+            },
+            orgMemberships,
+            classMemberships,
+            groupMemberships,
+            familyMemberships,
+            tx,
+          );
+
+          await rosterProviderIdRepository.create({
+            data: {
+              providerType: RosteringProvider.DASHBOARD,
+              providerId: result.id,
+              partnerId: resolvedRootOrgProvider,
+              entityType: RosteringEntityType.USER,
+              entityId: result.id,
+            },
+            transaction: tx,
+          });
+
+          return result.id;
+        },
+      });
+    } catch (error) {
+      // The DB transaction rolled back atomically; only the caller-created Firebase account needs
+      // compensating deletion.
+      await compensateDeleteFirebaseUser(firebaseUid, userId, email, 'import persistence DB failure');
+
+      if (error instanceof ApiError) throw error;
+
+      const dbError = unwrapDrizzleError(error);
+
+      if (isUniqueViolation(dbError)) {
+        throw new ApiError(ApiErrorMessage.CONFLICT, {
+          statusCode: StatusCodes.CONFLICT,
+          code: ApiErrorCode.RESOURCE_CONFLICT,
+          context: { userId, email },
+          cause: error,
+        });
+      }
+
+      if (isForeignKeyViolation(dbError)) {
+        throw new ApiError(ApiErrorMessage.UNPROCESSABLE_ENTITY, {
+          statusCode: StatusCodes.UNPROCESSABLE_ENTITY,
+          code: ApiErrorCode.RESOURCE_NOT_FOUND,
+          context: { userId, email },
+          cause: error,
+        });
+      }
+
+      logger.error({ err: error, context: { userId, email } }, 'DB write failed during imported-auth user create');
+      throw new ApiError('Failed to create user record', {
+        statusCode: StatusCodes.INTERNAL_SERVER_ERROR,
+        code: ApiErrorCode.DATABASE_QUERY_FAILED,
+        context: { userId, email, firebaseUid },
+        cause: error,
+      });
+    }
+
+    const fgaTuples = buildMembershipTuples(newUserId, memberships);
+
+    try {
+      await authorizationService.writeTuplesOrThrow(fgaTuples);
+    } catch (error) {
+      logger.error(
+        { err: error, context: { userId, newUserId, email, firebaseUid } },
+        'FGA write failed during imported-auth user create — beginning compensation',
+      );
+
+      const deleteTuples: TupleKeyWithoutCondition[] = fgaTuples.map(({ user, relation, object }) => ({
+        user,
+        relation,
+        object,
+      }));
+      await authorizationService.deleteTuples(deleteTuples);
+
+      try {
+        await userRepository.runTransaction({
+          fn: async (tx) => {
+            await rosterProviderIdRepository.deleteByEntityId(newUserId, tx);
+            await userRepository.delete({ id: newUserId, transaction: tx });
+          },
+        });
+      } catch (dbDeleteError) {
+        logger.error(
+          { err: dbDeleteError, context: { userId, newUserId, firebaseUid } },
+          'DB delete compensation failed after FGA write failure — manual cleanup required',
+        );
+      }
+
+      await compensateDeleteFirebaseUser(firebaseUid, userId, email, 'import FGA write failure');
+
+      throw new ApiError(ApiErrorMessage.EXTERNAL_SERVICE_UNAVAILABLE, {
+        statusCode: StatusCodes.INTERNAL_SERVER_ERROR,
+        code: ApiErrorCode.EXTERNAL_SERVICE_FAILED,
+        context: { userId, newUserId, email, firebaseUid },
+        cause: error,
+      });
+    }
+
+    logger.info({ userId, newUserId, email }, 'Created user (imported auth)');
+    return { id: newUserId };
+  }
+
+  /**
    * Verifies that a membership entity exists and is active (not rostered out).
    *
    * @param entityType The type of the membership entity to verify.
@@ -1471,5 +1669,14 @@ export function UserService({
     }
   }
 
-  return { findByAuthId, getById, create, update, recordUserAgreement, getUnsignedTosAgreements, createAnonymousUser };
+  return {
+    findByAuthId,
+    getById,
+    create,
+    createWithImportedAuth,
+    update,
+    recordUserAgreement,
+    getUnsignedTosAgreements,
+    createAnonymousUser,
+  };
 }

--- a/apps/backend/src/services/user/utils/firebase-password-hash.test.ts
+++ b/apps/backend/src/services/user/utils/firebase-password-hash.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from 'vitest';
+import { firebaseScryptHash, hashPasswordForImport, getFirebaseScryptParamsFromEnv } from './firebase-password-hash';
+
+/**
+ * Official Firebase scrypt test vector, published at https://github.com/firebase/scrypt.
+ * Hashing `password` with `salt` under these parameters MUST yield `expectedHash`. This is the
+ * ground-truth proof that our implementation matches Firebase's — if it drifts, imported users
+ * cannot sign in.
+ */
+const VECTOR = {
+  signerKey: 'jxspr8Ki0RYycVU8zykbdLGjFQ3McFUH0uiiTvC8pVMXAn210wjLNmdZJzxUECKbm0QsEmYUSDzZvpjeJ9WmXA==',
+  saltSeparator: 'Bw==',
+  rounds: 8,
+  memoryCost: 14,
+  salt: '42xEC+ixf3L2lw==',
+  password: 'user1password',
+  expectedHash: 'lSrfV15cpx95/sZS2W9c9Kp6i/LVgQNDNC/qzrCnh1SAyZvqmZqAjTdn3aoItz+VHjoZilo78198JAdRuid5lQ==',
+} as const;
+
+const vectorParams = () => ({
+  signerKey: Buffer.from(VECTOR.signerKey, 'base64'),
+  saltSeparator: Buffer.from(VECTOR.saltSeparator, 'base64'),
+  rounds: VECTOR.rounds,
+  memoryCost: VECTOR.memoryCost,
+});
+
+describe('firebaseScryptHash', () => {
+  it('matches the official Firebase scrypt test vector', async () => {
+    const hash = await firebaseScryptHash(VECTOR.password, Buffer.from(VECTOR.salt, 'base64'), vectorParams());
+    expect(hash.toString('base64')).toBe(VECTOR.expectedHash);
+  });
+
+  it('produces a different hash for a different password', async () => {
+    const hash = await firebaseScryptHash('not-the-password', Buffer.from(VECTOR.salt, 'base64'), vectorParams());
+    expect(hash.toString('base64')).not.toBe(VECTOR.expectedHash);
+  });
+});
+
+describe('hashPasswordForImport', () => {
+  it('generates a 16-byte salt and a hash reproducible from that salt', async () => {
+    const { passwordHash, passwordSalt } = await hashPasswordForImport(VECTOR.password, vectorParams());
+    expect(passwordSalt).toHaveLength(16);
+    // Re-hashing with the same salt reproduces the hash (deterministic given the salt).
+    const rehash = await firebaseScryptHash(VECTOR.password, passwordSalt, vectorParams());
+    expect(rehash.equals(passwordHash)).toBe(true);
+  });
+
+  it('uses a fresh random salt on each call', async () => {
+    const a = await hashPasswordForImport(VECTOR.password, vectorParams());
+    const b = await hashPasswordForImport(VECTOR.password, vectorParams());
+    expect(a.passwordSalt.equals(b.passwordSalt)).toBe(false);
+  });
+});
+
+describe('getFirebaseScryptParamsFromEnv', () => {
+  const validEnv = {
+    FIREBASE_SCRYPT_SIGNER_KEY: VECTOR.signerKey,
+    FIREBASE_SCRYPT_SALT_SEPARATOR: VECTOR.saltSeparator,
+    FIREBASE_SCRYPT_ROUNDS: String(VECTOR.rounds),
+    FIREBASE_SCRYPT_MEM_COST: String(VECTOR.memoryCost),
+  };
+
+  it('parses and base64-decodes the configured params', () => {
+    const params = getFirebaseScryptParamsFromEnv(validEnv);
+    expect(params.rounds).toBe(8);
+    expect(params.memoryCost).toBe(14);
+    expect(params.signerKey.equals(Buffer.from(VECTOR.signerKey, 'base64'))).toBe(true);
+    expect(params.saltSeparator.equals(Buffer.from(VECTOR.saltSeparator, 'base64'))).toBe(true);
+  });
+
+  it('throws listing the missing variables', () => {
+    expect(() => getFirebaseScryptParamsFromEnv({})).toThrow(/FIREBASE_SCRYPT_SIGNER_KEY/);
+  });
+
+  it('throws when rounds or mem_cost are not integers', () => {
+    expect(() => getFirebaseScryptParamsFromEnv({ ...validEnv, FIREBASE_SCRYPT_ROUNDS: 'abc' })).toThrow(/integers/);
+  });
+});

--- a/apps/backend/src/services/user/utils/firebase-password-hash.ts
+++ b/apps/backend/src/services/user/utils/firebase-password-hash.ts
@@ -1,0 +1,135 @@
+import { createCipheriv, randomBytes, scrypt as scryptCb } from 'node:crypto';
+import type { BinaryLike, ScryptOptions } from 'node:crypto';
+import { promisify } from 'node:util';
+
+/**
+ * Firebase Authentication hashes passwords with an internally modified scrypt. The bulk
+ * `importUsers` path requires each record to carry an already-computed `passwordHash` +
+ * `passwordSalt`, plus the project's hash parameters in `UserImportOptions.hash` so Firebase can
+ * verify the password at sign-in. This module computes that hash.
+ *
+ * Algorithm (mirrors https://github.com/firebase/scrypt and its language ports):
+ *   1. derivedKey = scrypt(password, passwordSalt ‖ saltSeparator, N = 2**memoryCost, r = rounds, p = 1, len = 64)
+ *   2. passwordHash = AES-256-CTR( key = derivedKey[0..32], iv = 16 zero bytes ).encrypt(signerKey)
+ *
+ * Correctness is pinned by a known-answer test against Firebase's published vector
+ * (see firebase-password-hash.test.ts).
+ */
+
+const scryptAsync = promisify(scryptCb) as (
+  password: BinaryLike,
+  salt: BinaryLike,
+  keylen: number,
+  options: ScryptOptions,
+) => Promise<Buffer>;
+
+const DERIVED_KEY_LENGTH = 64;
+const AES_KEY_LENGTH = 32;
+// Firebase's scrypt variant encrypts the signer key with a 16-byte all-zero IV.
+const AES_IV = Buffer.alloc(16);
+const PASSWORD_SALT_LENGTH = 16;
+
+/**
+ * Parameters for Firebase's modified scrypt. Every Firebase project has a unique set, found in the
+ * console under Authentication → Users → ⋮ → "Password hash parameters". Provision them as backend
+ * secrets — they must not live in source.
+ */
+export interface FirebaseScryptParams {
+  /** base64-decoded `base64_signer_key`. */
+  signerKey: Buffer;
+  /** base64-decoded `base64_salt_separator`. */
+  saltSeparator: Buffer;
+  /** `rounds` parameter (scrypt block size `r`). */
+  rounds: number;
+  /** `mem_cost` parameter; the scrypt CPU/memory cost is `N = 2 ** memoryCost`. */
+  memoryCost: number;
+}
+
+/**
+ * Computes Firebase's modified-scrypt password hash for a known salt.
+ *
+ * @param password - The plaintext password.
+ * @param passwordSalt - The per-user salt (raw bytes).
+ * @param params - The Firebase project's scrypt parameters.
+ * @returns The password hash as raw bytes (base64-encode for `importUsers` or comparison).
+ */
+export async function firebaseScryptHash(
+  password: string,
+  passwordSalt: Buffer,
+  params: FirebaseScryptParams,
+): Promise<Buffer> {
+  const { signerKey, saltSeparator, rounds, memoryCost } = params;
+  const cost = 2 ** memoryCost;
+  const salt = Buffer.concat([passwordSalt, saltSeparator]);
+  // scrypt needs ~128 * N * r bytes; give 2x headroom so larger mem_cost values don't trip maxmem.
+  const maxmem = 128 * cost * rounds * 2;
+
+  const derivedKey = await scryptAsync(Buffer.from(password), salt, DERIVED_KEY_LENGTH, {
+    N: cost,
+    r: rounds,
+    p: 1,
+    maxmem,
+  });
+
+  const cipher = createCipheriv('aes-256-ctr', derivedKey.subarray(0, AES_KEY_LENGTH), AES_IV);
+  return Buffer.concat([cipher.update(signerKey), cipher.final()]);
+}
+
+/**
+ * Generates a random per-user salt and returns the `{ passwordHash, passwordSalt }` pair for a
+ * Firebase `importUsers` `UserImportRecord`. The caller must pass the same `params` to
+ * `importUsers` via `UserImportOptions.hash` so Firebase can verify the password at sign-in.
+ *
+ * @param password - The plaintext password.
+ * @param params - The Firebase project's scrypt parameters.
+ * @returns The import-ready hash and salt buffers.
+ */
+export async function hashPasswordForImport(
+  password: string,
+  params: FirebaseScryptParams,
+): Promise<{ passwordHash: Buffer; passwordSalt: Buffer }> {
+  const passwordSalt = randomBytes(PASSWORD_SALT_LENGTH);
+  const passwordHash = await firebaseScryptHash(password, passwordSalt, params);
+  return { passwordHash, passwordSalt };
+}
+
+/**
+ * Reads the Firebase scrypt parameters from the environment, base64-decoding the signer key and
+ * salt separator. Throws a descriptive error if any are missing or malformed so a misconfigured
+ * deployment fails loudly rather than silently producing unverifiable hashes.
+ *
+ * @param env - The environment to read from (defaults to `process.env`; injectable for tests).
+ * @returns The parsed scrypt parameters.
+ * @throws {Error} If any required variable is missing or `rounds`/`mem_cost` are not integers.
+ */
+export function getFirebaseScryptParamsFromEnv(env: NodeJS.ProcessEnv = process.env): FirebaseScryptParams {
+  const signerKeyB64 = env.FIREBASE_SCRYPT_SIGNER_KEY;
+  const saltSeparatorB64 = env.FIREBASE_SCRYPT_SALT_SEPARATOR;
+  const roundsRaw = env.FIREBASE_SCRYPT_ROUNDS;
+  const memoryCostRaw = env.FIREBASE_SCRYPT_MEM_COST;
+
+  if (!signerKeyB64 || !saltSeparatorB64 || !roundsRaw || !memoryCostRaw) {
+    const missing = [
+      ['FIREBASE_SCRYPT_SIGNER_KEY', signerKeyB64],
+      ['FIREBASE_SCRYPT_SALT_SEPARATOR', saltSeparatorB64],
+      ['FIREBASE_SCRYPT_ROUNDS', roundsRaw],
+      ['FIREBASE_SCRYPT_MEM_COST', memoryCostRaw],
+    ]
+      .filter(([, value]) => !value)
+      .map(([name]) => name);
+    throw new Error(`Missing Firebase scrypt configuration: ${missing.join(', ')}`);
+  }
+
+  const rounds = Number(roundsRaw);
+  const memoryCost = Number(memoryCostRaw);
+  if (!Number.isInteger(rounds) || !Number.isInteger(memoryCost)) {
+    throw new Error('FIREBASE_SCRYPT_ROUNDS and FIREBASE_SCRYPT_MEM_COST must be integers');
+  }
+
+  return {
+    signerKey: Buffer.from(signerKeyB64, 'base64'),
+    saltSeparator: Buffer.from(saltSeparatorB64, 'base64'),
+    rounds,
+    memoryCost,
+  };
+}

--- a/apps/backend/src/test-support/mocks/firebase-admin.mock.ts
+++ b/apps/backend/src/test-support/mocks/firebase-admin.mock.ts
@@ -30,5 +30,6 @@ vi.mock('firebase-admin/auth', () => ({
     createCustomToken: vi.fn(),
     listUsers: vi.fn(),
     updateUser: vi.fn(),
+    importUsers: vi.fn(),
   })),
 }));

--- a/apps/backend/src/test-support/mocks/firebase-admin.mock.ts
+++ b/apps/backend/src/test-support/mocks/firebase-admin.mock.ts
@@ -25,6 +25,7 @@ vi.mock('firebase-admin/auth', () => ({
     verifyIdToken: vi.fn(),
     createUser: vi.fn(),
     getUserByEmail: vi.fn(),
+    getUsers: vi.fn(),
     deleteUser: vi.fn(),
     setCustomUserClaims: vi.fn(),
     createCustomToken: vi.fn(),

--- a/apps/backend/src/test-support/repositories/user.repository.ts
+++ b/apps/backend/src/test-support/repositories/user.repository.ts
@@ -18,6 +18,8 @@ export function createMockUserRepository(): MockedObject<UserRepository> {
     existsByUniqueFields: vi.fn(),
     findByEmails: vi.fn(),
     endAllEnrollments: vi.fn(),
+    getActiveMembershipsWithRoles: vi.fn(),
+    archiveUser: vi.fn(),
   } as MockedObject<UserRepository>;
 }
 

--- a/apps/backend/src/test-support/repositories/user.repository.ts
+++ b/apps/backend/src/test-support/repositories/user.repository.ts
@@ -17,6 +17,7 @@ export function createMockUserRepository(): MockedObject<UserRepository> {
     createWithMemberships: vi.fn(),
     existsByUniqueFields: vi.fn(),
     findByEmails: vi.fn(),
+    endAllEnrollments: vi.fn(),
   } as MockedObject<UserRepository>;
 }
 

--- a/apps/backend/src/test-support/repositories/user.repository.ts
+++ b/apps/backend/src/test-support/repositories/user.repository.ts
@@ -16,6 +16,7 @@ export function createMockUserRepository(): MockedObject<UserRepository> {
     findClassParentSchool: vi.fn(),
     createWithMemberships: vi.fn(),
     existsByUniqueFields: vi.fn(),
+    findByEmails: vi.fn(),
   } as MockedObject<UserRepository>;
 }
 

--- a/apps/backend/src/test-support/services/user.service.ts
+++ b/apps/backend/src/test-support/services/user.service.ts
@@ -11,6 +11,7 @@ export function createMockUserService(): MockedObject<ReturnType<typeof UserServ
     findByAuthId: vi.fn(),
     getById: vi.fn(),
     create: vi.fn(),
+    createWithImportedAuth: vi.fn(),
     update: vi.fn(),
     recordUserAgreement: vi.fn(),
     getUnsignedTosAgreements: vi.fn(),

--- a/apps/dashboard/src/helpers/csvRowToImportRow.js
+++ b/apps/dashboard/src/helpers/csvRowToImportRow.js
@@ -1,0 +1,64 @@
+/**
+ * Maps a CSV-mapped student row (keyed by RegisterStudents' canonical field names: `username`,
+ * `email`, `password`, `dob`, `grade`, `first`/`middle`/`last`, the demographic fields, `stateId`,
+ * `pid`, `unenroll`, …) directly into an `ImportUserRow` for `POST /v1/users/import`.
+ *
+ * This produces the contract shape in one step — no intermediate Firekit payload. The caller
+ * (`transformStudentData`) resolves organizations into `memberships` separately, since that requires
+ * async org-id lookups. Demographic keys are renamed to the contract's (`ellStatus` → `statusEll`,
+ * etc.); the retired `testData` field is intentionally dropped.
+ */
+
+const TRUTHY = new Set(['true', 'yes', '1', 't', 'y']);
+
+/** Coerce a CSV cell (string/boolean) into a boolean; empty/absent is false. */
+export function toBoolean(value) {
+  if (typeof value === 'boolean') return value;
+  if (value == null) return false;
+  return TRUTHY.has(String(value).trim().toLowerCase());
+}
+
+function isPresent(value) {
+  return value != null && value !== '';
+}
+
+/**
+ * @param {Record<string, unknown>} row - A CSV-mapped student row (canonical keys).
+ * @returns {object} An `ImportUserRow` with `memberships: []` (the caller fills memberships in).
+ */
+export function csvRowToImportRow(row) {
+  const importRow = { userType: 'student', name: {}, memberships: [] };
+
+  // A username maps to a synthetic email; an explicit email (if mapped) wins.
+  if (isPresent(row.username)) importRow.email = `${row.username}@roar-auth.com`;
+  if (isPresent(row.email)) importRow.email = row.email;
+
+  if (isPresent(row.password)) importRow.password = row.password;
+  if (isPresent(row.dob)) importRow.dob = row.dob;
+  if (isPresent(row.grade)) importRow.grade = row.grade;
+
+  if (isPresent(row.first)) importRow.name.first = row.first;
+  if (isPresent(row.middle)) importRow.name.middle = row.middle;
+  if (isPresent(row.last)) importRow.name.last = row.last;
+
+  const demographics = {};
+  if (isPresent(row.gender)) demographics.gender = row.gender;
+  if (isPresent(row.race)) demographics.race = row.race;
+  if (isPresent(row.ellStatus)) demographics.statusEll = row.ellStatus;
+  if (isPresent(row.frlStatus)) demographics.statusFrl = row.frlStatus;
+  if (isPresent(row.iepStatus)) demographics.statusIep = row.iepStatus;
+  if (isPresent(row.hispanicEthnicity)) demographics.hispanicEthnicity = toBoolean(row.hispanicEthnicity);
+  if (isPresent(row.homeLanguage)) demographics.homeLanguage = row.homeLanguage;
+  if (Object.keys(demographics).length > 0) importRow.demographics = demographics;
+
+  const identifiers = {};
+  if (isPresent(row.stateId)) identifiers.stateId = row.stateId;
+  if (isPresent(row.pid)) identifiers.pid = row.pid;
+  if (Object.keys(identifiers).length > 0) importRow.identifiers = identifiers;
+
+  if (toBoolean(row.unenroll)) importRow.unenroll = true;
+
+  return importRow;
+}
+
+export default csvRowToImportRow;

--- a/apps/dashboard/src/helpers/csvRowToImportRow.test.js
+++ b/apps/dashboard/src/helpers/csvRowToImportRow.test.js
@@ -1,0 +1,73 @@
+import { describe, it, expect } from 'vitest';
+import { csvRowToImportRow, toBoolean } from './csvRowToImportRow';
+
+describe('csvRowToImportRow', () => {
+  it('maps a username to a synthetic email', () => {
+    expect(csvRowToImportRow({ username: 'ada' }).email).toBe('ada@roar-auth.com');
+  });
+
+  it('prefers an explicit email over the synthetic username email', () => {
+    expect(csvRowToImportRow({ username: 'ada', email: 'ada@school.org' }).email).toBe('ada@school.org');
+  });
+
+  it('builds the nested name and core fields with userType student', () => {
+    const row = csvRowToImportRow({ first: 'Ada', last: 'Lovelace', password: 'pw', dob: '2015-01-01', grade: '3' });
+    expect(row).toMatchObject({
+      userType: 'student',
+      name: { first: 'Ada', last: 'Lovelace' },
+      password: 'pw',
+      dob: '2015-01-01',
+      grade: '3',
+    });
+  });
+
+  it('renames demographics to the contract keys and coerces hispanicEthnicity to a boolean', () => {
+    const { demographics } = csvRowToImportRow({
+      gender: 'female',
+      race: 'White',
+      ellStatus: 'true',
+      frlStatus: 'free',
+      iepStatus: 'false',
+      hispanicEthnicity: 'yes',
+      homeLanguage: 'en',
+    });
+    expect(demographics).toEqual({
+      gender: 'female',
+      race: 'White',
+      statusEll: 'true',
+      statusFrl: 'free',
+      statusIep: 'false',
+      hispanicEthnicity: true,
+      homeLanguage: 'en',
+    });
+  });
+
+  it('maps identifiers and the unenroll flag, and drops the retired testData field', () => {
+    const row = csvRowToImportRow({ stateId: 's1', pid: 'p1', unenroll: 'true', testData: 'true' });
+    expect(row.identifiers).toEqual({ stateId: 's1', pid: 'p1' });
+    expect(row.unenroll).toBe(true);
+    expect(row).not.toHaveProperty('testData');
+  });
+
+  it('omits unenroll when falsy and demographics/identifiers when empty; memberships starts empty', () => {
+    const row = csvRowToImportRow({ username: 'ada', first: 'Ada', last: 'L' });
+    expect(row).not.toHaveProperty('unenroll');
+    expect(row).not.toHaveProperty('demographics');
+    expect(row).not.toHaveProperty('identifiers');
+    expect(row.memberships).toEqual([]);
+  });
+
+  it('does not write an omitted middle name', () => {
+    expect(csvRowToImportRow({ first: 'Ada', last: 'L' }).name).not.toHaveProperty('middle');
+  });
+});
+
+describe('toBoolean', () => {
+  it('treats common truthy strings (and true) as true', () => {
+    for (const value of ['true', 'YES', '1', 't', 'y', true]) expect(toBoolean(value)).toBe(true);
+  });
+
+  it('treats everything else as false', () => {
+    for (const value of ['false', 'no', '0', '', null, undefined, 'x']) expect(toBoolean(value)).toBe(false);
+  });
+});

--- a/apps/dashboard/src/pages/RegisterStudents.vue
+++ b/apps/dashboard/src/pages/RegisterStudents.vue
@@ -382,6 +382,9 @@ import Button from 'primevue/button';
 import PvFileUpload from 'primevue/fileupload';
 import PvToggleSwitch from 'primevue/toggleswitch';
 import { csvFileToJson } from '@/helpers';
+import csvRowToImportRow from '@/helpers/csvRowToImportRow';
+import { getRoarApiClient } from '@/clients/roar-api';
+import { StatusCodes } from 'http-status-codes';
 import { orgFetchAll } from '@/helpers/query/orgs';
 import { useToast } from 'primevue/usetoast';
 import { useAuthStore } from '@/store/auth';
@@ -782,137 +785,112 @@ const preTransformStudents = () => {
   mappedStudents.value = transformedStudents;
   showSubmitTable.value = true;
 };
+// Maps the org-field key (plural) to the import-row membership entity type (singular).
+const ORG_KEY_TO_ENTITY_TYPE = {
+  districts: 'district',
+  schools: 'school',
+  classes: 'class',
+  groups: 'group',
+  families: 'family',
+};
+
 const transformStudentData = async (rawStudent) => {
-  const transformedStudent = {};
+  // Build the import-row shape directly from the CSV-mapped row; fill memberships below.
+  const importRow = csvRowToImportRow(rawStudent);
 
-  // Handle required fields
-  Object.keys(mappedColumns.value.required).forEach((key) => {
-    if (rawStudent[key]) {
-      if (key === 'username') {
-        _set(transformedStudent, 'email', `${rawStudent[key]}@roar-auth.com`);
-        _set(transformedStudent, 'userData.username', rawStudent[key]);
-      } else if (['email', 'password'].includes(key)) {
-        _set(transformedStudent, key, rawStudent[key]);
-      } else {
-        _set(transformedStudent, `userData.${key}`, rawStudent[key]);
-      }
+  const addMembership = (entityType, entityId) => {
+    if (entityId) {
+      // Students belong to a family as a `child`; to every other entity as a `student`.
+      importRow.memberships.push({ entityType, entityId, role: entityType === 'family' ? 'child' : 'student' });
     }
-  });
+  };
 
-  // Handle name fields
-  Object.keys(mappedColumns.value.names).forEach((key) => {
-    if (rawStudent[key]) _set(transformedStudent, `userData.name.${key}`, rawStudent[key]);
-  });
-
-  // Handle demographic fields
-  Object.keys(mappedColumns.value.demographics).forEach((key) => {
-    if (rawStudent[key] && key === 'race') {
-      _set(transformedStudent, `userData.${key}`, rawStudent[key].split(', '));
-    } else if (rawStudent[key]) {
-      _set(transformedStudent, `userData.${key}`, rawStudent[key]);
-    }
-  });
-
-  // Handle optional fields
-  Object.keys(mappedColumns.value.optional).forEach((key) => {
-    if (rawStudent[key]) {
-      _set(transformedStudent, `userData.${key}`, rawStudent[key]);
-    }
-  });
-
-  // Handle organizations
   if (!usingOrgPicker.value) {
-    // If the org picker is not being used, we are given the names of the orgs as values.
-    // To submit, we need to send orgIds. Education orgs, districts, schools, and classes
-    // are fetched in order. First district, then school, then class. If any of these are not
-    // found, it will skip the rest as they are required to find the class.
+    // The CSV supplies org names; resolve them to IDs in district -> school -> class order. If a
+    // parent is missing the dependent lookups are skipped (they need the parent to resolve).
+    const orgFields = mappedColumns.value.organizations;
     let studentDistrictId = null;
     let studentSchoolId = null;
-    const orgFields = mappedColumns.value.organizations;
 
-    // First check for non-educational orgs
     if (orgFields.groups && rawStudent['groups']) {
-      const groupName = rawStudent['groups'];
-      const groupId = await getOrgId('groups', groupName);
-      if (groupId) {
-        _set(transformedStudent, 'userData.groups', { id: groupId });
-      }
+      addMembership('group', await getOrgId('groups', rawStudent['groups']));
     }
-    // Process district -> school -> class hierarchy
+
     if (orgFields.districts && rawStudent['districts']) {
-      const districtName = rawStudent['districts'];
-      studentDistrictId = await getOrgId('districts', districtName);
-      if (studentDistrictId) {
-        _set(transformedStudent, 'userData.districts', { id: studentDistrictId });
-      } else {
-        // TODO: display this gracefully on the UI.
-        console.error(`District ${districtName} not found.`);
-      }
+      studentDistrictId = await getOrgId('districts', rawStudent['districts']);
+      if (studentDistrictId) addMembership('district', studentDistrictId);
+      // TODO: display this gracefully on the UI.
+      else console.error(`District ${rawStudent['districts']} not found.`);
     }
 
     if (studentDistrictId && orgFields.schools && rawStudent['schools']) {
-      const schoolName = rawStudent['schools'];
-      studentSchoolId = await getOrgId('schools', schoolName, studentDistrictId);
-      if (studentSchoolId) {
-        _set(transformedStudent, 'userData.schools', { id: studentSchoolId });
-      } else {
-        // TODO: display this gracefully on the UI.
-        console.error(`School ${schoolName} not found.`);
-      }
+      studentSchoolId = await getOrgId('schools', rawStudent['schools'], studentDistrictId);
+      if (studentSchoolId) addMembership('school', studentSchoolId);
+      else console.error(`School ${rawStudent['schools']} not found.`);
     }
 
     if (studentSchoolId && orgFields.classes && rawStudent['classes']) {
-      const className = rawStudent['classes'];
-      const classId = await getOrgId('classes', className, studentDistrictId, studentSchoolId);
-      if (classId) {
-        _set(transformedStudent, 'userData.classes', { id: classId });
-      } else {
-        // TODO: display this gracefully on the UI.
-        console.error(`Class ${className} not found.`);
-      }
+      const classId = await getOrgId('classes', rawStudent['classes'], studentDistrictId, studentSchoolId);
+      if (classId) addMembership('class', classId);
+      else console.error(`Class ${rawStudent['classes']} not found.`);
     }
   } else {
-    // Take input from the org picker
+    // The org picker supplies selected org IDs directly.
     Object.keys(selectedOrgs.value).forEach((key) => {
       if (selectedOrgs.value[key].length) {
-        _set(transformedStudent, `userData.${key}`, { id: selectedOrgs.value[key][0].id });
+        addMembership(ORG_KEY_TO_ENTITY_TYPE[key], selectedOrgs.value[key][0].id);
       }
     });
   }
 
-  return transformedStudent;
+  return importRow;
 };
 
 const submit = async () => {
   submitting.value = SubmitStatus.TRANSFORMING;
 
-  // Transform each student's data according to the mappings
-  const transformedStudents = [];
+  // Transform each student into an import row (memberships resolved via org-id lookups).
+  const importRows = [];
   for (const student of mappedStudents.value) {
-    const transformedStudent = await transformStudentData(student);
-    transformedStudents.push(transformedStudent);
+    importRows.push(await transformStudentData(student));
   }
   submitting.value = SubmitStatus.SUBMITTING;
 
-  // Chunk users into chunks of 50 for submission
-  const chunkedUsers = _chunk(transformedStudents, 50);
+  // Chunk under the endpoint's 100-row cap (50 keeps headroom) and submit each chunk.
+  const client = getRoarApiClient();
+  const chunkedUsers = _chunk(importRows, 50);
   for (const chunk of chunkedUsers) {
-    await roarfirekit.value.createUpdateUsers(chunk).then((results) => {
-      for (const result of results.data) {
-        if (result?.status === 'rejected') {
-          const email = result.email;
-          toast.add({
-            severity: 'error',
-            summary: 'Error',
-            detail: `User ${email} failed to process: ${result.reason}`,
-            life: 5000,
-          });
-        } else if (result?.status === 'fulfilled') {
-          const email = result.email;
-          toast.add({ severity: 'success', summary: 'Success', detail: `User ${email} processed!`, life: 3000 });
-        }
+    const response = await client.users.bulkImport({ body: { users: chunk } });
+
+    if (response.status !== StatusCodes.OK) {
+      toast.add({
+        severity: 'error',
+        summary: 'Error',
+        detail: `A batch of ${chunk.length} users failed to process (status ${response.status}).`,
+        life: 5000,
+      });
+      continue;
+    }
+
+    // The endpoint returns a per-row multi-status body; map each result back to its row's email.
+    for (const rowResult of response.body.data.results) {
+      const email = chunk[rowResult.index]?.email;
+      if (rowResult.status === 'ok') {
+        toast.add({
+          severity: 'success',
+          summary: 'Success',
+          detail: `User ${email} ${rowResult.classification}.`,
+          life: 3000,
+        });
+      } else {
+        toast.add({
+          severity: 'error',
+          summary: 'Error',
+          detail: `User ${email} failed: ${rowResult.error.message}`,
+          life: 5000,
+        });
       }
-    });
+    }
   }
   submitting.value = SubmitStatus.COMPLETE;
 };

--- a/packages/api-contract/src/v1/users/contract.ts
+++ b/packages/api-contract/src/v1/users/contract.ts
@@ -6,6 +6,8 @@ import {
   CreateUserRequestBodySchema,
   CreateUserResponseSchema,
   UpdateUserRequestBodySchema,
+  ImportUsersRequestSchema,
+  ImportUsersResponseSchema,
   RecordUserAgreementRequestBodySchema,
   RecordUserAgreementResponseSchema,
 } from './schema';
@@ -76,6 +78,28 @@ export const UsersContract = c.router(
         'Returns a 422 if the request body is well-formed but contains semantically invalid data (e.g., invalid grade level). ' +
         'Returns a 429 if the user creation rate limit has been exceeded. ' +
         'Returns a 500 if an internal server error occurs.',
+    },
+    bulkImport: {
+      method: 'POST',
+      path: '/import',
+      contentType: 'application/json',
+      body: ImportUsersRequestSchema,
+      responses: {
+        200: SuccessEnvelopeSchema(ImportUsersResponseSchema),
+        400: ErrorEnvelopeSchema,
+        401: ErrorEnvelopeSchema,
+        500: ErrorEnvelopeSchema,
+      },
+      strictStatusCodes: true,
+      summary: 'Bulk create, update, and unenroll users',
+      description:
+        'Processes up to 100 rows, classifying each by email into create, update, or unenroll and ' +
+        'applying it against Firebase Auth, Postgres, and OpenFGA with per-row atomicity. ' +
+        'Always returns 200 with a multi-status body for any well-formed, authenticated request — ' +
+        'per-row outcomes (including failures) live in `results`, never in the HTTP status code. ' +
+        'Returns a 400 if the request body is missing, empty, over 100 rows, or malformed. ' +
+        'Returns a 401 if the requesting user is not authenticated. ' +
+        'Returns a 500 if an internal error occurs before per-row processing begins.',
     },
     update: {
       method: 'PATCH',

--- a/packages/api-contract/src/v1/users/schema.ts
+++ b/packages/api-contract/src/v1/users/schema.ts
@@ -127,6 +127,94 @@ export const CreateUserResponseSchema = z.object({
 export type CreateUserResponse = z.infer<typeof CreateUserResponseSchema>;
 
 /**
+ * Per-row body for POST /users/import (bulk create / update / unenroll).
+ *
+ * Intentionally the single-create row shape (`CreateUserRequestBodySchema`) with two changes:
+ * - `password` is optional here and validated per-bin during processing (required for create
+ *   rows, optional for update rows, ignored for unenroll rows). The client cannot know which bin
+ *   a row lands in until the server matches it by email, so the schema cannot require it.
+ * - `unenroll: true` routes an existing user to the unenroll bin.
+ *
+ * The server classifies create / update / unenroll by matching `email` against existing users —
+ * the client never declares the bin.
+ *
+ * @NOTE Parity gap to verify against the legacy `batchImportUpdate` cloud function before merge:
+ *   the single-create schema requires `email` and has no `username`. If the cloud function imports
+ *   username-only students (synthesizing an email), this schema must grow `username` and thread it
+ *   through the create path. Tracked as part of the batchImportUpdate parity review.
+ */
+export const ImportUserRowSchema = CreateUserRequestBodySchema.omit({ password: true })
+  .extend({
+    password: z.string().min(8).optional(),
+    unenroll: z.boolean().optional(),
+  })
+  .strict();
+
+export type ImportUserRow = z.infer<typeof ImportUserRowSchema>;
+
+/**
+ * Request body for POST /users/import. Capped at 100 rows — the dashboard chunks at 50 and
+ * Firebase `importUsers` accepts up to 1,000, so 100 sits comfortably between the two.
+ */
+export const ImportUsersRequestSchema = z.object({
+  users: z.array(ImportUserRowSchema).min(1).max(100),
+});
+
+export type ImportUsersRequest = z.infer<typeof ImportUsersRequestSchema>;
+
+/** The bin the server routed a row to (past tense — reflects the outcome). */
+export const ImportClassificationSchema = z.enum(['created', 'updated', 'unenrolled']);
+
+export type ImportClassification = z.infer<typeof ImportClassificationSchema>;
+
+/**
+ * Per-row result, discriminated on `status`. Successful rows carry the resulting user `id`;
+ * failed rows carry a safe `{ code, message }` (from the `ApiErrorCode` / `ApiErrorMessage`
+ * enums on the server). `classification` is the bin the row was routed to, even on failure, so
+ * the operator can see which path went wrong.
+ */
+export const ImportUserResultSchema = z.discriminatedUnion('status', [
+  z.object({
+    index: z.number().int().nonnegative(),
+    classification: ImportClassificationSchema,
+    status: z.literal('ok'),
+    id: z.string().uuid(),
+  }),
+  z.object({
+    index: z.number().int().nonnegative(),
+    classification: ImportClassificationSchema,
+    status: z.literal('failed'),
+    error: z.object({
+      code: z.string(),
+      message: z.string(),
+    }),
+  }),
+]);
+
+export type ImportUserResult = z.infer<typeof ImportUserResultSchema>;
+
+export const ImportUsersSummarySchema = z.object({
+  total: z.number().int().nonnegative(),
+  created: z.number().int().nonnegative(),
+  updated: z.number().int().nonnegative(),
+  unenrolled: z.number().int().nonnegative(),
+  failed: z.number().int().nonnegative(),
+});
+
+export type ImportUsersSummary = z.infer<typeof ImportUsersSummarySchema>;
+
+/**
+ * Multi-status response for POST /users/import. The endpoint returns 200 for any well-formed,
+ * authenticated request; per-row outcomes live in `results`, and `summary` totals each bin.
+ */
+export const ImportUsersResponseSchema = z.object({
+  results: z.array(ImportUserResultSchema),
+  summary: ImportUsersSummarySchema,
+});
+
+export type ImportUsersResponse = z.infer<typeof ImportUsersResponseSchema>;
+
+/**
  * Request body schema for PATCH /users/:id
  *
  * All fields are optional — only provided fields are updated (partial update semantics).


### PR DESCRIPTION
> [!IMPORTANT]
> This is work I completed **before I left Stanford but never pushed.** It is being published now, **as-is**, as a **draft** for the team to pick up. It is **out of date** — branched from `project/backend-refactor` at `880ddeeda` (**2026-06-22**), now ~150+ commits behind — and is **not mergeable as-is.** A Stanford developer will need to rebase/adapt it onto the current `project/backend-refactor` before merge.

> [!IMPORTANT]
> **This PR depends on the backend endpoint PR** (`POST /v1/users/import`, from `enh/users-bulk-import/import-e2e-proofs`) — adopt/merge that first.

## What this does

Cuts the existing **RegisterStudents** CSV-upload flow over from the legacy client-side registration path to the new **`POST /v1/users/import`** endpoint, so bulk student registration goes through the backend importer (create/update/unenroll bins) instead of writing directly.

- `apps/dashboard/src/pages/RegisterStudents.vue` — repointed at the new endpoint.
- `apps/dashboard/src/helpers/csvRowToImportRow.js` (+ `csvRowToImportRow.test.js`) — maps a parsed CSV row to the `ImportUserRow` request shape.

## How to review this PR (commit overlap)

This branch is based on the backend base branch, so GitHub shows **11 commits** here — but **10 of them are the shared backend commits** already under review in the backend PR. Cross-fork PRs can't target another fork's branch as their base, which is why they can't be hidden.

**Review only the one frontend commit and the `apps/dashboard/**` changes:**
- `62d74b4cf` — _F5: cut RegisterStudents CSV upload over to POST /v1/users/import_

Once the backend line is adopted/merged into `project/backend-refactor`, those 10 commits drop out of this diff and only the frontend change remains.

## Dependency to map on adoption

The cutover assumes the dashboard's ts-rest API client exposes `users.bulkImport` (from the backend contract). After the backend contract lands and the client is regenerated/typechecked, wire `RegisterStudents.vue` to it. If the registration UI has changed on the current `project/backend-refactor`, re-apply the cutover against its current version rather than force-applying.

## Testing

`csvRowToImportRow.test.js` covers the CSV-row → `ImportUserRow` mapping. The end-to-end path is exercised by the backend PR's `users-import.cy.js` proofs.

## Provenance

Authored 2026-06-23; recovered from a local branch that was never pushed. Base commit `880ddeeda`. Head branch `enh/csv-import-cutover`.
