### PR TITLE
Wire can_read_child into the two administration read endpoints

### DIFF
--- a/apps/backend/src/routes/users.integration.test.ts
+++ b/apps/backend/src/routes/users.integration.test.ts
@@ -1234,6 +1234,19 @@ describe('GET /v1/users/:userId/administrations', () => {
       expect(res.body.data).toHaveProperty('pagination');
     });
 
+    it('teacher can list administrations for users in their district', async () => {
+      // tiers.educator is a TEACHER at baseFixture.district.id (a supervisory
+      // role), so it should retain descendant access to schoolAStudent the
+      // same way tiers.admin does above — unaffected by the new guardian
+      // check, which only applies once the admin/teacher intersection is empty.
+      const res = await expectRoute('GET', `/v1/users/${baseFixture.schoolAStudent.id}/administrations`)
+        .as(tiers.educator)
+        .toReturn(StatusCodes.OK);
+
+      expect(res.body.data).toHaveProperty('items');
+      expect(res.body.data).toHaveProperty('pagination');
+    });
+
     it('authorized guardian can list administrations for a child in their family', async () => {
       const { UserFamilyFactory } = await import('../test-support/factories/user-family.factory');
       const { FamilyFactory } = await import('../test-support/factories/family.factory');
@@ -3091,6 +3104,31 @@ describe('GET /v1/users/:userId/administrations/:administrationId/agreements', (
     it('super admin can list agreements for any user', async () => {
       const res = await expectRoute('GET', path(minorTarget.id, administrationId))
         .as(tiers.superAdmin)
+        .toReturn(StatusCodes.OK);
+
+      expect(res.body.data).toHaveProperty('items');
+      expect(res.body.data).toHaveProperty('pagination');
+    });
+
+    it('admin can list agreements for a user in their district', async () => {
+      // tiers.admin is an administrator at baseFixture.district.id, the same
+      // org the administration is assigned to and minorTarget is enrolled in —
+      // this exercises the admin/teacher intersection path directly, unaffected
+      // by the guardian check that only applies once that intersection is empty.
+      const res = await expectRoute('GET', path(minorTarget.id, administrationId))
+        .as(tiers.admin)
+        .toReturn(StatusCodes.OK);
+
+      expect(res.body.data).toHaveProperty('items');
+      expect(res.body.data).toHaveProperty('pagination');
+    });
+
+    it('teacher can list agreements for a user in their district', async () => {
+      // tiers.educator is a TEACHER at baseFixture.district.id — a supervisory
+      // role — so it retains the same admin/teacher intersection access as
+      // tiers.admin above.
+      const res = await expectRoute('GET', path(minorTarget.id, administrationId))
+        .as(tiers.educator)
         .toReturn(StatusCodes.OK);
 
       expect(res.body.data).toHaveProperty('items');

--- a/apps/backend/src/routes/users.integration.test.ts
+++ b/apps/backend/src/routes/users.integration.test.ts
@@ -1374,7 +1374,7 @@ describe('GET /v1/users/:userId/administrations', () => {
         return new Map(tasks.map((t) => [t.variantId, t]));
       }
 
-      it("embeds the child target user's progress (run state), not the requesting guardian's", async () => {
+      it("embeds the child target user's task state (progress and assignment), not the requesting guardian's", async () => {
         const byVariant = await getGuardianEmbeddedTasks();
 
         expect(byVariant.get(progressVariant.id)?.progress).toEqual({
@@ -1382,10 +1382,6 @@ describe('GET /v1/users/:userId/administrations', () => {
           completedOn: childCompletedAt.toISOString(),
           allowRetake: false,
         });
-      });
-
-      it('embeds assigned/optional flags evaluated against the child target user, not the requesting guardian', async () => {
-        const byVariant = await getGuardianEmbeddedTasks();
 
         // The child's grade ('3') satisfies `grade == '3'` → assigned.
         expect(byVariant.get(assignedVariant.id)?.assigned).toBe(true);

--- a/apps/backend/src/routes/users.integration.test.ts
+++ b/apps/backend/src/routes/users.integration.test.ts
@@ -1273,6 +1273,125 @@ describe('GET /v1/users/:userId/administrations', () => {
       expect(res.body.data.items).toBeDefined();
     });
 
+    describe('embed reflects the child target user, not the requesting guardian', () => {
+      // Shared fixture: one guardian/child pair and one administration with two
+      // task variants — a plain one (progress) and a conditionally-assigned one
+      // (assigned/optional) — seeded once so both assertions below reuse the same
+      // administration, task variants, and FGA sync instead of paying full setup
+      // cost per test.
+      let guardianEmbedAdmin: DbAdministration;
+      let progressVariant: DbTaskVariant;
+      let assignedVariant: DbTaskVariant;
+      let guardianChild: { id: string };
+      let guardianParent: { id: string; authId: string };
+
+      // Only the CHILD has a canonical run — the parent never touched this task.
+      // If the embed were accidentally keyed to the requester (the parent)
+      // instead of the target (the child), progress would come back null.
+      const childCompletedAt = new Date('2025-10-01T12:00:00.000Z');
+
+      beforeAll(async () => {
+        const { UserFamilyFactory } = await import('../test-support/factories/user-family.factory');
+        const { FamilyFactory } = await import('../test-support/factories/family.factory');
+        const { TaskFactory } = await import('../test-support/factories/task.factory');
+        const { TaskVariantFactory } = await import('../test-support/factories/task-variant.factory');
+        const { AdministrationTaskVariantFactory } =
+          await import('../test-support/factories/administration-task-variant.factory');
+        const { RunFactory } = await import('../test-support/factories/run.factory');
+        const { syncFgaTuplesFromPostgres } = await import('../test-support/fga');
+
+        // The parent is an adult with no `grade` — if `assigned_if` were
+        // evaluated against the REQUESTER's demographics instead of the
+        // target child's, the assigned-variant assertion below would flip.
+        const parent = await UserFactory.create({ dob: '1986-07-07' });
+        const child = await UserFactory.create({ dob: '2017-07-07', grade: '3' });
+        guardianParent = { id: parent.id, authId: parent.authId! };
+        guardianChild = { id: child.id };
+
+        const family = await FamilyFactory.create();
+        await UserFamilyFactory.create({ userId: parent.id, familyId: family.id, role: 'parent' });
+        await UserFamilyFactory.create({ userId: child.id, familyId: family.id, role: 'child' });
+        await UserOrgFactory.create({ userId: child.id, orgId: baseFixture.district.id, role: UserRole.STUDENT });
+
+        guardianEmbedAdmin = await AdministrationFactory.create({
+          name: 'Guardian Embed Admin',
+          createdBy: baseFixture.districtAdmin.id,
+        });
+        await AdministrationOrgFactory.create({
+          administrationId: guardianEmbedAdmin.id,
+          orgId: baseFixture.district.id,
+        });
+        await writeFgaAdministrationAssignment(guardianEmbedAdmin.id, baseFixture.district.id, FgaType.DISTRICT);
+
+        const task = await TaskFactory.create({
+          name: 'Guardian Embed Task',
+          slug: `guardian-embed-${faker.string.alphanumeric(8).toLowerCase()}`,
+        });
+        [progressVariant, assignedVariant] = await Promise.all([
+          TaskVariantFactory.create({ taskId: task.id, name: 'Progress Variant' }),
+          TaskVariantFactory.create({ taskId: task.id, name: 'Assigned Variant' }),
+        ]);
+
+        const ASSIGNED_IF_GRADE_3: Condition = { field: 'studentData.grade', op: Operator.EQUAL, value: '3' };
+        await Promise.all([
+          AdministrationTaskVariantFactory.create({
+            administrationId: guardianEmbedAdmin.id,
+            taskVariantId: progressVariant.id,
+            orderIndex: 0,
+          }),
+          AdministrationTaskVariantFactory.create({
+            administrationId: guardianEmbedAdmin.id,
+            taskVariantId: assignedVariant.id,
+            orderIndex: 1,
+            conditionsAssignment: ASSIGNED_IF_GRADE_3,
+            conditionsRequirements: null,
+          }),
+        ]);
+
+        await RunFactory.create({
+          userId: child.id,
+          administrationId: guardianEmbedAdmin.id,
+          taskVariantId: progressVariant.id,
+          taskId: task.id,
+          useForReporting: true,
+          reliableRun: true,
+          completedAt: childCompletedAt,
+        });
+
+        await syncFgaTuplesFromPostgres();
+      });
+
+      async function getGuardianEmbeddedTasks(): Promise<Map<string, AdministrationTask>> {
+        const res = await expectRoute('GET', `/v1/users/${guardianChild.id}/administrations?embed=progress&perPage=100`)
+          .as(guardianParent)
+          .toReturn(StatusCodes.OK);
+
+        const item = res.body.data.items.find((i: Administration) => i.id === guardianEmbedAdmin.id);
+        if (!item) {
+          throw new Error('Expected the seeded guardian embed administration in the response');
+        }
+        const tasks = (item.tasks ?? []) as AdministrationTask[];
+        return new Map(tasks.map((t) => [t.variantId, t]));
+      }
+
+      it("embeds the child target user's progress (run state), not the requesting guardian's", async () => {
+        const byVariant = await getGuardianEmbeddedTasks();
+
+        expect(byVariant.get(progressVariant.id)?.progress).toEqual({
+          startedOn: expect.stringMatching(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/),
+          completedOn: childCompletedAt.toISOString(),
+          allowRetake: false,
+        });
+      });
+
+      it('embeds assigned/optional flags evaluated against the child target user, not the requesting guardian', async () => {
+        const byVariant = await getGuardianEmbeddedTasks();
+
+        // The child's grade ('3') satisfies `grade == '3'` → assigned.
+        expect(byVariant.get(assignedVariant.id)?.assigned).toBe(true);
+      });
+    });
+
     it('returns 401 when unauthenticated', async () => {
       const res = await expectRoute('GET', `/v1/users/${baseFixture.schoolAStudent.id}/administrations`)
         .unauthenticated()

--- a/apps/backend/src/routes/users.integration.test.ts
+++ b/apps/backend/src/routes/users.integration.test.ts
@@ -1234,6 +1234,32 @@ describe('GET /v1/users/:userId/administrations', () => {
       expect(res.body.data).toHaveProperty('pagination');
     });
 
+    it('authorized guardian can list administrations for a child in their family', async () => {
+      const { UserFamilyFactory } = await import('../test-support/factories/user-family.factory');
+      const { FamilyFactory } = await import('../test-support/factories/family.factory');
+      const { syncFgaTuplesFromPostgres } = await import('../test-support/fga');
+
+      const parent = await UserFactory.create({ dob: '1987-02-02' });
+      const child = await UserFactory.create({ dob: '2018-02-02', grade: '2' });
+      const family = await FamilyFactory.create();
+      await UserFamilyFactory.create({ userId: parent.id, familyId: family.id, role: 'parent' });
+      await UserFamilyFactory.create({ userId: child.id, familyId: family.id, role: 'child' });
+
+      await UserOrgFactory.create({
+        userId: child.id,
+        orgId: baseFixture.district.id,
+        role: UserRole.STUDENT,
+      });
+
+      await syncFgaTuplesFromPostgres();
+
+      const res = await expectRoute('GET', `/v1/users/${child.id}/administrations`)
+        .as({ id: parent.id, authId: parent.authId! })
+        .toReturn(StatusCodes.OK);
+
+      expect(res.body.data.items).toBeDefined();
+    });
+
     it('returns 401 when unauthenticated', async () => {
       const res = await expectRoute('GET', `/v1/users/${baseFixture.schoolAStudent.id}/administrations`)
         .unauthenticated()
@@ -1859,6 +1885,58 @@ describe('GET /v1/users/:userId/administrations', () => {
       // districtBStudent is in a different district from tiers.admin (who is in districtA)
       const res = await expectRoute('GET', `/v1/users/${baseFixture.districtBStudent.id}/administrations`)
         .as(tiers.admin)
+        .toReturn(StatusCodes.FORBIDDEN);
+
+      expect(res.body.error.code).toBe(ApiErrorCode.AUTH_FORBIDDEN);
+    });
+
+    it('returns 403 when guardian tries to list administrations for a child from another family', async () => {
+      const { UserFamilyFactory } = await import('../test-support/factories/user-family.factory');
+      const { FamilyFactory } = await import('../test-support/factories/family.factory');
+      const { syncFgaTuplesFromPostgres } = await import('../test-support/fga');
+
+      const parent = await UserFactory.create({ dob: '1988-03-03' });
+      const child = await UserFactory.create({ dob: '2019-03-03', grade: '1' });
+      const targetFamily = await FamilyFactory.create();
+      const unrelatedFamily = await FamilyFactory.create();
+      await UserFamilyFactory.create({ userId: parent.id, familyId: unrelatedFamily.id, role: 'parent' });
+      await UserFamilyFactory.create({ userId: child.id, familyId: targetFamily.id, role: 'child' });
+
+      await UserOrgFactory.create({
+        userId: child.id,
+        orgId: baseFixture.district.id,
+        role: UserRole.STUDENT,
+      });
+
+      await syncFgaTuplesFromPostgres();
+
+      const res = await expectRoute('GET', `/v1/users/${child.id}/administrations`)
+        .as({ id: parent.id, authId: parent.authId! })
+        .toReturn(StatusCodes.FORBIDDEN);
+
+      expect(res.body.error.code).toBe(ApiErrorCode.AUTH_FORBIDDEN);
+    });
+
+    it('returns 403 when a user with no guardian relation tries to list administrations for a child', async () => {
+      const { UserFamilyFactory } = await import('../test-support/factories/user-family.factory');
+      const { FamilyFactory } = await import('../test-support/factories/family.factory');
+      const { syncFgaTuplesFromPostgres } = await import('../test-support/fga');
+
+      const parent = await UserFactory.create({ dob: '1991-07-07' });
+      const child = await UserFactory.create({ dob: '2020-07-07', grade: '1' });
+      const family = await FamilyFactory.create();
+      await UserFamilyFactory.create({ userId: child.id, familyId: family.id, role: 'child' });
+
+      await UserOrgFactory.create({
+        userId: child.id,
+        orgId: baseFixture.district.id,
+        role: UserRole.STUDENT,
+      });
+
+      await syncFgaTuplesFromPostgres();
+
+      const res = await expectRoute('GET', `/v1/users/${child.id}/administrations`)
+        .as({ id: parent.id, authId: parent.authId! })
         .toReturn(StatusCodes.FORBIDDEN);
 
       expect(res.body.error.code).toBe(ApiErrorCode.AUTH_FORBIDDEN);
@@ -3019,6 +3097,32 @@ describe('GET /v1/users/:userId/administrations/:administrationId/agreements', (
       expect(res.body.data).toHaveProperty('pagination');
     });
 
+    it('authorized guardian can list agreements for a child in their family', async () => {
+      const { UserFamilyFactory } = await import('../test-support/factories/user-family.factory');
+      const { FamilyFactory } = await import('../test-support/factories/family.factory');
+      const { syncFgaTuplesFromPostgres } = await import('../test-support/fga');
+
+      const parent = await UserFactory.create({ dob: '1989-04-04' });
+      const child = await UserFactory.create({ dob: '2020-04-04', grade: '1' });
+      const family = await FamilyFactory.create();
+      await UserFamilyFactory.create({ userId: parent.id, familyId: family.id, role: 'parent' });
+      await UserFamilyFactory.create({ userId: child.id, familyId: family.id, role: 'child' });
+
+      await UserOrgFactory.create({
+        userId: child.id,
+        orgId: baseFixture.district.id,
+        role: UserRole.STUDENT,
+      });
+
+      await syncFgaTuplesFromPostgres();
+
+      const res = await expectRoute('GET', path(child.id, administrationId))
+        .as({ id: parent.id, authId: parent.authId! })
+        .toReturn(StatusCodes.OK);
+
+      expect(res.body.data.items).toBeDefined();
+    });
+
     it('returns 404 when the target user does not exist', async () => {
       const res = await expectRoute('GET', path('00000000-0000-0000-0000-000000000000', administrationId))
         .as(tiers.superAdmin)
@@ -3043,6 +3147,58 @@ describe('GET /v1/users/:userId/administrations/:administrationId/agreements', (
       // middleware/FGA stack for the cross-user access path.
       const res = await expectRoute('GET', path(minorTarget.id, administrationId))
         .as({ id: baseFixture.districtBAdmin.id, authId: baseFixture.districtBAdmin.authId! })
+        .toReturn(StatusCodes.FORBIDDEN);
+
+      expect(res.body.error.code).toBe(ApiErrorCode.AUTH_FORBIDDEN);
+    });
+
+    it('returns 403 when guardian tries to list agreements for a child from another family', async () => {
+      const { UserFamilyFactory } = await import('../test-support/factories/user-family.factory');
+      const { FamilyFactory } = await import('../test-support/factories/family.factory');
+      const { syncFgaTuplesFromPostgres } = await import('../test-support/fga');
+
+      const parent = await UserFactory.create({ dob: '1990-05-05' });
+      const child = await UserFactory.create({ dob: '2020-05-05', grade: '1' });
+      const targetFamily = await FamilyFactory.create();
+      const unrelatedFamily = await FamilyFactory.create();
+      await UserFamilyFactory.create({ userId: parent.id, familyId: unrelatedFamily.id, role: 'parent' });
+      await UserFamilyFactory.create({ userId: child.id, familyId: targetFamily.id, role: 'child' });
+
+      await UserOrgFactory.create({
+        userId: child.id,
+        orgId: baseFixture.district.id,
+        role: UserRole.STUDENT,
+      });
+
+      await syncFgaTuplesFromPostgres();
+
+      const res = await expectRoute('GET', path(child.id, administrationId))
+        .as({ id: parent.id, authId: parent.authId! })
+        .toReturn(StatusCodes.FORBIDDEN);
+
+      expect(res.body.error.code).toBe(ApiErrorCode.AUTH_FORBIDDEN);
+    });
+
+    it('returns 403 when a user with no guardian relation tries to list agreements for a child', async () => {
+      const { UserFamilyFactory } = await import('../test-support/factories/user-family.factory');
+      const { FamilyFactory } = await import('../test-support/factories/family.factory');
+      const { syncFgaTuplesFromPostgres } = await import('../test-support/fga');
+
+      const parent = await UserFactory.create({ dob: '1991-06-06' });
+      const child = await UserFactory.create({ dob: '2020-06-06', grade: '1' });
+      const family = await FamilyFactory.create();
+      await UserFamilyFactory.create({ userId: child.id, familyId: family.id, role: 'child' });
+
+      await UserOrgFactory.create({
+        userId: child.id,
+        orgId: baseFixture.district.id,
+        role: UserRole.STUDENT,
+      });
+
+      await syncFgaTuplesFromPostgres();
+
+      const res = await expectRoute('GET', path(child.id, administrationId))
+        .as({ id: parent.id, authId: parent.authId! })
         .toReturn(StatusCodes.FORBIDDEN);
 
       expect(res.body.error.code).toBe(ApiErrorCode.AUTH_FORBIDDEN);

--- a/apps/backend/src/services/administration/administration.service.test.ts
+++ b/apps/backend/src/services/administration/administration.service.test.ts
@@ -3107,6 +3107,48 @@ describe('AdministrationService', () => {
       expect(result.totalItems).toBe(2);
     });
 
+    it('returns the target child administrations for an authorized guardian (can_read_child), bypassing the requester intersection', async () => {
+      // Proxy-launch: a parent with `can_read_child` on the child's family lists the
+      // child's administrations. The parent holds no administration-level access of
+      // their own, so the admin/teacher intersection would be empty — the guardian
+      // path returns the child's full accessible set instead.
+      const child = UserFactory.build({ id: 'child-1', rosteringEnded: null });
+      mockUserRepository.getById.mockResolvedValue(child);
+
+      const childAdmins = AdministrationFactory.buildList(2);
+      mockAuthorizationService.listAccessibleObjects.mockResolvedValue(
+        childAdmins.map((a) => `administration:${a.id}`),
+      );
+      mockUserRepository.getUserEntityMemberships.mockResolvedValue([{ entityType: 'family', entityId: 'family-1' }]);
+      mockAuthorizationService.hasAnyPermission.mockResolvedValue(true);
+      mockAdministrationRepository.getByIds.mockResolvedValue({ items: childAdmins, totalItems: 2 });
+
+      const service = AdministrationService({
+        administrationRepository: mockAdministrationRepository,
+        userRepository: mockUserRepository,
+        authorizationService: mockAuthorizationService,
+      });
+
+      const result = await service.getUserAdministrations({ userId: 'parent-1', isSuperAdmin: false }, 'child-1', {
+        page: 1,
+        perPage: 25,
+        sortBy: 'createdAt',
+        sortOrder: 'desc',
+      });
+
+      // Guardianship is checked via `can_read_child` on the child's family.
+      expect(mockAuthorizationService.hasAnyPermission).toHaveBeenCalledWith('parent-1', 'can_read_child', [
+        'family:family-1',
+      ]);
+      // Only the target's accessible-objects lookup runs — no requester intersection.
+      expect(mockAuthorizationService.listAccessibleObjects).toHaveBeenCalledTimes(1);
+      expect(mockAdministrationRepository.getByIds).toHaveBeenCalledWith(
+        childAdmins.map((a) => a.id),
+        expect.objectContaining({ page: 1, perPage: 25 }),
+      );
+      expect(result.items).toHaveLength(2);
+    });
+
     it('throws 404 when a rostering-ended user requests their own administrations (#1742 defense-in-depth)', async () => {
       // The auth guard (#1735) blocks rostering-ended users end-to-end, but
       // the service-layer check runs BEFORE the `requesterUserId === userId`
@@ -5295,6 +5337,47 @@ describe('AdministrationService', () => {
       const unsignedItem = result.items.find((i) => i.agreement.id === 'agreement-unsigned');
       expect(signedItem!.signed).toBe(true);
       expect(unsignedItem!.signed).toBe(false);
+    });
+
+    it('allows an authorized guardian (can_read_child) to read the target child agreements', async () => {
+      // Proxy-launch consent gate: a parent with `can_read_child` on the child's
+      // family reads the child's per-administration agreements. The guardian has no
+      // administration-level `can_read`, so the guardian path must be accepted in
+      // place of the admin/teacher fallback.
+      const child = UserFactory.build({ id: 'child-1', isSuperAdmin: false });
+      const mockAdmin = AdministrationFactory.build({ id: 'admin-123' });
+      const mockAgreementRepo = createMockAgreementRepository();
+
+      mockUserRepository.getById.mockResolvedValue(child);
+      mockAdministrationRepository.getById.mockResolvedValue(mockAdmin);
+      mockAuthorizationService.requirePermission.mockResolvedValue(undefined);
+      mockUserRepository.getUserEntityMemberships.mockResolvedValue([{ entityType: 'family', entityId: 'family-1' }]);
+      mockAuthorizationService.hasAnyPermission.mockResolvedValue(true);
+      mockAdministrationRepository.getAgreementsByAdministrationId.mockResolvedValue({
+        items: [buildAgreementItem('agreement-1')],
+        totalItems: 1,
+      });
+      mockAgreementRepo.getSignedAgreementIds.mockResolvedValue(new Set());
+
+      const service = AdministrationService({
+        administrationRepository: mockAdministrationRepository,
+        userRepository: mockUserRepository,
+        authorizationService: mockAuthorizationService,
+        agreementRepository: mockAgreementRepo,
+      });
+
+      const result = await service.listUserAdministrationAgreements(
+        { userId: 'parent-1', isSuperAdmin: false },
+        'child-1',
+        'admin-123',
+        defaultOptions,
+      );
+
+      // Guardianship is checked via `can_read_child` on the child's family.
+      expect(mockAuthorizationService.hasAnyPermission).toHaveBeenCalledWith('parent-1', 'can_read_child', [
+        'family:family-1',
+      ]);
+      expect(result.totalItems).toBe(1);
     });
 
     it('allows a self-read (requester === target) with a single requirePermission call', async () => {

--- a/apps/backend/src/services/administration/administration.service.test.ts
+++ b/apps/backend/src/services/administration/administration.service.test.ts
@@ -3269,10 +3269,11 @@ describe('AdministrationService', () => {
       expect(result.totalItems).toBe(2);
     });
 
-    it('should return empty result when target user has no accessible administrations', async () => {
+    it('throws 403 for non-super-admin, non-guardian requester when target user has no accessible administrations', async () => {
       const mockUser = UserFactory.build({ id: 'target-user-123' });
 
       mockUserRepository.getById.mockResolvedValue(mockUser);
+      mockUserRepository.getUserEntityMemberships.mockResolvedValue([]);
       mockAuthorizationService.listAccessibleObjects.mockResolvedValue([]);
 
       const service = AdministrationService({
@@ -3281,18 +3282,72 @@ describe('AdministrationService', () => {
         authorizationService: mockAuthorizationService,
       });
 
+      await expect(
+        service.getUserAdministrations({ userId: 'requester-user', isSuperAdmin: false }, 'target-user-123', {
+          page: 1,
+          perPage: 25,
+          sortBy: 'createdAt',
+          sortOrder: 'desc',
+        }),
+      ).rejects.toMatchObject({
+        statusCode: 403,
+        message: ApiErrorMessage.FORBIDDEN,
+        code: ApiErrorCode.AUTH_FORBIDDEN,
+      });
+
+      // Only the target's accessible-objects lookup runs — the requester's FGA
+      // call is skipped since the intersection can never be non-empty.
+      expect(mockAuthorizationService.listAccessibleObjects).toHaveBeenCalledTimes(1);
+      expect(mockAdministrationRepository.getByIds).not.toHaveBeenCalled();
+    });
+
+    it('returns empty result for super admin when target user has no accessible administrations', async () => {
+      const mockUser = UserFactory.build({ id: 'target-user-123' });
+
+      mockUserRepository.getById.mockResolvedValue(mockUser);
+      mockAuthorizationService.listAccessibleObjects.mockResolvedValue([]);
+      mockAdministrationRepository.getByIds.mockResolvedValue({ items: [], totalItems: 0 });
+
+      const service = AdministrationService({
+        administrationRepository: mockAdministrationRepository,
+        userRepository: mockUserRepository,
+        authorizationService: mockAuthorizationService,
+      });
+
       const result = await service.getUserAdministrations(
-        { userId: 'requester-user', isSuperAdmin: false },
+        { userId: 'super-admin', isSuperAdmin: true },
         'target-user-123',
         { page: 1, perPage: 25, sortBy: 'createdAt', sortOrder: 'desc' },
       );
 
-      expect(mockAuthorizationService.listAccessibleObjects).toHaveBeenCalledWith(
-        'target-user-123',
-        'can_list',
-        'administration',
-      );
-      expect(mockAdministrationRepository.getByIds).not.toHaveBeenCalled();
+      expect(mockAdministrationRepository.getByIds).toHaveBeenCalledWith([], expect.anything());
+      expect(result.items).toEqual([]);
+      expect(result.totalItems).toBe(0);
+    });
+
+    it('returns empty result for authorized guardian when child has no accessible administrations', async () => {
+      const child = UserFactory.build({ id: 'child-1', rosteringEnded: null });
+
+      mockUserRepository.getById.mockResolvedValue(child);
+      mockAuthorizationService.listAccessibleObjects.mockResolvedValue([]);
+      mockUserRepository.getUserEntityMemberships.mockResolvedValue([{ entityType: 'family', entityId: 'family-1' }]);
+      mockAuthorizationService.hasAnyPermission.mockResolvedValue(true);
+      mockAdministrationRepository.getByIds.mockResolvedValue({ items: [], totalItems: 0 });
+
+      const service = AdministrationService({
+        administrationRepository: mockAdministrationRepository,
+        userRepository: mockUserRepository,
+        authorizationService: mockAuthorizationService,
+      });
+
+      const result = await service.getUserAdministrations({ userId: 'parent-1', isSuperAdmin: false }, 'child-1', {
+        page: 1,
+        perPage: 25,
+        sortBy: 'createdAt',
+        sortOrder: 'desc',
+      });
+
+      expect(mockAdministrationRepository.getByIds).toHaveBeenCalledWith([], expect.anything());
       expect(result.items).toEqual([]);
       expect(result.totalItems).toBe(0);
     });

--- a/apps/backend/src/services/administration/administration.service.test.ts
+++ b/apps/backend/src/services/administration/administration.service.test.ts
@@ -3226,6 +3226,7 @@ describe('AdministrationService', () => {
       const mockUser = UserFactory.build({ id: 'target-user-123' });
 
       mockUserRepository.getById.mockResolvedValue(mockUser);
+      mockUserRepository.getUserEntityMemberships.mockResolvedValue([]);
       mockAuthorizationService.listAccessibleObjects
         .mockResolvedValueOnce(['admin-1', 'admin-2', 'admin-3'].map((id) => `administration:${id}`))
         .mockResolvedValueOnce(['admin-2', 'admin-3', 'admin-4'].map((id) => `administration:${id}`));
@@ -3325,6 +3326,7 @@ describe('AdministrationService', () => {
       const mockUser = UserFactory.build({ id: 'target-user-123' });
 
       mockUserRepository.getById.mockResolvedValue(mockUser);
+      mockUserRepository.getUserEntityMemberships.mockResolvedValue([]);
       mockAuthorizationService.listAccessibleObjects
         .mockResolvedValueOnce(['admin-1', 'admin-2'].map((id) => `administration:${id}`))
         .mockResolvedValueOnce(['admin-3', 'admin-4'].map((id) => `administration:${id}`));
@@ -3395,6 +3397,7 @@ describe('AdministrationService', () => {
       const mockUser = UserFactory.build({ id: 'target-user-123' });
 
       mockUserRepository.getById.mockResolvedValue(mockUser);
+      mockUserRepository.getUserEntityMemberships.mockResolvedValue([]);
       mockAuthorizationService.listAccessibleObjects
         .mockResolvedValueOnce([`administration:${mockAdmin.id}`])
         .mockResolvedValueOnce([`administration:${mockAdmin.id}`]);
@@ -5424,6 +5427,7 @@ describe('AdministrationService', () => {
       const mockAgreementRepo = createMockAgreementRepository();
 
       mockUserRepository.getById.mockResolvedValue(mockUser);
+      mockUserRepository.getUserEntityMemberships.mockResolvedValue([]);
       mockAdministrationRepository.getById.mockResolvedValue(mockAdmin);
       mockAuthorizationService.requirePermission.mockResolvedValue(undefined);
       mockAdministrationRepository.getAgreementsByAdministrationId.mockResolvedValue({
@@ -5467,6 +5471,7 @@ describe('AdministrationService', () => {
       const mockAgreementRepo = createMockAgreementRepository();
 
       mockUserRepository.getById.mockResolvedValue(mockUser);
+      mockUserRepository.getUserEntityMemberships.mockResolvedValue([]);
       mockAdministrationRepository.getById.mockResolvedValue(mockAdmin);
       // Target user passes; requester is denied.
       mockAuthorizationService.requirePermission.mockResolvedValueOnce(undefined).mockRejectedValueOnce(

--- a/apps/backend/src/services/administration/administration.service.ts
+++ b/apps/backend/src/services/administration/administration.service.ts
@@ -1107,9 +1107,6 @@ export function AdministrationService({
       );
       const targetUserAdminIds = targetUserAdmins.map(extractFgaObjectId);
 
-      if (targetUserAdminIds.length === 0) {
-        return { items: [], totalItems: 0 };
-      }
       // Fetch administrations based on user role and authorization
       let result: PaginatedResult<Administration>;
 
@@ -1122,12 +1119,18 @@ export function AdministrationService({
         // the intersection would always be empty.
         result = await administrationRepository.getByIds(targetUserAdminIds, queryParams);
       } else {
-        const requesterUserAdmins = await authorizationService.listAccessibleObjects(
-          requesterUserId,
-          FgaRelation.CAN_LIST,
-          FgaType.ADMINISTRATION,
-        );
-        const requesterUserAdminIds = new Set(requesterUserAdmins.map(extractFgaObjectId));
+        const requesterUserAdminIds =
+          targetUserAdminIds.length > 0
+            ? new Set(
+                (
+                  await authorizationService.listAccessibleObjects(
+                    requesterUserId,
+                    FgaRelation.CAN_LIST,
+                    FgaType.ADMINISTRATION,
+                  )
+                ).map(extractFgaObjectId),
+              )
+            : new Set<string>();
         const intersectedIds = targetUserAdminIds.filter((id) => requesterUserAdminIds.has(id));
 
         if (intersectedIds.length === 0) {

--- a/apps/backend/src/services/administration/administration.service.ts
+++ b/apps/backend/src/services/administration/administration.service.ts
@@ -16,6 +16,7 @@ import { StatusCodes } from 'http-status-codes';
 import type { Administration, User } from '../../db/schema';
 import { AuthorizationService } from '../authorization/authorization.service';
 import { FgaType, FgaRelation } from '../authorization/fga-constants';
+import { EntityType } from '../../types/entity-type';
 import { extractFgaObjectId } from '../authorization/helpers/extract-fga-object-id.helper';
 import { collectStreamedFgaObjects } from '../authorization/helpers/collect-streamed-fga-objects.helper';
 import {
@@ -1009,6 +1010,31 @@ export function AdministrationService({
   }
 
   /**
+   * Whether the requester is an authorized guardian of the target user — i.e. holds
+   * `can_read_child` on any family the target belongs to. Mirrors the parent-consent
+   * check in `UserService.recordUserAgreement` (which uses `can_consent_for_child`).
+   *
+   * Non-throwing on purpose: callers combine it with the existing self / super-admin /
+   * admin-teacher access paths, so it returns a boolean rather than throwing FORBIDDEN.
+   *
+   * @param requesterUserId - The authenticated requester (e.g. the launching parent)
+   * @param targetUserId - The user whose data is being accessed (e.g. the child)
+   * @returns true when the requester holds `can_read_child` on a shared family
+   */
+  async function hasGuardianReadAccess(requesterUserId: string, targetUserId: string): Promise<boolean> {
+    const targetMemberships = await userRepository.getUserEntityMemberships(targetUserId);
+    const familyObjects = targetMemberships
+      .filter((membership) => membership.entityType === EntityType.FAMILY)
+      .map((membership) => `${FgaType.FAMILY}:${membership.entityId}`);
+
+    if (familyObjects.length === 0) {
+      return false;
+    }
+
+    return authorizationService.hasAnyPermission(requesterUserId, FgaRelation.CAN_READ_CHILD, familyObjects);
+  }
+
+  /**
    * List administrations accessible to a requester and target user with pagination, sorting, and optional embeds.
    *
    * super_admin users have unrestricted access to all administrations.
@@ -1088,6 +1114,12 @@ export function AdministrationService({
       let result: PaginatedResult<Administration>;
 
       if (isSuperAdmin) {
+        result = await administrationRepository.getByIds(targetUserAdminIds, queryParams);
+      } else if (await hasGuardianReadAccess(requesterUserId, userId)) {
+        // Authorized guardians (can_read_child) see all of the target child's
+        // administrations, bypassing the admin/teacher shared-access intersection
+        // below — a guardian holds no administration-level access of their own, so
+        // the intersection would always be empty.
         result = await administrationRepository.getByIds(targetUserAdminIds, queryParams);
       } else {
         const requesterUserAdmins = await authorizationService.listAccessibleObjects(
@@ -1516,11 +1548,19 @@ export function AdministrationService({
           { requesterUserId, userId, administrationId },
           'Requester attempting cross-user administration agreements access',
         );
-        await authorizationService.requirePermission(
-          requesterUserId,
-          FgaRelation.CAN_READ,
-          `${FgaType.ADMINISTRATION}:${administrationId}`,
-        );
+        // Authorized guardians (can_read_child on the target's family) may read their
+        // child's per-administration consent agreements. A guardian holds no
+        // administration-level access, so check the guardian path first and otherwise
+        // require can_read on the administration (the admin/teacher path), which throws
+        // FORBIDDEN for everyone else.
+        const isGuardian = await hasGuardianReadAccess(requesterUserId, userId);
+        if (!isGuardian) {
+          await authorizationService.requirePermission(
+            requesterUserId,
+            FgaRelation.CAN_READ,
+            `${FgaType.ADMINISTRATION}:${administrationId}`,
+          );
+        }
       }
 
       const queryParams = {


### PR DESCRIPTION
## Summary

This PR wires the FGA `can_read_child` relation into the two administration **read** endpoints a parent hits when proxy-launching their child, so the child's homepage and consent gate resolve under a parent session instead of `403`-ing. It is a service-layer authorization change only — no contract, route, controller, or schema changes.

## What was missing

`getUserAdministrations` and `listUserAdministrationAgreements` authorized only super-admin, self, or an admin/teacher whose accessible-administration set intersects the target's. A parent reading their own child is none of those, so the proxy-launch homepage and consent gate returned `403`. Run creation (`can_create_run_for_child`) and parent consent recording (`can_consent_for_child`) were already authorized; only these two reads were not.

## Changes

- **`hasGuardianReadAccess(requesterUserId, targetUserId)`** — a new private, **non-throwing** helper in `administration.service.ts`. It reads the target user's entity memberships, keeps the `family` ones, and asks FGA whether the requester has `can_read_child` on any of those family objects (`hasAnyPermission`). It returns a boolean (rather than throwing) so callers can fall through to other authorization paths. This mirrors the parent block already in `user.service.recordUserAgreement`.
- **`getUserAdministrations`** — in the non-super-admin / non-self branch, the guardian path is tried **before** the existing admin/teacher intersection fallback. When the requester is an authorized guardian, the target child's administrations are returned directly (by IDs), bypassing the requester-intersection logic that exists for admins/teachers.
- **`listUserAdministrationAgreements`** — inside the existing `!isSuperAdmin && requesterUserId !== userId` block, an authorized guardian is accepted in place of the administration-level `can_read` requirement.

## Authorization behavior (please verify each)

1. **Super-admin bypass is unchanged and still checked first.** The guardian path lives only in the non-super-admin, non-self branch.
2. **404-before-403 ordering is preserved.** `listUserAdministrationAgreements` still verifies the child and the administration exist before the guardian check runs.
3. **Correct FGA relation and object.** Access is `can_read_child` on `family:<id>` for each family the **child** belongs to — not an administration-scoped relation, and keyed to the child's family, not the requester's.

## Why the guardian sees the child's data, not their own (embed scoping)

`getUserAdministrations` resolves embeds after the authorization decision. Stats are gated to super-admins only (a guardian never receives them). The tasks embed is fetched unfiltered (its `userId` argument is only error-logging context), and per-student task state is attached **keyed to the target user** (the child). So the guardian path returns the child's administrations and the child's per-task state. Confirm this in review against the embed-resolution code.

## Testing

- **Unit tests added** for both endpoints (guardian-allowed). These mock FGA, so they assert the **wiring**: that `hasAnyPermission` is called with `('<requester>', 'can_read_child', ['family:<childFamily>'])`, that the self/admin paths are not taken, and that the child's data is returned.
- **Integration tests added** for the following cases: (a) a guardian with `can_read_child` on the child's family is **allowed** on both endpoints; (b) a user **without** that relation, and a guardian of a **different** family, are **denied** (`403`); (c) the super-admin, self, and admin/teacher paths are unaffected. (based on https://github.com/yeatmanlab/roar-dashboard/pull/1993 specifications) 
- Lint, format, and `check-types` were run for the changed backend files.

## Out of scope

- `recordUserAgreement` (already authorizes parents via `can_consent_for_child`).
- The dependent **frontend** proxy-launch cutover (`enh/proxy-launch-frontend`), which builds on this PR.



> [!NOTE]
> **Cross-fork stacking.** Because intermediate branches live only on `richford`, a `yeatmanlab/roar-dashboard` PR cannot use one as its base — every PR in this series targets `project/backend-refactor`, and they are reviewed/merged **bottom-up** so each shows only its own slice once its parent merges.

> [!IMPORTANT]
> **Merge order:** first in its stack — targets `project/backend-refactor` directly.

Resolves #1975
Part of #1958