### PR TITLE
Child proxy-launch: resolve participant identity from launchId

### DIFF
--- a/apps/dashboard/src/components/tasks/TaskLetter.vue
+++ b/apps/dashboard/src/components/tasks/TaskLetter.vue
@@ -122,8 +122,8 @@ async function startTask(selectedAdmin) {
     // administrations in parallel to resolve the correct administrationId and variantId.
     //
     // authStore.roarUid is a Firestore UID, not a Postgres UUID. GET /me resolves the
-    // Postgres UUID for the currently authenticated user (self-launch path).
-    // TODO: resolve the participant's Postgres UUID for the proxy-launch path (launchId set).
+    // Postgres UUID for the currently authenticated user (self-launch path); the
+    // proxy-launch path uses props.launchId directly (see below).
     //
     // NOTE: Until the dashboard migrates its administration queries to the new REST API,
     // selectedAdmin.value.id is a Firestore document ID and will not match any administration
@@ -143,16 +143,12 @@ async function startTask(selectedAdmin) {
       throw new Error(`Failed to resolve current user from the ROAR backend (status ${meRes.status}).`);
     }
 
-    // Proxy-launch path (launchId set) requires resolving the participant's Postgres UUID from
-    // the launch record — props.launchId is an assignment/launch ID, not a user ID. Passing it
-    // as participantId would silently create runs under the wrong ID. Fail loudly until this
-    // is properly implemented (see TODO above).
-    if (props.launchId) {
-      throw new Error(
-        'Proxy-launch path is not yet supported for Letter. Resolve the participant Postgres UUID before enabling this path.',
-      );
-    }
-    const participantId = meRes.body.data.id;
+    // Proxy-launch path: `props.launchId` is the participant's ROAR (Postgres) user UUID
+    // (set by StudentCardSimple when a parent launches a child), so it is the participant
+    // identity directly. On the self path (`launchId` null) we use the launching user's own
+    // `/me` ID. Run creation targets this participant via POST /v1/user/:userId/runs, which
+    // the backend authorizes with `can_create_run_for_child` (proxy) or self.
+    const participantId = props.launchId ?? meRes.body.data.id;
 
     // Fetch the participant's administrations from the ROAR POSTGRES backend.
     const adminsRes = await roarApiClient.users.listUserAdministrations({

--- a/apps/dashboard/src/components/tasks/TaskMultichoice.vue
+++ b/apps/dashboard/src/components/tasks/TaskMultichoice.vue
@@ -125,8 +125,8 @@ async function startTask(selectedAdmin) {
     // administrations in parallel to resolve the correct administrationId and variantId.
     //
     // authStore.roarUid is a Firestore UID, not a Postgres UUID. GET /me resolves the
-    // Postgres UUID for the currently authenticated user (self-launch path).
-    // TODO: resolve the participant's Postgres UUID for the proxy-launch path (launchId set).
+    // Postgres UUID for the currently authenticated user (self-launch path); the
+    // proxy-launch path uses props.launchId directly (see below).
     //
     // NOTE: Until the dashboard migrates its administration queries to the new REST API,
     // selectedAdmin.value.id is a Firestore document ID and will not match any administration
@@ -146,16 +146,12 @@ async function startTask(selectedAdmin) {
       throw new Error(`Failed to resolve current user from the ROAR backend (status ${meRes.status}).`);
     }
 
-    // Proxy-launch path (launchId set) requires resolving the participant's Postgres UUID from
-    // the launch record — props.launchId is an assignment/launch ID, not a user ID. Passing it
-    // as participantId would silently create runs under the wrong ID. Fail loudly until this
-    // is properly implemented (see TODO above).
-    if (props.launchId) {
-      throw new Error(
-        'Proxy-launch path is not yet supported for Multichoice. Resolve the participant Postgres UUID before enabling this path.',
-      );
-    }
-    const participantId = meRes.body.data.id;
+    // Proxy-launch path: `props.launchId` is the participant's ROAR (Postgres) user UUID
+    // (set by StudentCardSimple when a parent launches a child), so it is the participant
+    // identity directly. On the self path (`launchId` null) we use the launching user's own
+    // `/me` ID. Run creation targets this participant via POST /v1/user/:userId/runs, which
+    // the backend authorizes with `can_create_run_for_child` (proxy) or self.
+    const participantId = props.launchId ?? meRes.body.data.id;
 
     // Fetch the participant's administrations from the ROAR POSTGRES backend.
     const adminsRes = await roarApiClient.users.listUserAdministrations({

--- a/apps/dashboard/src/components/tasks/TaskPA.vue
+++ b/apps/dashboard/src/components/tasks/TaskPA.vue
@@ -119,8 +119,8 @@ async function startTask(selectedAdmin) {
     // administrations in parallel to resolve the correct administrationId and variantId.
     //
     // authStore.roarUid is a Firestore UID, not a Postgres UUID. GET /me resolves the
-    // Postgres UUID for the currently authenticated user (self-launch path).
-    // TODO: resolve the participant's Postgres UUID for the proxy-launch path (launchId set).
+    // Postgres UUID for the currently authenticated user (self-launch path); the
+    // proxy-launch path uses props.launchId directly (see below).
     //
     // NOTE: Until the dashboard migrates its administration queries to the new REST API,
     // selectedAdmin.value.id is a Firestore document ID and will not match any administration
@@ -140,16 +140,12 @@ async function startTask(selectedAdmin) {
       throw new Error(`Failed to resolve current user from the ROAR backend (status ${meRes.status}).`);
     }
 
-    // Proxy-launch path (launchId set) requires resolving the participant's Postgres UUID from
-    // the launch record — props.launchId is an assignment/launch ID, not a user ID. Passing it
-    // as participantId would silently create runs under the wrong ID. Fail loudly until this
-    // is properly implemented (see TODO on line 128).
-    if (props.launchId) {
-      throw new Error(
-        'Proxy-launch path is not yet supported for PA. Resolve the participant Postgres UUID before enabling this path.',
-      );
-    }
-    const participantId = meRes.body.data.id;
+    // Proxy-launch path: `props.launchId` is the participant's ROAR (Postgres) user UUID
+    // (set by StudentCardSimple when a parent launches a child), so it is the participant
+    // identity directly. On the self path (`launchId` null) we use the launching user's own
+    // `/me` ID. Run creation targets this participant via POST /v1/user/:userId/runs, which
+    // the backend authorizes with `can_create_run_for_child` (proxy) or self.
+    const participantId = props.launchId ?? meRes.body.data.id;
 
     // Fetch the participant's administrations from the ROAR POSTGRES backend.
     const adminsRes = await roarApiClient.users.listUserAdministrations({

--- a/apps/dashboard/src/components/tasks/TaskSRE.vue
+++ b/apps/dashboard/src/components/tasks/TaskSRE.vue
@@ -121,8 +121,8 @@ async function startTask(selectedAdmin) {
     // administrations in parallel to resolve the correct administrationId and variantId.
     //
     // authStore.roarUid is a Firestore UID, not a Postgres UUID. GET /me resolves the
-    // Postgres UUID for the currently authenticated user (self-launch path).
-    // TODO: resolve the participant's Postgres UUID for the proxy-launch path (launchId set).
+    // Postgres UUID for the currently authenticated user (self-launch path); the
+    // proxy-launch path uses props.launchId directly (see below).
     //
     // NOTE: Until the dashboard migrates its administration queries to the new REST API,
     // selectedAdmin.value.id is a Firestore document ID and will not match any administration
@@ -142,16 +142,12 @@ async function startTask(selectedAdmin) {
       throw new Error(`Failed to resolve current user from the ROAR backend (status ${meRes.status}).`);
     }
 
-    // Proxy-launch path (launchId set) requires resolving the participant's Postgres UUID from
-    // the launch record — props.launchId is an assignment/launch ID, not a user ID. Passing it
-    // as participantId would silently create runs under the wrong ID. Fail loudly until this
-    // is properly implemented (see TODO above).
-    if (props.launchId) {
-      throw new Error(
-        'Proxy-launch path is not yet supported for SRE. Resolve the participant Postgres UUID before enabling this path.',
-      );
-    }
-    const participantId = meRes.body.data.id;
+    // Proxy-launch path: `props.launchId` is the participant's ROAR (Postgres) user UUID
+    // (set by StudentCardSimple when a parent launches a child), so it is the participant
+    // identity directly. On the self path (`launchId` null) we use the launching user's own
+    // `/me` ID. Run creation targets this participant via POST /v1/user/:userId/runs, which
+    // the backend authorizes with `can_create_run_for_child` (proxy) or self.
+    const participantId = props.launchId ?? meRes.body.data.id;
 
     // Fetch the participant's administrations from the ROAR POSTGRES backend.
     const adminsRes = await roarApiClient.users.listUserAdministrations({

--- a/apps/dashboard/src/components/tasks/TaskSWR.vue
+++ b/apps/dashboard/src/components/tasks/TaskSWR.vue
@@ -121,8 +121,8 @@ async function startTask(selectedAdmin) {
     // administrations in parallel to resolve the correct administrationId and variantId.
     //
     // authStore.roarUid is a Firestore UID, not a Postgres UUID. GET /me resolves the
-    // Postgres UUID for the currently authenticated user (self-launch path).
-    // TODO: resolve the participant's Postgres UUID for the proxy-launch path (launchId set).
+    // Postgres UUID for the currently authenticated user (self-launch path); the
+    // proxy-launch path uses props.launchId directly (see below).
     //
     // NOTE: Until the dashboard migrates its administration queries to the new REST API,
     // selectedAdmin.value.id is a Firestore document ID and will not match any administration
@@ -142,16 +142,12 @@ async function startTask(selectedAdmin) {
       throw new Error(`Failed to resolve current user from the ROAR backend (status ${meRes.status}).`);
     }
 
-    // Proxy-launch path (launchId set) requires resolving the participant's Postgres UUID from
-    // the launch record — props.launchId is an assignment/launch ID, not a user ID. Passing it
-    // as participantId would silently create runs under the wrong ID. Fail loudly until this
-    // is properly implemented (see TODO on line 129).
-    if (props.launchId) {
-      throw new Error(
-        'Proxy-launch path is not yet supported for SWR. Resolve the participant Postgres UUID before enabling this path.',
-      );
-    }
-    const participantId = meRes.body.data.id;
+    // Proxy-launch path: `props.launchId` is the participant's ROAR (Postgres) user UUID
+    // (set by StudentCardSimple when a parent launches a child), so it is the participant
+    // identity directly. On the self path (`launchId` null) we use the launching user's own
+    // `/me` ID. Run creation targets this participant via POST /v1/user/:userId/runs, which
+    // the backend authorizes with `can_create_run_for_child` (proxy) or self.
+    const participantId = props.launchId ?? meRes.body.data.id;
 
     // Fetch the participant's administrations from the ROAR POSTGRES backend.
     const adminsRes = await roarApiClient.users.listUserAdministrations({

--- a/apps/dashboard/src/pages/HomeParticipant.vue
+++ b/apps/dashboard/src/pages/HomeParticipant.vue
@@ -213,6 +213,23 @@ const {
   enabled: computed(() => initialized.value && Boolean(userId.value)),
 });
 
+// Resolve the participant's ROAR (Postgres) user ID — the identity the
+// `GET /users/:userId/administrations` endpoint expects, NOT the Firebase
+// `roarUid`.
+//
+// In proxy-launch mode (`props.launchId` set — e.g. a parent launching a
+// child from StudentCardSimple), `launchId` IS the participant's ROAR user
+// UUID, so it is the participant identity. On the self path (`launchId`
+// null) we fall back to the launching user's own `/me` ID. This drives the
+// per-user administrations query, the consent-gate agreements query, and
+// consent recording below.
+//
+// Reading another user's administrations and agreements relies on the backend
+// guardian-read authorization (`can_read_child`); without it the parent-scoped
+// reads return 403.
+const { data: me } = useMeQuery({ enabled: initialized });
+const userId = computed(() => props.launchId ?? me.value?.id);
+
 const {
   isLoading: isLoadingAssignments,
   isFetching: isFetchingAssignments,


### PR DESCRIPTION
## Summary

This PR finishes the child proxy-launch cutover by using the child's user UUID — already carried end to end as the `launchId` route param — as the participant identity in `HomeParticipant.vue` and the five backend-cut-over task players, instead of falling back to the launching parent's `me.id`. It removes the documented "not yet implemented" limitation and the players' fail-loud guard.

> **Depends on `enh/parent-child-read-authz`** (guardian `can_read_child` on the two administration read endpoints). Without that backend change the parent-scoped reads here return `403`. Merge the backend PR first.

## Why `launchId` is the right identity

`launchId` originates in exactly one place — `StudentCardSimple.vue`, which sets it to `props.userId`, the child's ROAR (Postgres) user UUID. The router threads it to `HomeParticipant.vue`, and `GameTabs.vue` forwards it into each player route (`/launch/${launchId}/game/...`). No other component navigates into the launch routes, and nothing passes an assignment/launch ID there. The players' older "assignment/launch ID, not a user ID" comment was over-cautious and is removed.

## Changes

- **`HomeParticipant.vue`**: `const userId = computed(() => props.launchId ?? me.value?.id)`. This single change cascades to the per-user administrations query, the per-administration agreements (consent gate) query, and consent recording — all of which already key off `userId`. Removed the stale proxy-launch NOTE.
- **`TaskSWR.vue`, `TaskSRE.vue`, `TaskPA.vue`, `TaskLetter.vue`, `TaskMultichoice.vue`**: replaced the `if (props.launchId) throw new Error(...)` guard with `const participantId = props.launchId ?? meRes.body.data.id`, and removed the accompanying TODO/comment. Run creation then targets the child via the already-authorized `POST /v1/user/:userId/runs` (`can_create_run_for_child`).

## Out of scope

- The nine firekit-blocked players (Crowding, Levante, MEP, RAN, ReadAloud, ROAM, ROAV, Survey, Vocab) still launch via `startAssessment`/`appKit` and are unchanged — they're blocked on each assessment's SDK republish.
- Backend authorization for the parent-scoped reads is the separate `enh/parent-child-read-authz` PR this one depends on.

## Testing

- **No existing unit/component tests** cover these five players or `HomeParticipant` (they're integration-launch components with no test harness in the repo today), so this PR adds none — the change is a one-line participant-identity resolution in each. Verified locally with Prettier and a `@vue/compiler-sfc` parse/compile of all six SFCs.
- The meaningful coverage for this workflow is a **proxy-launch e2e** under the seeded local stack (Postgres + OpenFGA + Auth emulator + `server-test.ts`) that exercises a parent launching a child end to end. That spec depends on (a) this change, (b) the backend `enh/parent-child-read-authz` authz, and (c) a dashboard-aware `cy.loginAsTestUser` helper. Per the `frontend-e2e-testing-pattern` rule, the legacy launch specs are currently `describe.skip`-ed pending rewrite under that stack; standing up the proxy-launch e2e is a follow-up once the backend authz lands.
- End-to-end behavior must be exercised against a backend that includes `enh/parent-child-read-authz`; flagged for the reviewer since the two PRs are exercised together.



> [!NOTE]
> **Cross-fork stacking.** Because intermediate branches live only on `richford`, a `yeatmanlab/roar-dashboard` PR cannot use one as its base — every PR in this series targets `project/backend-refactor`, and they are reviewed/merged **bottom-up** so each shows only its own slice once its parent merges.

> [!IMPORTANT]
> **Merge order:** first in its stack — targets `project/backend-refactor` directly.
>
> **Runtime dependency:** merge #1993 first.

Resolves #1976
Part of #1958