### PR TITLE
fix(dev): prevent orphaned PostgreSQL volumes during teardown

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -322,6 +322,23 @@ with the `superAdmin` entry — email `<uuid>@test.local`, password `password`.
 **Resetting:** to wipe and re-seed all databases, run
 `npm run dev:reset && npm run dev:seed`.
 
+**Stopping and restarting:** run `docker compose stop` to stop the containers
+while retaining PostgreSQL and Firebase Auth emulator data. Restart them with
+`docker compose up -d --wait`.
+
+**Tearing down:** run `npm run dev:down` to remove the local stack and delete
+PostgreSQL data. This preserves the `firebase-auth-data` volume. The next
+startup needs `npm run dev:init` to recreate and seed the databases. A raw
+`docker compose down` retains the explicitly managed PostgreSQL volume, which
+is reused on the next startup instead of creating another anonymous volume.
+
+The teardown command also removes a legacy anonymous PostgreSQL volume when it
+is still attached to the `roar-postgres` container. For volumes that were
+already detached by the previous configuration, use `docker system df -v` and
+`docker volume inspect <volume-name>` to identify the volume before removing it
+with `docker volume rm <volume-name>`. Do not use a broad volume prune when
+unrelated Docker projects are present.
+
 ## ROAR coding style
 
 Most ROAR repositories use [prettier][link_prettier] and [eslint][link_eslint]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,7 @@ services:
     ports:
       - "${ROAR_PG_PORT:-5432}:5432"
     volumes:
+      - postgres-data:/var/lib/postgresql
       - ./docker/postgres:/docker-entrypoint-initdb.d:ro
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U postgres"]
@@ -77,4 +78,6 @@ services:
       retries: 12
 
 volumes:
+  postgres-data:
+    name: roar-postgres-data
   firebase-auth-data:

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "dev:reset": "cd apps/backend && npm run dev:reset",
     "dev:seed:tasks": "cd apps/backend && npm run dev:seed:tasks",
     "dev:init": "cd apps/backend && npm run dev:init",
+    "dev:down": "bash scripts/dev-env-down.sh",
     "dev:setup:certs": "setup-certs",
     "watch": "turbo watch dev",
     "build": "turbo run build",

--- a/scripts/dev-env-down.sh
+++ b/scripts/dev-env-down.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# dev-env-down.sh — Tear down the local platform stack and delete PostgreSQL
+# data while preserving Firebase Auth emulator data.
+#
+# Called from the root package's `dev:down` script. The teardown is destructive,
+# so it prompts for confirmation when run interactively. Skip the prompt with
+# -y/--yes/--force, or from a non-TTY such as CI.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+COMPOSE_FILE="$REPO_ROOT/docker-compose.yml"
+POSTGRES_CONTAINER="roar-postgres"
+POSTGRES_VOLUME="roar-postgres-data"
+
+confirm_teardown() {
+  local arg reply
+  for arg in "$@"; do
+    case "$arg" in
+      -y | --yes | --force) return 0 ;;
+    esac
+  done
+
+  [ -t 0 ] || return 0
+
+  echo "WARNING: this stops the local ROAR stack and DELETES PostgreSQL data." >&2
+  echo "         Firebase Auth emulator data is preserved." >&2
+  read -r -p "Continue? [y/N] " reply
+  case "$reply" in
+    [Yy] | [Yy][Ee][Ss]) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+if ! confirm_teardown "$@"; then
+  echo "Aborted — the local stack and PostgreSQL data were left intact." >&2
+  exit 0
+fi
+
+cd "$REPO_ROOT"
+
+# Capture the volume currently mounted by Postgres before Compose removes the
+# container. This also targets an anonymous volume created by the previous
+# configuration, but only when it is still attached to the known ROAR container
+# at the expected PostgreSQL mount point.
+mounted_postgres_volume="$(
+  docker inspect \
+    --format '{{range .Mounts}}{{if and (eq .Type "volume") (eq .Destination "/var/lib/postgresql")}}{{println .Name}}{{end}}{{end}}' \
+    "$POSTGRES_CONTAINER" 2>/dev/null || true
+)"
+
+echo "Stopping the local ROAR stack..."
+docker compose -f "$COMPOSE_FILE" down --remove-orphans
+
+postgres_volumes=("$POSTGRES_VOLUME")
+if [[ -n "$mounted_postgres_volume" && "$mounted_postgres_volume" != "$POSTGRES_VOLUME" ]]; then
+  postgres_volumes+=("$mounted_postgres_volume")
+fi
+
+for volume in "${postgres_volumes[@]}"; do
+  if docker volume inspect "$volume" >/dev/null 2>&1; then
+    docker volume rm "$volume" >/dev/null
+    echo "Removed PostgreSQL volume $volume."
+  fi
+done
+
+echo "Local ROAR stack stopped. Firebase Auth emulator data was preserved."


### PR DESCRIPTION
## Proposed changes

The `postgres:18` image declares `/var/lib/postgresql` as a volume. Because the Compose service did not manage that mount explicitly, every new `roar-postgres` container received a new anonymous volume. `docker compose down` removed the container but retained its data volume, so repeated teardown/startup cycles could accumulate detached PostgreSQL volumes until Docker Desktop ran out of disk space.

This PR:

- mounts PostgreSQL data on the explicit `roar-postgres-data` volume, so raw `docker compose down` followed by `up` reuses the same volume instead of allocating another anonymous volume;
- adds `npm run dev:down`, which removes the ROAR containers and PostgreSQL data while preserving Firebase Auth emulator data and unrelated Docker workloads;
- detects and removes a legacy anonymous PostgreSQL volume when it is still attached to the known `roar-postgres` container at `/var/lib/postgresql`; and
- documents the supported start, stop, restart, reset, teardown, and targeted legacy-volume cleanup workflows.

Resolves yeatmanlab/roar-project-management#2033

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (non-breaking change that does not add functionality but makes code cleaner or more efficient)
- [x] Documentation Update
- [ ] Tests (new or updated tests)
- [ ] Style (changes to code styling)
- [ ] CI (continuous integration changes)
- [ ] Repository Maintenance
- [ ] Other (please describe below)

## Checklist

- [x] I have read the [guidelines for contributing](https://github.com/yeatmanlab/roar-dashboard/blob/main/.github/CONTRIBUTING.md).
- [x] The changes in this PR are as small as they can be. They represent one and only one fix or enhancement.
- [x] Linting checks pass with my changes.
- [ ] Any existing unit tests pass with my changes.
- [ ] Any existing end-to-end tests pass with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] If this PR fixes an existing issue, I have added a unit or end-to-end test that will detect if this issue reoccurs.
- [ ] I have added JSDoc comments as appropriate.
- [ ] I have added the necessary documentation to the [roar-docs repository](https://github.com/yeatmanlab/roar-docs).
- [ ] I have shared this PR on the roar-pr-reviews channel (if I have access)
- [x] I have linked relevant issues (if any)

## Justification of missing checklist items

- This change is limited to Docker Compose configuration, a Bash teardown script, and local-development documentation. No application code or JSDoc was changed.
- The behavior was validated through the real Docker lifecycle rather than a unit or browser end-to-end test.
- Repository-local contributing documentation was updated; no separate `roar-docs` change is needed.
- The aggregate test run completed 33 of 34 package tasks. Three existing `@roar-platform/assessment-sdk` Firekit storage-mock assertions failed; those files are unrelated to this PR. The local OpenFGA model test was skipped in CI mode because the `fga` CLI is not installed locally and is covered by its dedicated GitHub Action.

## Validation

- `npm run format:check`
- `npm run lint` (passes with existing warnings)
- `npm run check-types`
- `bash -n scripts/dev-env-down.sh`
- `docker compose config`
- `docker compose stop` followed by `docker compose up -d --wait` retained a marker database on the same named volume.
- Raw `docker compose down` followed by `up` reused the same named volume and did not create another anonymous volume.
- `npm run dev:down -- --yes` removed `roar-postgres-data`, preserved `firebase-auth-data`, and left the unrelated Airbyte stack running.
- A clean `docker compose up -d --wait` followed by `npm run dev:init` recreated, migrated, and seeded the databases successfully.

## Further comments

The teardown command prompts before deleting PostgreSQL data when run interactively. `--yes` and `--force` are available for deliberate non-interactive use.
