### PR TITLE
maint: Reconcile score report charts across `main` and `project/backend-refactor`

### DIFF
--- a/apps/dashboard/src/components/reports/ScoreDistributionOverview.cy.js
+++ b/apps/dashboard/src/components/reports/ScoreDistributionOverview.cy.js
@@ -1,0 +1,117 @@
+import ScoreDistributionOverview from './ScoreDistributionOverview.vue';
+import { SCORE_SUPPORT_SKILL_LEVELS } from '@/constants/scores';
+
+/**
+ * Component-level behavior only: which sections and rows render, and which task-name
+ * fields are read. The count arithmetic these charts display lives in
+ * `mapSupportLevelCounts` / `aggregateSupportLevelRuns` and is covered directly in
+ * `helpers/plotting.test.js` — the bars render to a canvas, so counts aren't
+ * assertable from the DOM here.
+ */
+
+/** One task's entry as the score-overview endpoint returns it. */
+const supportLevels = (below, some, above) => ({
+  needsExtraSupport: { count: below },
+  developingSkill: { count: some },
+  achievedSkill: { count: above },
+});
+
+/** A client-side run backing the foundational-composite row. */
+const compositeRun = (supportLevel) => ({ scores: { support_level: supportLevel } });
+
+const mountChart = (props = {}) => {
+  cy.mount(ScoreDistributionOverview, {
+    props: {
+      taskIds: ['swr'],
+      supportLevelsByTaskId: { swr: supportLevels(1, 1, 1) },
+      compositeFoundationalRuns: null,
+      tasksDictionary: {},
+      ...props,
+    },
+  });
+};
+
+describe('<ScoreDistributionOverview />', () => {
+  describe('task grouping', () => {
+    it('splits tasks into foundational, Spanish, and comprehension sections', () => {
+      mountChart({
+        taskIds: ['swr', 'swr-es', 'morphology'],
+        supportLevelsByTaskId: {
+          swr: supportLevels(1, 1, 1),
+          'swr-es': supportLevels(1, 1, 1),
+          morphology: supportLevels(1, 1, 1),
+        },
+      });
+
+      cy.contains('Foundational Literacy Skills').should('be.visible');
+      cy.contains('Spanish Foundational Literacy Skills').should('be.visible');
+      cy.contains('Comprehension Skills').should('be.visible');
+    });
+
+    it('omits the Spanish and comprehension sections when no such task is present', () => {
+      mountChart({ taskIds: ['swr'] });
+
+      cy.contains('Spanish Foundational Literacy Skills').should('not.exist');
+      cy.contains('Comprehension Skills').should('not.exist');
+    });
+
+    it('renders a row per task without erroring when one is missing from the response', () => {
+      // A task absent from the score-overview response must still render (as an empty
+      // chart) rather than throwing — the endpoint only returns scored tasks.
+      mountChart({
+        taskIds: ['swr', 'sre'],
+        supportLevelsByTaskId: { swr: supportLevels(1, 2, 3) },
+      });
+
+      cy.get('canvas').should('have.length.at.least', 2);
+    });
+  });
+
+  describe('task labels', () => {
+    it('uses the backend nameTechnical / nameSimple fields', () => {
+      // Regression: this component arrived from main reading Firestore-era
+      // `technicalName` / `publicName`, which the backend Task schema does not have,
+      // so every row rendered a bare slug instead of a task name.
+      mountChart({
+        tasksDictionary: { swr: { nameTechnical: 'Single Word Recognition', nameSimple: 'Word' } },
+      });
+
+      cy.contains('Single Word Recognition').should('be.visible');
+      cy.contains('Word').should('be.visible');
+    });
+
+    it('falls back to the task slug when the dictionary has no entry', () => {
+      mountChart({ tasksDictionary: {} });
+
+      cy.contains('swr').should('be.visible');
+    });
+  });
+
+  describe('foundational composite row', () => {
+    it('is hidden when no composite runs are supplied', () => {
+      mountChart({ compositeFoundationalRuns: null });
+
+      cy.contains('Foundational Skills Composite').should('not.exist');
+    });
+
+    it('renders for an array of runs at school/class/group scope', () => {
+      mountChart({
+        compositeFoundationalRuns: [
+          compositeRun(SCORE_SUPPORT_SKILL_LEVELS.NEEDS_EXTRA_SUPPORT),
+          compositeRun(SCORE_SUPPORT_SKILL_LEVELS.ACHIEVED_SKILL),
+        ],
+      });
+
+      cy.contains('Foundational Skills Composite').should('be.visible');
+    });
+
+    it('renders for pre-aggregated totals at district scope', () => {
+      // Both shapes are accepted without a scope prop; the helper distinguishes them.
+      mountChart({
+        compositeFoundationalRuns: { below: { total: 4 }, some: { total: 5 }, above: { total: 6 } },
+      });
+
+      cy.contains('Foundational Skills Composite').should('be.visible');
+    });
+  });
+});

--- a/apps/dashboard/src/components/reports/ScoreDistributionOverview.vue
+++ b/apps/dashboard/src/components/reports/ScoreDistributionOverview.vue
@@ -155,23 +155,42 @@
 <script setup>
 import { computed } from 'vue';
 import PvChart from 'primevue/chart';
-import { setDistributionChartData, setDistributionChartOptions } from '@/helpers/plotting';
-import { SCORE_SUPPORT_LEVEL_COLORS, SCORE_SUPPORT_SKILL_LEVELS } from '@/constants/scores';
+import {
+  setDistributionChartData,
+  setDistributionChartOptions,
+  mapSupportLevelCounts,
+  aggregateSupportLevelRuns,
+} from '@/helpers/plotting';
+import { SCORE_SUPPORT_LEVEL_COLORS } from '@/constants/scores';
 import { descriptionsByTaskId } from '@/helpers/reports';
-import { SINGULAR_ORG_TYPES } from '@/constants/orgTypes';
 
 const props = defineProps({
   taskIds: {
     type: Array,
     required: true,
   },
-  runsByTaskId: {
+  /**
+   * Backend-aggregated support-level distributions from the score-overview
+   * endpoint, keyed by task slug and shaped
+   * `{ needsExtraSupport: { count }, developingSkill: { count }, achievedSkill: { count } }`.
+   * Already scoped to the report's org/class/group by the server.
+   */
+  supportLevelsByTaskId: {
     type: Object,
-    required: true,
+    required: false,
+    default: () => ({}),
   },
-  orgType: {
-    type: String,
-    required: true,
+  /**
+   * Runs backing the foundational-composite row, which has no equivalent in the
+   * score-overview endpoint and so is still derived client-side. Either shape is
+   * accepted — an array of runs at school/class/group scope, or the pre-aggregated
+   * `{ below: { total }, ... }` object at district scope — and
+   * {@link aggregateSupportLevelRuns} distinguishes them, so no scope prop is needed.
+   */
+  compositeFoundationalRuns: {
+    type: [Array, Object],
+    required: false,
+    default: null,
   },
   tasksDictionary: {
     type: Object,
@@ -195,56 +214,16 @@ const comprehensionTaskIds = computed(() => {
   return props.taskIds.filter((id) => comprehension.includes(id));
 });
 
-const compositeFoundational = computed(() => {
-  const composite = props.runsByTaskId?.['compositeFoundational'];
-  if (!composite) return null;
+const compositeFoundational = computed(() => aggregateSupportLevelRuns(props.compositeFoundationalRuns));
 
-  if (props.orgType === SINGULAR_ORG_TYPES.DISTRICTS) {
-    return {
-      below: composite.below?.total ?? 0,
-      some: composite.some?.total ?? 0,
-      above: composite.above?.total ?? 0,
-    };
-  }
-
-  const counts = { below: 0, some: 0, above: 0 };
-  for (const run of composite) {
-    const supportLevel = run.scores?.support_level;
-    if (supportLevel === SCORE_SUPPORT_SKILL_LEVELS.NEEDS_EXTRA_SUPPORT) counts.below++;
-    else if (supportLevel === SCORE_SUPPORT_SKILL_LEVELS.DEVELOPING_SKILL) counts.some++;
-    else if (supportLevel === SCORE_SUPPORT_SKILL_LEVELS.ACHIEVED_SKILL) counts.above++;
-  }
-  return counts;
-});
-
-const supportLevelCountsByTaskId = computed(() => {
-  const result = {};
-  for (const taskId of props.taskIds) {
-    const runs = props.runsByTaskId?.[taskId];
-    if (!runs) {
-      result[taskId] = { below: 0, some: 0, above: 0 };
-      continue;
-    }
-
-    if (props.orgType === SINGULAR_ORG_TYPES.DISTRICTS) {
-      result[taskId] = {
-        below: runs.below?.total ?? 0,
-        some: runs.some?.total ?? 0,
-        above: runs.above?.total ?? 0,
-      };
-    } else {
-      const counts = { below: 0, some: 0, above: 0 };
-      for (const run of runs) {
-        const supportLevel = run.scores?.support_level;
-        if (supportLevel === SCORE_SUPPORT_SKILL_LEVELS.NEEDS_EXTRA_SUPPORT) counts.below++;
-        else if (supportLevel === SCORE_SUPPORT_SKILL_LEVELS.DEVELOPING_SKILL) counts.some++;
-        else if (supportLevel === SCORE_SUPPORT_SKILL_LEVELS.ACHIEVED_SKILL) counts.above++;
-      }
-      result[taskId] = counts;
-    }
-  }
-  return result;
-});
+// Server-aggregated counts, mapped from the endpoint's support-level names to the
+// chart's below/some/above vocabulary. The endpoint already aggregates across the
+// report's scope, so there is no district-vs-school branch to make here.
+const supportLevelCountsByTaskId = computed(() =>
+  Object.fromEntries(
+    props.taskIds.map((taskId) => [taskId, mapSupportLevelCounts(props.supportLevelsByTaskId?.[taskId])]),
+  ),
+);
 
 const isChartEmpty = (chartData) => {
   return !chartData || (chartData.below === 0 && chartData.some === 0 && chartData.above === 0);

--- a/apps/dashboard/src/helpers/plotting.js
+++ b/apps/dashboard/src/helpers/plotting.js
@@ -1,5 +1,5 @@
 import { PROGRESS_COLORS } from '@/constants/completionStatus';
-import { SCORE_SUPPORT_LEVEL_COLORS } from '@/constants/scores';
+import { SCORE_SUPPORT_LEVEL_COLORS, SCORE_SUPPORT_SKILL_LEVELS } from '@/constants/scores';
 
 export const chart = {};
 
@@ -180,6 +180,60 @@ export const setProgressChartOptions = (orgStats) => {
       },
     },
   };
+};
+
+/**
+ * Maps a task's server-aggregated support-level distribution onto the
+ * `{ below, some, above }` shape the distribution charts consume.
+ *
+ * The score-overview endpoint (`ScoreOverviewResponseSchema.tasks[].supportLevels`)
+ * returns `{ needsExtraSupport: { count }, developingSkill: { count }, achievedSkill: { count } }`
+ * and has already aggregated across the report's org/class/group, so there is no
+ * scope-dependent branching to do here — unlike
+ * {@link aggregateSupportLevelRuns}, which still has to.
+ *
+ * @param {Object|undefined} supportLevels - The endpoint's `supportLevels` object for one task.
+ * @returns {{below: number, some: number, above: number}} Counts, zeroed for a missing task.
+ */
+export const mapSupportLevelCounts = (supportLevels) => ({
+  below: supportLevels?.needsExtraSupport?.count ?? 0,
+  some: supportLevels?.developingSkill?.count ?? 0,
+  above: supportLevels?.achievedSkill?.count ?? 0,
+});
+
+/**
+ * Aggregates client-side runs into `{ below, some, above }` counts.
+ *
+ * Used only for the foundational composite, which the score-overview endpoint has no
+ * equivalent for. Accepts either shape the caller may hold: an array of runs carrying
+ * `scores.support_level` (school/class/group scope), or the pre-aggregated
+ * `{ below: { total }, ... }` object the Firestore district feed supplies.
+ *
+ * Runs with an unrecognized or absent support level are skipped, matching the prior
+ * client aggregation — only classified runs count toward the distribution.
+ *
+ * @param {Array|Object|null|undefined} runs - Runs array, or pre-aggregated district totals.
+ * @returns {{below: number, some: number, above: number}|null} Counts, or null when absent.
+ */
+export const aggregateSupportLevelRuns = (runs) => {
+  if (!runs) return null;
+
+  if (!Array.isArray(runs)) {
+    return {
+      below: runs.below?.total ?? 0,
+      some: runs.some?.total ?? 0,
+      above: runs.above?.total ?? 0,
+    };
+  }
+
+  const counts = { below: 0, some: 0, above: 0 };
+  for (const run of runs) {
+    const supportLevel = run?.scores?.support_level;
+    if (supportLevel === SCORE_SUPPORT_SKILL_LEVELS.NEEDS_EXTRA_SUPPORT) counts.below++;
+    else if (supportLevel === SCORE_SUPPORT_SKILL_LEVELS.DEVELOPING_SKILL) counts.some++;
+    else if (supportLevel === SCORE_SUPPORT_SKILL_LEVELS.ACHIEVED_SKILL) counts.above++;
+  }
+  return counts;
 };
 
 /**

--- a/apps/dashboard/src/helpers/plotting.test.js
+++ b/apps/dashboard/src/helpers/plotting.test.js
@@ -4,9 +4,11 @@ import {
   setProgressChartOptions,
   setDistributionChartData,
   setDistributionChartOptions,
+  mapSupportLevelCounts,
+  aggregateSupportLevelRuns,
 } from './plotting';
 import { PROGRESS_COLORS } from '@/constants/completionStatus';
-import { SCORE_SUPPORT_LEVEL_COLORS } from '@/constants/scores';
+import { SCORE_SUPPORT_LEVEL_COLORS, SCORE_SUPPORT_SKILL_LEVELS } from '@/constants/scores';
 
 global.document = {
   documentElement: {},
@@ -293,6 +295,91 @@ describe('plotting', () => {
         const result = labelFn(context);
 
         expect(result).toContain('33%');
+      });
+    });
+  });
+
+  describe('mapSupportLevelCounts', () => {
+    it('maps the score-overview support-level names onto the chart vocabulary', () => {
+      const supportLevels = {
+        needsExtraSupport: { count: 3 },
+        developingSkill: { count: 5 },
+        achievedSkill: { count: 7 },
+      };
+
+      expect(mapSupportLevelCounts(supportLevels)).toEqual({ below: 3, some: 5, above: 7 });
+    });
+
+    it('zeroes a task the endpoint returned no entry for', () => {
+      expect(mapSupportLevelCounts(undefined)).toEqual({ below: 0, some: 0, above: 0 });
+      expect(mapSupportLevelCounts(null)).toEqual({ below: 0, some: 0, above: 0 });
+    });
+
+    it('zeroes individual levels that are absent', () => {
+      expect(mapSupportLevelCounts({ developingSkill: { count: 2 } })).toEqual({
+        below: 0,
+        some: 2,
+        above: 0,
+      });
+    });
+
+    it('preserves a zero count rather than coercing it away', () => {
+      const supportLevels = {
+        needsExtraSupport: { count: 0 },
+        developingSkill: { count: 0 },
+        achievedSkill: { count: 4 },
+      };
+
+      expect(mapSupportLevelCounts(supportLevels)).toEqual({ below: 0, some: 0, above: 4 });
+    });
+  });
+
+  describe('aggregateSupportLevelRuns', () => {
+    it('returns null when there are no runs', () => {
+      expect(aggregateSupportLevelRuns(null)).toBeNull();
+      expect(aggregateSupportLevelRuns(undefined)).toBeNull();
+    });
+
+    it('counts an array of runs by support level', () => {
+      const runs = [
+        { scores: { support_level: SCORE_SUPPORT_SKILL_LEVELS.NEEDS_EXTRA_SUPPORT } },
+        { scores: { support_level: SCORE_SUPPORT_SKILL_LEVELS.NEEDS_EXTRA_SUPPORT } },
+        { scores: { support_level: SCORE_SUPPORT_SKILL_LEVELS.DEVELOPING_SKILL } },
+        { scores: { support_level: SCORE_SUPPORT_SKILL_LEVELS.ACHIEVED_SKILL } },
+      ];
+
+      expect(aggregateSupportLevelRuns(runs)).toEqual({ below: 2, some: 1, above: 1 });
+    });
+
+    it('skips runs with an absent or unrecognized support level', () => {
+      // Only classified runs count toward the distribution, matching the prior
+      // client-side aggregation — an unscored run must not inflate any bucket.
+      const runs = [
+        { scores: { support_level: SCORE_SUPPORT_SKILL_LEVELS.ACHIEVED_SKILL } },
+        { scores: { support_level: null } },
+        { scores: { support_level: 'Optional' } },
+        { scores: {} },
+        {},
+      ];
+
+      expect(aggregateSupportLevelRuns(runs)).toEqual({ below: 0, some: 0, above: 1 });
+    });
+
+    it('returns zeroes for an empty runs array', () => {
+      expect(aggregateSupportLevelRuns([])).toEqual({ below: 0, some: 0, above: 0 });
+    });
+
+    it('reads pre-aggregated district totals without iterating', () => {
+      const districtTotals = { below: { total: 4 }, some: { total: 5 }, above: { total: 6 } };
+
+      expect(aggregateSupportLevelRuns(districtTotals)).toEqual({ below: 4, some: 5, above: 6 });
+    });
+
+    it('zeroes district totals that are absent', () => {
+      expect(aggregateSupportLevelRuns({ some: { total: 2 } })).toEqual({
+        below: 0,
+        some: 2,
+        above: 0,
       });
     });
   });

--- a/apps/dashboard/src/pages/ScoreReport.vue
+++ b/apps/dashboard/src/pages/ScoreReport.vue
@@ -61,8 +61,8 @@
             >
               <ScoreDistributionOverview
                 :task-ids="sortedAndFilteredTaskIds"
-                :runs-by-task-id="runsByTaskIdForDistributionChart"
-                :org-type="props.orgType"
+                :support-levels-by-task-id="scoreOverviewBySlug"
+                :composite-foundational-runs="compositeFoundationalRunsForChart"
                 :tasks-dictionary="tasksDictionary"
               />
               <!-- One/all of word, sentence, phoneme have been taken, but additionally they have other assessments that do not show charts (we want to say we only show charts for validated assessments)  -->
@@ -486,20 +486,21 @@ const {
   enabled: computed(() => initialized.value && props.orgType === 'district'),
 });
 
-// Server-computed support-level distributions per task, scoped to this org/class/group.
+// Server-computed support-level distributions per task: the source of the "at a glance"
+// chart values, already scoped to this org/class/group. Keyed by task slug to match the
+// slug-based `sortedAndFilteredTaskIds` the chart iterates.
 //
-// NOTE (merge of main into project/backend-refactor): main's #1910 replaced the per-task
-// vega charts this query fed with `ScoreDistributionOverview`, which computes its counts
-// client-side from `runsByTaskIdForDistributionChart`. Only the loading flag is consumed
-// here for now; re-pointing the chart's counts at `scoreOverviewData.tasks[].supportLevels`
-// (keyed by `taskSlug`) is the follow-up PR that finishes the backend migration for this
-// chart. The composite-foundational row has no backend equivalent and stays client-side
-// until the overview endpoint grows one.
-const { isLoading: isLoadingScoreOverview } = useAdministrationScoreOverviewQuery(
+// The foundational-composite row is the one part the endpoint can't supply — it has no
+// composite equivalent — so that row alone stays client-derived via
+// `compositeFoundationalRunsForChart` below.
+const { data: scoreOverviewData, isLoading: isLoadingScoreOverview } = useAdministrationScoreOverviewQuery(
   props.administrationId,
   props.orgType,
   props.orgId,
   { enabled: initialized },
+);
+const scoreOverviewBySlug = computed(() =>
+  Object.fromEntries((scoreOverviewData.value?.tasks ?? []).map((task) => [task.taskSlug, task.supportLevels])),
 );
 
 // Server-computed distribution facets per task (support-level + score bins, faceted by
@@ -1539,16 +1540,18 @@ const tableDataWithBackendScores = computed(() => {
   });
 });
 
-// runsByTaskId for the ScoreDistributionOverview chart, including the foundational composite score
-// (kept separate from computeAssignmentAndRunData.runsByTaskId since 'compositeFoundational' is not a real taskId
-// and would break taskId-keyed logic like sortedTaskIds and CSV export).
-const runsByTaskIdForDistributionChart = computed(() => {
-  if (props.orgType === 'district') return aggregatedDistrictSupportCategories.value;
+// Runs backing the ScoreDistributionOverview chart's foundational-composite row. The
+// per-task rows come from the backend score-overview endpoint (`scoreOverviewBySlug`);
+// the composite is the only row without a server equivalent, so it stays client-derived
+// until the overview endpoint grows one. Kept out of
+// `computeAssignmentAndRunData.runsByTaskId` because 'compositeFoundational' is not a real
+// taskId and would break taskId-keyed logic like sortedTaskIds and CSV export.
+const compositeFoundationalRunsForChart = computed(() => {
+  if (props.orgType === SINGULAR_ORG_TYPES.DISTRICTS) {
+    return aggregatedDistrictSupportCategories.value?.compositeFoundational ?? null;
+  }
 
-  const { runsByTaskId, compositeFoundationalRuns } = computeAssignmentAndRunData.value;
-  if (!compositeFoundationalRuns?.length) return runsByTaskId;
-
-  return { ...runsByTaskId, compositeFoundational: compositeFoundationalRuns };
+  return computeAssignmentAndRunData.value.compositeFoundationalRuns ?? null;
 });
 
 // This composable manages the data which is passed into the FilterBar component slot for filtering


### PR DESCRIPTION
## Summary

This PR finishes the backend migration for the score report's "at a glance" distribution chart, pointing its per-task counts at the score-overview endpoint instead of aggregating raw runs in the browser.

It is the deliberate follow-up to the `main` → `project/backend-refactor` merge. That merge adopted `main`'s redesigned `ScoreDistributionOverview` (#1910) as-is, which computes its counts client-side, leaving `useAdministrationScoreOverviewQuery` wired only for its loading flag. Splitting the rewiring out kept novel scoring-path logic from riding inside a 44-file merge, where a reviewer scanning for resolution mistakes would likely skim past it.

**Base:** `maint/2035/merge-main-into-berf` — chained, merge that first. **Scope:** 5 files, +319 / −79.

## Data flow

```mermaid
graph LR
  subgraph Before
    A1[computeAssignmentAndRunData<br/>runsByTaskId] --> B1{orgType<br/>district?}
    A2[aggregatedDistrictSupportCategories<br/>Firestore] --> B1
    B1 -->|yes| C1[read .total per level]
    B1 -->|no| C2[walk runs,<br/>count support_level]
    C1 --> D1[below/some/above]
    C2 --> D1
  end

  subgraph After
    A3[GET /reports/scores/overview<br/>already scoped] --> C3[mapSupportLevelCounts]
    C3 --> D2[below/some/above]
  end
```

The endpoint aggregates across the report's org/class/group server-side, so the district-vs-school branch disappears entirely rather than moving.

## Changes

**`ScoreReport.vue`** — two seams:

- `scoreOverviewBySlug` restored and passed as `support-levels-by-task-id`. The query previously supplied only `isLoadingScoreOverview`.
- `runsByTaskIdForDistributionChart` narrowed to `compositeFoundationalRunsForChart`. The foundational composite is now the only client-derived row.

**`helpers/plotting.js`** — two pure helpers, placed next to `setDistributionChartData` which consumes their output:

- `mapSupportLevelCounts` — maps `{ needsExtraSupport, developingSkill, achievedSkill }` to the chart's `{ below, some, above }`.
- `aggregateSupportLevelRuns` — counts an array of runs by `scores.support_level`, or reads pre-aggregated `{ below: { total } }` district totals.

**`ScoreDistributionOverview.vue`** — consumes `supportLevelsByTaskId` (backend) plus `compositeFoundationalRuns` (client). Net −57/+36 in logic.

## Two simplifications

**The `orgType` prop is gone.** Per-task counts no longer branch on scope, since the endpoint has already applied it. `aggregateSupportLevelRuns` then distinguishes the composite's two possible shapes with `Array.isArray` rather than a scope flag, so the component no longer needs to know its own scope at all — one fewer prop for callers to keep in sync with the data they pass.

**The extraction was driven by testability, not tidiness.** The first attempt asserted mapped counts through a stubbed `PvChart` and failed: `<script setup>` resolves components as local bindings, so Vue Test Utils' name-based `stubs` never applies, and the bars render to a `<canvas>` where counts aren't readable from the DOM. Rather than settle for asserting that _a_ chart rendered, the arithmetic moved into pure functions where it can be asserted exactly.

## Testing

| Suite                             | Result                |
| --------------------------------- | --------------------- |
| `helpers/plotting.test.js`        | 36 passed (11 new)    |
| `ScoreDistributionOverview.cy.js` | 8 passed (new file)   |
| Full dashboard suite              | 1566 passed, 0 failed |

Unit tests cover the arithmetic: support-level name mapping, missing tasks and absent levels zeroed, zero counts preserved rather than coerced away, runs with an absent or unrecognized support level skipped so an unscored run can't inflate a bucket, and both composite input shapes.

Component tests cover what only mounting shows: section grouping, slug fallback, composite row visibility for each shape, and the `nameTechnical` / `nameSimple` regression — this component arrived from `main` reading Firestore-era `technicalName` / `publicName`, which the backend `Task` schema does not have, so every row would otherwise render a bare slug.

## Not addressed

**The foundational composite is still client-derived.** `ScoreOverviewResponseSchema` returns per-task `supportLevels` only, with no composite equivalent, so that one row keeps `computeAssignmentAndRunData` load-bearing for this chart. Retiring it needs the overview endpoint to grow a composite — a backend change, not a frontend one.

**District composite path is unchanged and untested end-to-end.** `aggregatedDistrictSupportCategories.value?.compositeFoundational` is preserved exactly as it was, so at district scope that row still depends on the Firestore feed containing that key. Behavior is identical to the base branch, but it's the one path these tests don't prove against real data.
